### PR TITLE
Grind out as much performance as possible with lower-ish hanging fruit

### DIFF
--- a/kmk/common/abstract/matrix_scanner.py
+++ b/kmk/common/abstract/matrix_scanner.py
@@ -5,21 +5,5 @@ class AbstractMatrixScanner():
     def __init__(self, cols, rows, active_layers, diode_orientation=DiodeOrientation.COLUMNS):
         raise NotImplementedError('Abstract implementation')
 
-    def _normalize_matrix(self, matrix):
-        '''
-        We always want to internally look at a keyboard as a list of rows,
-        where a "row" is a list of keycodes (columns).
-
-        This will convert DiodeOrientation.COLUMNS matrix scans into a
-        ROWS scan, so we never have to think about these things again.
-        '''
-        if self.diode_orientation == DiodeOrientation.ROWS:
-            return matrix
-
-        return [
-            [col[col_entry] for col in matrix]
-            for col_entry in range(max(len(col) for col in matrix))
-        ]
-
-    def raw_scan(self):
+    def scan_for_pressed(self):
         raise NotImplementedError('Abstract implementation')

--- a/kmk/common/event_defs.py
+++ b/kmk/common/event_defs.py
@@ -1,4 +1,5 @@
 import logging
+from collections import namedtuple
 
 from micropython import const
 
@@ -16,31 +17,46 @@ MACRO_COMPLETE_EVENT = const(8)
 logger = logging.getLogger(__name__)
 
 
+InitFirmware = namedtuple('InitFirmware', (
+    'type',
+    'keymap',
+    'row_pins',
+    'col_pins',
+    'diode_orientation',
+    'unicode_mode',
+))
+
+KeyUpDown = namedtuple('KeyUpDown', ('type', 'row', 'col'))
+KeycodeUpDown = namedtuple('KeycodeUpDown', ('type', 'keycode'))
+NewMatrix = namedtuple('NewMatrix', ('type', 'matrix'))
+BareEvent = namedtuple('BareEvent', ('type',))
+
+
 def init_firmware(keymap, row_pins, col_pins, diode_orientation, unicode_mode):
-    return {
-        'type': INIT_FIRMWARE_EVENT,
-        'keymap': keymap,
-        'row_pins': row_pins,
-        'col_pins': col_pins,
-        'diode_orientation': diode_orientation,
-        'unicode_mode': unicode_mode,
-    }
+    return InitFirmware(
+        type=INIT_FIRMWARE_EVENT,
+        keymap=keymap,
+        row_pins=row_pins,
+        col_pins=col_pins,
+        diode_orientation=diode_orientation,
+        unicode_mode=unicode_mode,
+    )
 
 
 def key_up_event(row, col):
-    return {
-        'type': KEY_UP_EVENT,
-        'row': row,
-        'col': col,
-    }
+    return KeyUpDown(
+        type=KEY_UP_EVENT,
+        row=row,
+        col=col,
+    )
 
 
 def key_down_event(row, col):
-    return {
-        'type': KEY_DOWN_EVENT,
-        'row': row,
-        'col': col,
-    }
+    return KeyUpDown(
+        type=KEY_DOWN_EVENT,
+        row=row,
+        col=col,
+    )
 
 
 def keycode_up_event(keycode):
@@ -48,10 +64,10 @@ def keycode_up_event(keycode):
     Press a key by Keycode object, bypassing the keymap. Used mostly for
     macros.
     '''
-    return {
-        'type': KEYCODE_UP_EVENT,
-        'keycode': keycode,
-    }
+    return KeycodeUpDown(
+        type=KEYCODE_UP_EVENT,
+        keycode=keycode,
+    )
 
 
 def keycode_down_event(keycode):
@@ -59,29 +75,29 @@ def keycode_down_event(keycode):
     Release a key by Keycode object, bypassing the keymap. Used mostly for
     macros.
     '''
-    return {
-        'type': KEYCODE_DOWN_EVENT,
-        'keycode': keycode,
-    }
+    return KeycodeUpDown(
+        type=KEYCODE_DOWN_EVENT,
+        keycode=keycode,
+    )
 
 
 def new_matrix_event(matrix):
-    return {
-        'type': NEW_MATRIX_EVENT,
-        'matrix': matrix,
-    }
+    return NewMatrix(
+        type=NEW_MATRIX_EVENT,
+        matrix=matrix,
+    )
 
 
 def hid_report_event():
-    return {
-        'type': HID_REPORT_EVENT,
-    }
+    return BareEvent(
+        type=HID_REPORT_EVENT,
+    )
 
 
 def macro_complete_event():
-    return {
-        'type': MACRO_COMPLETE_EVENT,
-    }
+    return BareEvent(
+        type=MACRO_COMPLETE_EVENT,
+    )
 
 
 def matrix_changed(new_matrix):

--- a/kmk/common/internal_keycodes.py
+++ b/kmk/common/internal_keycodes.py
@@ -4,7 +4,7 @@ from kmk.common.event_defs import KEY_DOWN_EVENT, KEY_UP_EVENT
 from kmk.common.keycodes import Keycodes, RawKeycodes
 
 
-def process_internal_key_event(state, action, changed_key, logger=None):
+def process_internal_key_event(state, action_type, changed_key, logger=None):
     if logger is None:
         logger = logging.getLogger(__name__)
 
@@ -14,71 +14,58 @@ def process_internal_key_event(state, action, changed_key, logger=None):
     # objects
 
     if changed_key.code == RawKeycodes.KC_DF:
-        return df(state, action, changed_key, logger=logger)
+        return df(state, action_type, changed_key, logger=logger)
     elif changed_key.code == RawKeycodes.KC_MO:
-        return mo(state, action, changed_key, logger=logger)
+        return mo(state, action_type, changed_key, logger=logger)
     elif changed_key.code == RawKeycodes.KC_TG:
-        return tg(state, action, changed_key, logger=logger)
+        return tg(state, action_type, changed_key, logger=logger)
     elif changed_key.code == RawKeycodes.KC_TO:
-        return to(state, action, changed_key, logger=logger)
+        return to(state, action_type, changed_key, logger=logger)
     elif changed_key.code == Keycodes.KMK.KC_GESC.code:
-        return grave_escape(state, action, logger=logger)
+        return grave_escape(state, action_type, logger=logger)
     elif changed_key.code == RawKeycodes.KC_UC_MODE:
-        return unicode_mode(state, action, changed_key, logger=logger)
+        return unicode_mode(state, action_type, changed_key, logger=logger)
     else:
         return state
 
 
-def grave_escape(state, action, logger):
-    if action[0] == KEY_DOWN_EVENT:
+def grave_escape(state, action_type, logger):
+    if action_type == KEY_DOWN_EVENT:
         for key in state.keys_pressed:
-            if key in {Keycodes.Modifiers.KC_LSHIFT, Keycodes.Modifiers.KC_RSHIFT}:
-                # if Shift is held, return KC_GRAVE which will become KC_TILDE on OS level
-                return state.update(
-                    keys_pressed=(
-                        state.keys_pressed | {Keycodes.Common.KC_GRAVE}
-                    ),
-                )
-            elif key in {Keycodes.Modifiers.KC_LGUI, Keycodes.Modifiers.KC_RGUI}:
-                # if GUI is held, return KC_GRAVE
-                return state.update(
-                    keys_pressed=(
-                        state.keys_pressed | {Keycodes.Common.KC_GRAVE}
-                    ),
-                )
+            if key in {
+                Keycodes.Modifiers.KC_LSHIFT, Keycodes.Modifiers.KC_RSHIFT,
+                Keycodes.Modifiers.KC_LGUI, Keycodes.Modifiers.KC_RGUI,
+            }:
+                # if Shift is held, KC_GRAVE will become KC_TILDE on OS level
+                state.keys_pressed.add(Keycodes.Common.KC_GRAVE)
+                return state
 
             # else return KC_ESC
-            return state.update(
-                keys_pressed=(
-                    state.keys_pressed | {Keycodes.Common.KC_ESCAPE}
-                ),
-            )
+            state.keys_pressed.add(Keycodes.Common.KC_ESCAPE)
+            return state
 
-    elif action[0] == KEY_UP_EVENT:
-        return state.update(
-            keys_pressed=frozenset(
-                key for key in state.keys_pressed
-                if key not in {Keycodes.Common.KC_ESCAPE, Keycodes.Common.KC_GRAVE}
-            ),
-        )
+    elif action_type == KEY_UP_EVENT:
+        state.keys_pressed.discard(Keycodes.Common.KC_ESCAPE)
+        state.keys_pressed.discard(Keycodes.Common.KC_GRAVE)
+        return state
 
 
-def df(state, action, changed_key, logger):
+def df(state, action_type, changed_key, logger):
     """Switches the default layer"""
-    if action[0] == KEY_DOWN_EVENT:
+    if action_type == KEY_DOWN_EVENT:
         state.active_layers[0] = changed_key.layer
 
     return state
 
 
-def mo(state, action, changed_key, logger):
+def mo(state, action_type, changed_key, logger):
     """Momentarily activates layer, switches off when you let go"""
-    if action[0] == KEY_UP_EVENT:
+    if action_type == KEY_UP_EVENT:
         state.active_layers = [
             layer for layer in state.active_layers
             if layer != changed_key.layer
         ]
-    elif action[0] == KEY_DOWN_EVENT:
+    elif action_type == KEY_DOWN_EVENT:
         state.active_layers.append(changed_key.layer)
 
     return state
@@ -92,9 +79,9 @@ def lt(layer, kc):
     """Momentarily activates layer if held, sends kc if tapped"""
 
 
-def tg(state, action, changed_key, logger):
+def tg(state, action_type, changed_key, logger):
     """Toggles the layer (enables it if not active, and vise versa)"""
-    if action[0] == KEY_DOWN_EVENT:
+    if action_type == KEY_DOWN_EVENT:
         if changed_key.layer in state.active_layers:
             state.active_layers = [
                 layer for layer in state.active_layers
@@ -106,9 +93,9 @@ def tg(state, action, changed_key, logger):
     return state
 
 
-def to(state, action, changed_key, logger):
+def to(state, action_type, changed_key, logger):
     """Activates layer and deactivates all other layers"""
-    if action[0] == KEY_DOWN_EVENT:
+    if action_type == KEY_DOWN_EVENT:
         state.active_layers = [changed_key.layer]
 
     return state
@@ -118,8 +105,8 @@ def tt(layer):
     """Momentarily activates layer if held, toggles it if tapped repeatedly"""
 
 
-def unicode_mode(state, action, changed_key, logger):
-    if action[0] == KEY_DOWN_EVENT:
+def unicode_mode(state, action_type, changed_key, logger):
+    if action_type == KEY_DOWN_EVENT:
         state.unicode_mode = changed_key.mode
 
     return state

--- a/kmk/common/internal_keycodes.py
+++ b/kmk/common/internal_keycodes.py
@@ -30,7 +30,7 @@ def process_internal_key_event(state, action, changed_key, logger=None):
 
 
 def grave_escape(state, action, logger):
-    if action['type'] == KEY_DOWN_EVENT:
+    if action[0] == KEY_DOWN_EVENT:
         for key in state.keys_pressed:
             if key in {Keycodes.Modifiers.KC_LSHIFT, Keycodes.Modifiers.KC_RSHIFT}:
                 # if Shift is held, return KC_GRAVE which will become KC_TILDE on OS level
@@ -54,7 +54,7 @@ def grave_escape(state, action, logger):
                 ),
             )
 
-    elif action['type'] == KEY_UP_EVENT:
+    elif action[0] == KEY_UP_EVENT:
         return state.update(
             keys_pressed=frozenset(
                 key for key in state.keys_pressed
@@ -65,7 +65,7 @@ def grave_escape(state, action, logger):
 
 def df(state, action, changed_key, logger):
     """Switches the default layer"""
-    if action['type'] == KEY_DOWN_EVENT:
+    if action[0] == KEY_DOWN_EVENT:
         state.active_layers[0] = changed_key.layer
 
     return state
@@ -73,12 +73,12 @@ def df(state, action, changed_key, logger):
 
 def mo(state, action, changed_key, logger):
     """Momentarily activates layer, switches off when you let go"""
-    if action['type'] == KEY_UP_EVENT:
+    if action[0] == KEY_UP_EVENT:
         state.active_layers = [
             layer for layer in state.active_layers
             if layer != changed_key.layer
         ]
-    elif action['type'] == KEY_DOWN_EVENT:
+    elif action[0] == KEY_DOWN_EVENT:
         state.active_layers.append(changed_key.layer)
 
     return state
@@ -94,7 +94,7 @@ def lt(layer, kc):
 
 def tg(state, action, changed_key, logger):
     """Toggles the layer (enables it if not active, and vise versa)"""
-    if action['type'] == KEY_DOWN_EVENT:
+    if action[0] == KEY_DOWN_EVENT:
         if changed_key.layer in state.active_layers:
             state.active_layers = [
                 layer for layer in state.active_layers
@@ -108,7 +108,7 @@ def tg(state, action, changed_key, logger):
 
 def to(state, action, changed_key, logger):
     """Activates layer and deactivates all other layers"""
-    if action['type'] == KEY_DOWN_EVENT:
+    if action[0] == KEY_DOWN_EVENT:
         state.active_layers = [changed_key.layer]
 
     return state
@@ -119,7 +119,7 @@ def tt(layer):
 
 
 def unicode_mode(state, action, changed_key, logger):
-    if action['type'] == KEY_DOWN_EVENT:
+    if action[0] == KEY_DOWN_EVENT:
         state.unicode_mode = changed_key.mode
 
     return state

--- a/kmk/common/internal_keycodes.py
+++ b/kmk/common/internal_keycodes.py
@@ -3,6 +3,11 @@ import logging
 from kmk.common.event_defs import KEY_DOWN_EVENT, KEY_UP_EVENT
 from kmk.common.keycodes import Keycodes, RawKeycodes
 
+GESC_TRIGGERS = {
+    Keycodes.Modifiers.KC_LSHIFT, Keycodes.Modifiers.KC_RSHIFT,
+    Keycodes.Modifiers.KC_LGUI, Keycodes.Modifiers.KC_RGUI,
+}
+
 
 def process_internal_key_event(state, action_type, changed_key, logger=None):
     if logger is None:
@@ -31,18 +36,14 @@ def process_internal_key_event(state, action_type, changed_key, logger=None):
 
 def grave_escape(state, action_type, logger):
     if action_type == KEY_DOWN_EVENT:
-        for key in state.keys_pressed:
-            if key in {
-                Keycodes.Modifiers.KC_LSHIFT, Keycodes.Modifiers.KC_RSHIFT,
-                Keycodes.Modifiers.KC_LGUI, Keycodes.Modifiers.KC_RGUI,
-            }:
-                # if Shift is held, KC_GRAVE will become KC_TILDE on OS level
-                state.keys_pressed.add(Keycodes.Common.KC_GRAVE)
-                return state
-
-            # else return KC_ESC
-            state.keys_pressed.add(Keycodes.Common.KC_ESCAPE)
+        if any(key in GESC_TRIGGERS for key in state.keys_pressed):
+            # if Shift is held, KC_GRAVE will become KC_TILDE on OS level
+            state.keys_pressed.add(Keycodes.Common.KC_GRAVE)
             return state
+
+        # else return KC_ESC
+        state.keys_pressed.add(Keycodes.Common.KC_ESCAPE)
+        return state
 
     elif action_type == KEY_UP_EVENT:
         state.keys_pressed.discard(Keycodes.Common.KC_ESCAPE)

--- a/kmk/common/internal_state.py
+++ b/kmk/common/internal_state.py
@@ -26,9 +26,9 @@ class ReduxStore:
             self.logger.debug('Finished thunk')
             return None
 
-        self.logger.debug('Dispatching action: Type {} >> {}'.format(action[0], action))
+        self.logger.debug('Dispatching action: Type {} >> {}'.format(action.type, action))
         self.state = self.reducer(self.state, action, logger=self.logger)
-        self.logger.debug('Dispatching complete: Type {}'.format(action[0]))
+        self.logger.debug('Dispatching complete: Type {}'.format(action.type))
 
         self.logger.debug('New state: {}'.format(self.state))
 
@@ -132,10 +132,10 @@ def kmk_reducer(state=None, action=None, logger=None):
 
         return state
 
-    if action[0] == NEW_MATRIX_EVENT:
+    if action.type == NEW_MATRIX_EVENT:
         matrix_keys_pressed = {
             find_key_in_map(state, row, col)
-            for row, col in action[1]
+            for row, col in action.matrix
         }
 
         pressed = matrix_keys_pressed - state.keys_pressed
@@ -171,45 +171,41 @@ def kmk_reducer(state=None, action=None, logger=None):
                     logger=logger,
                 )
 
-        state.matrix = action[1]
+        state.matrix = action.matrix
         state.keys_pressed |= pressed
         state.keys_pressed -= released
         state.hid_pending = True
 
         return state
 
-    if action[0] == KEYCODE_UP_EVENT:
-        state.keys_pressed.discard(action[1])
+    if action.type == KEYCODE_UP_EVENT:
+        state.keys_pressed.discard(action.keycode)
         state.hid_pending = True
         return state
 
-    if action[0] == KEYCODE_DOWN_EVENT:
-        state.keys_pressed.add(action[1])
+    if action.type == KEYCODE_DOWN_EVENT:
+        state.keys_pressed.add(action.keycode)
         state.hid_pending = True
         return state
 
-    if action[0] == INIT_FIRMWARE_EVENT:
+    if action.type == INIT_FIRMWARE_EVENT:
         return state.update(
             keymap=action.keymap,
             row_pins=action.row_pins,
             col_pins=action.col_pins,
             diode_orientation=action.diode_orientation,
             unicode_mode=action.unicode_mode,
-            matrix=[
-                [False for c in action.col_pins]
-                for r in action.row_pins
-            ],
         )
 
     # HID events are non-mutating, used exclusively for listeners to know
     # they should be doing things. This could/should arguably be folded back
     # into KEY_UP_EVENT and KEY_DOWN_EVENT, but for now it's nice to separate
     # this out for debugging's sake.
-    if action[0] == HID_REPORT_EVENT:
+    if action.type == HID_REPORT_EVENT:
         state.hid_pending = False
         return state
 
-    if action[0] == MACRO_COMPLETE_EVENT:
+    if action.type == MACRO_COMPLETE_EVENT:
         return state.update(macro_pending=None)
 
     # On unhandled events, log and do not mutate state

--- a/kmk/common/internal_state.py
+++ b/kmk/common/internal_state.py
@@ -26,9 +26,9 @@ class ReduxStore:
             self.logger.debug('Finished thunk')
             return None
 
-        self.logger.debug('Dispatching action: Type {} >> {}'.format(action['type'], action))
+        self.logger.debug('Dispatching action: Type {} >> {}'.format(action[0], action))
         self.state = self.reducer(self.state, action, logger=self.logger)
-        self.logger.debug('Dispatching complete: Type {}'.format(action['type']))
+        self.logger.debug('Dispatching complete: Type {}'.format(action[0]))
 
         self.logger.debug('New state: {}'.format(self.state))
 
@@ -133,28 +133,28 @@ def kmk_reducer(state=None, action=None, logger=None):
 
         return state
 
-    if action['type'] == NEW_MATRIX_EVENT:
+    if action[0] == NEW_MATRIX_EVENT:
         return state.update(
-            matrix=action['matrix'],
+            matrix=action[1],
         )
 
-    if action['type'] == KEYCODE_UP_EVENT:
+    if action[0] == KEYCODE_UP_EVENT:
         return state.update(
             keys_pressed=frozenset(
-                key for key in state.keys_pressed if key != action['keycode']
+                key for key in state.keys_pressed if key != action[1]
             ),
         )
 
-    if action['type'] == KEYCODE_DOWN_EVENT:
+    if action[0] == KEYCODE_DOWN_EVENT:
         return state.update(
             keys_pressed=(
-                state.keys_pressed | {action['keycode']}
+                state.keys_pressed | {action[1]}
             ),
         )
 
-    if action['type'] == KEY_UP_EVENT:
-        row = action['row']
-        col = action['col']
+    if action[0] == KEY_UP_EVENT:
+        row = action[1]
+        col = action[2]
 
         changed_key = find_key_in_map(state, row, col)
 
@@ -182,9 +182,9 @@ def kmk_reducer(state=None, action=None, logger=None):
 
         return newstate
 
-    if action['type'] == KEY_DOWN_EVENT:
-        row = action['row']
-        col = action['col']
+    if action[0] == KEY_DOWN_EVENT:
+        row = action[1]
+        col = action[2]
 
         changed_key = find_key_in_map(state, row, col)
 
@@ -212,16 +212,16 @@ def kmk_reducer(state=None, action=None, logger=None):
 
         return newstate
 
-    if action['type'] == INIT_FIRMWARE_EVENT:
+    if action[0] == INIT_FIRMWARE_EVENT:
         return state.update(
-            keymap=action['keymap'],
-            row_pins=action['row_pins'],
-            col_pins=action['col_pins'],
-            diode_orientation=action['diode_orientation'],
-            unicode_mode=action['unicode_mode'],
+            keymap=action.keymap,
+            row_pins=action.row_pins,
+            col_pins=action.col_pins,
+            diode_orientation=action.diode_orientation,
+            unicode_mode=action.unicode_mode,
             matrix=[
-                [False for c in action['col_pins']]
-                for r in action['row_pins']
+                [False for c in action.col_pins]
+                for r in action.row_pins
             ],
         )
 
@@ -229,10 +229,10 @@ def kmk_reducer(state=None, action=None, logger=None):
     # they should be doing things. This could/should arguably be folded back
     # into KEY_UP_EVENT and KEY_DOWN_EVENT, but for now it's nice to separate
     # this out for debugging's sake.
-    if action['type'] == HID_REPORT_EVENT:
+    if action[0] == HID_REPORT_EVENT:
         return state
 
-    if action['type'] == MACRO_COMPLETE_EVENT:
+    if action[0] == MACRO_COMPLETE_EVENT:
         return state.update(macro_pending=None)
 
     # On unhandled events, log and do not mutate state

--- a/kmk/micropython/matrix.py
+++ b/kmk/micropython/matrix.py
@@ -57,7 +57,6 @@ class MatrixScanner(AbstractMatrixScanner):
             opin.value(0)
 
         if len(pressed) != self.last_pressed_len:
-            print('LEN PRESSED {} LEN LAST PRESSED {}'.format(len(pressed), self.last_pressed_len))
             self.last_pressed_len = len(pressed)
             return matrix_changed(pressed)
 

--- a/kmk/micropython/matrix.py
+++ b/kmk/micropython/matrix.py
@@ -21,6 +21,7 @@ class MatrixScanner(AbstractMatrixScanner):
         self.rows = [machine.Pin(pin) for pin in rows]
         self.diode_orientation = diode_orientation
         self.active_layers = active_layers
+        self.last_pressed_len = 0
 
         if self.diode_orientation == DiodeOrientation.COLUMNS:
             self.outputs = self.cols
@@ -41,29 +42,23 @@ class MatrixScanner(AbstractMatrixScanner):
             pin.init(machine.Pin.IN, machine.Pin.PULL_DOWN)
             pin.off()
 
-    def _normalize_matrix(self, matrix):
-        return super()._normalize_matrix(matrix)
+    def scan_for_pressed(self):
+        pressed = []
 
-    def raw_scan(self):
-        matrix = []
-
-        for opin in self.outputs:
+        for oidx, opin in enumerate(self.outputs):
             opin.value(1)
-            matrix.append([bool(ipin.value()) for ipin in self.inputs])
+
+            for iidx, ipin in enumerate(self.inputs):
+                if ipin.value():
+                    pressed.append(
+                        (oidx, iidx) if self.diode_orientation == DiodeOrientation.ROWS else (iidx, oidx)  # noqa
+                    )
+
             opin.value(0)
 
-        return self._normalize_matrix(matrix)
-
-    def scan_for_changes(self, old_matrix):
-        matrix = self.raw_scan()
-
-        if any(
-            any(
-                col != old_matrix[ridx][cidx]
-                for cidx, col in enumerate(row)
-            )
-            for ridx, row in enumerate(matrix)
-        ):
-            return matrix_changed(matrix)
+        if len(pressed) != self.last_pressed_len:
+            print('LEN PRESSED {} LEN LAST PRESSED {}'.format(len(pressed), self.last_pressed_len))
+            self.last_pressed_len = len(pressed)
+            return matrix_changed(pressed)
 
         return None  # The default, but for explicitness

--- a/kmk/micropython/pyb_hid.py
+++ b/kmk/micropython/pyb_hid.py
@@ -6,6 +6,7 @@ from kmk.common.consts import HID_REPORT_STRUCTURE, HIDReportTypes
 from kmk.common.event_defs import HID_REPORT_EVENT
 from kmk.common.keycodes import (FIRST_KMK_INTERNAL_KEYCODE, ConsumerKeycode,
                                  ModifierKeycode)
+from kmk.common.macros import KMKMacro
 
 
 def generate_pyb_hid_descriptor():
@@ -71,7 +72,7 @@ class HIDHelper:
                 self.add_key(consumer_key)
             else:
                 for key in state.keys_pressed:
-                    if key.code >= FIRST_KMK_INTERNAL_KEYCODE:
+                    if isinstance(key, KMKMacro) or key.code >= FIRST_KMK_INTERNAL_KEYCODE:
                         continue
 
                     if isinstance(key, ModifierKeycode):
@@ -98,7 +99,7 @@ class HIDHelper:
         # It'd be real awesome if pyb.USB_HID.send/recv would support
         # uselect.poll or uselect.select to more safely determine when
         # it is safe to write to the host again...
-        delay(10)
+        delay(5)
 
         return self
 

--- a/kmk/micropython/pyb_hid.py
+++ b/kmk/micropython/pyb_hid.py
@@ -44,7 +44,7 @@ class HIDHelper:
         self.report_non_mods = memoryview(self._evt)[3:]
 
     def _subscription(self, state, action):
-        if action[0] == HID_REPORT_EVENT:
+        if action.type == HID_REPORT_EVENT:
             self.clear_all()
 
             consumer_key = None

--- a/kmk/micropython/pyb_hid.py
+++ b/kmk/micropython/pyb_hid.py
@@ -43,7 +43,7 @@ class HIDHelper:
         self.report_non_mods = memoryview(self._evt)[3:]
 
     def _subscription(self, state, action):
-        if action['type'] == HID_REPORT_EVENT:
+        if action[0] == HID_REPORT_EVENT:
             self.clear_all()
 
             consumer_key = None


### PR DESCRIPTION
We're still slower than QMK, but thankfully not by a ton. Typing (ノಠ痊ಠ)ノ彡┻━┻ is now almost as fast of a process as my QMK board.

How'd I do it?

- Only send a list of pressed keys per matrix scan. This saves way more cycles than it looks like at first glance, because we used to do _several_ loops through an entire key matrix (meaning the perf hit scaled with the size of the board) to do various things: normalize it, check for any keys changed, check for which specific keys changed. We now just send a very small list of the matrix coordinates that are pressed if the length of the pressed list changes (this is assuming someone can't release key A and press key B all within the same processor tick - I'm gonna call BS if anyone claims they can do it on supported hardware). This will be far nicer to work with over I2C and BLE for splits, as well - less data going over the connection.

- Finally fold `KEY_UP_EVENT` and `KEY_DOWN_EVENT` into `MATRIX_CHANGED_EVENT` like I thought of doing long ago. Those two event codes are still used internally (for the sub-reducers in `internal_keycodes.py`), but are no longer exposed to the event loop. This results in fewer burned cycles of reducer overhead.

- Stop recreating `MatrixScanner` any time anything in the State changes. Just... don't ask. I have no idea why I was doing this, and I only discovered it because of other bugs that popped up in this branch that led me to it - had I not done the above bullet point, I'd have never triggered this and would have likely had no idea this was happening.

Some other cursory benefits of this are lower RAM usage (not storing lists on lists on lists) and fewer GC cycles (because we're not creating and immediately abandoning tons of intermediary iterables, mostly wasted in the old implementation of `MatrixScanner`)

This also allowed me to trim out a ton of bloat from `MatrixScanner` such as `normalize_matrix`, so that's less crap to port to CircuitPython once I finally have an NRF board up and running.

There's another change in here (which was partially rolled back to its current state) where we no longer send a million dicts around as our event representations; they're now `namedtuples`, though there is still a dict-style lookup because (for readability and sanity) we still access the event attributes by name rather than by index (at one point in this branch they were accessed by index, and it absolutely sucks to read).

PHEW!