### PR TITLE
Improve Makefile: Stop clobbering /vendor, detect submodule changes more intelligently

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
             - v1-kmk-venv-{{ checksum "Pipfile.lock" }}
 
       - run: pip install pipenv==2018.7.1
+      - run: apt-get update && apt-get install -y gcc-arm-none-eabi gettext wget unzip rsync
       - run: make test
 
   build_pyboard:
@@ -54,7 +55,7 @@ jobs:
             - v1-kmk-venv-{{ checksum "Pipfile.lock" }}
 
       - run: pip install pipenv==2018.7.1
-      - run: apt-get update && apt-get install -y gcc-arm-none-eabi gettext wget unzip
+      - run: apt-get update && apt-get install -y gcc-arm-none-eabi gettext wget unzip rsync
 
       - run: make SKIP_KEYMAP_VALIDATION=1 USER_KEYMAP=user_keymaps/noop.py build-pyboard
 
@@ -73,7 +74,7 @@ jobs:
             - v1-kmk-venv-{{ checksum "Pipfile.lock" }}
 
       - run: pip install pipenv==2018.7.1
-      - run: apt-get update && apt-get install -y gcc-arm-none-eabi gettext wget unzip
+      - run: apt-get update && apt-get install -y gcc-arm-none-eabi gettext wget unzip rsync
 
       - run: make USER_KEYMAP=user_keymaps/noop.py build-teensy-3.1
 

--- a/bin/micropython.sh
+++ b/bin/micropython.sh
@@ -1,6 +1,6 @@
-if [ ! -f vendor/micropython/ports/unix/micropython ]; then
+if [ ! -f build/micropython/ports/unix/micropython ]; then
 	echo "Run make micropython-build-unix"
 	exit 1
 fi
 
-vendor/micropython/ports/unix/micropython $@
+build/micropython/ports/unix/micropython $@

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .git,__pycache__,vendor,.venv
+exclude = .git,__pycache__,vendor,.venv,build
 max_line_length = 99
 ignore = X100, E262
 per-file-ignores =

--- a/submodules.toml
+++ b/submodules.toml
@@ -1,0 +1,4 @@
+[submodules]
+"vendor/circuitpython" = "d751740"
+"vendor/micropython" = "65a49fa"
+"vendor/upy-lib" = "f20d89c"


### PR DESCRIPTION
We should never again have half-broken submodule clones that we can't rescue from without `rm -rf kmk_firmware` and a full re-clone, because we now copy `/vendor` to `/build` before writing anything, and detect submodule changes automatically in the Makefile.