### PR TITLE
Some backports from work on #46 to greatly speed up Circle builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,134 +1,66 @@
 version: 2
 jobs:
-  lint:
-    docker:
-      - image: 'ubuntu:bionic'
-
-    environment:
-        KMK_TEST: 1
-        PIPENV_VENV_IN_PROJECT: 1
-
-    steps:
-      - run: apt-get update && apt-get install -y software-properties-common git ssh wget
-      - run: add-apt-repository ppa:deadsnakes/ppa
-      - run: apt-get update && apt-get install -y python3.7 python3.7-dev build-essential pkg-config libffi-dev
-      - run: wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
-      - run: python3.7 /tmp/get-pip.py
-      - run: python3.7 -m pip install pip==18.0  # downgrade pip to work around https://github.com/pypa/pipenv/issues/2924
-
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-kmk-venv-{{ checksum "Pipfile.lock" }}
-
-      - run: python3.7 -m pip install pipenv==2018.7.1
-      - run: make lint
-
-      - save_cache:
-          key: v1-kmk-venv-{{ checksum "Pipfile.lock" }}
-          paths:
-            - .venv
-
   test:
     docker:
-      - image: 'ubuntu:bionic'
+      - image: 'kmkfw/base'
 
     environment:
         KMK_TEST: 1
         PIPENV_VENV_IN_PROJECT: 1
 
     steps:
-      - run: apt-get update && apt-get install -y software-properties-common git ssh
-      - run: add-apt-repository ppa:team-gcc-arm-embedded/ppa
-      - run: add-apt-repository ppa:deadsnakes/ppa
-      - run: apt-get update && apt-get install -y gcc-arm-embedded gettext wget unzip rsync python3.7 python3.7-dev build-essential pkg-config libffi-dev
-      - run: wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
-      - run: python3.7 /tmp/get-pip.py
-      - run: python3.7 -m pip install pip==18.0  # downgrade pip to work around https://github.com/pypa/pipenv/issues/2924
-
       - checkout
       - restore_cache:
           keys:
-            - v1-kmk-venv-{{ checksum "Pipfile.lock" }}
+            - v2-kmk-venv-{{ checksum "Pipfile.lock" }}
 
-      - run: python3.7 -m pip install pipenv==2018.7.1
       - run: make test
 
   build_feather_m4_express:
     docker:
-      - image: 'ubuntu:bionic'
+      - image: 'kmkfw/base'
 
     environment:
         KMK_TEST: 1
         PIPENV_VENV_IN_PROJECT: 1
 
     steps:
-      - run: apt-get update && apt-get install -y software-properties-common git ssh
-      - run: add-apt-repository ppa:team-gcc-arm-embedded/ppa
-      - run: add-apt-repository ppa:deadsnakes/ppa
-      - run: apt-get update && apt-get install -y gcc-arm-embedded gettext wget unzip rsync python3.7 python3.7-dev build-essential pkg-config libffi-dev
-      - run: wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
-      - run: python3.7 /tmp/get-pip.py
-      - run: python3.7 -m pip install pip==18.0  # downgrade pip to work around https://github.com/pypa/pipenv/issues/2924
-
       - checkout
       - restore_cache:
           keys:
-            - v1-kmk-venv-{{ checksum "Pipfile.lock" }}
-
-      - run: python3.7 -m pip install pipenv==2018.7.1
+            - v2-kmk-venv-{{ checksum "Pipfile.lock" }}
 
       - run: make SKIP_KEYMAP_VALIDATION=1 USER_KEYMAP=user_keymaps/noop.py build-feather-m4-express
 
   build_itsybitsy_m4_express:
     docker:
-      - image: 'ubuntu:bionic'
+      - image: 'kmkfw/base'
 
     environment:
         KMK_TEST: 1
         PIPENV_VENV_IN_PROJECT: 1
 
     steps:
-      - run: apt-get update && apt-get install -y software-properties-common git ssh
-      - run: add-apt-repository ppa:team-gcc-arm-embedded/ppa
-      - run: add-apt-repository ppa:deadsnakes/ppa
-      - run: apt-get update && apt-get install -y gcc-arm-embedded gettext wget unzip rsync python3.7 python3.7-dev build-essential pkg-config libffi-dev
-      - run: wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
-      - run: python3.7 /tmp/get-pip.py
-      - run: python3.7 -m pip install pip==18.0  # downgrade pip to work around https://github.com/pypa/pipenv/issues/2924
-
       - checkout
       - restore_cache:
           keys:
-            - v1-kmk-venv-{{ checksum "Pipfile.lock" }}
-
-      - run: python3.7 -m pip install pipenv==2018.7.1
+            - v2-kmk-venv-{{ checksum "Pipfile.lock" }}
 
       - run: make SKIP_KEYMAP_VALIDATION=1 USER_KEYMAP=user_keymaps/noop.py build-itsybitsy-m4-express
 
   build_pyboard:
     docker:
-      - image: 'ubuntu:bionic'
+      - image: 'kmkfw/base'
 
     environment:
         KMK_TEST: 1
         PIPENV_VENV_IN_PROJECT: 1
 
     steps:
-      - run: apt-get update && apt-get install -y software-properties-common git ssh
-      - run: add-apt-repository ppa:team-gcc-arm-embedded/ppa
-      - run: add-apt-repository ppa:deadsnakes/ppa
-      - run: apt-get update && apt-get install -y gcc-arm-embedded gettext wget unzip rsync python3.7 python3.7-dev build-essential pkg-config libffi-dev
-      - run: wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
-      - run: python3.7 /tmp/get-pip.py
-      - run: python3.7 -m pip install pip==18.0  # downgrade pip to work around https://github.com/pypa/pipenv/issues/2924
-
       - checkout
       - restore_cache:
           keys:
-            - v1-kmk-venv-{{ checksum "Pipfile.lock" }}
-
-      - run: python3.7 -m pip install pipenv==2018.7.1
+            - v2-kmk-venv-{{ checksum "Pipfile.lock" }}
 
       - run: make SKIP_KEYMAP_VALIDATION=1 USER_KEYMAP=user_keymaps/noop.py build-pyboard
 
@@ -136,20 +68,12 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - lint:
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
       - test:
           filters:
             branches:
               only: /.*/
             tags:
               only: /.*/
-          requires:
-            - lint
       - build_feather_m4_express:
           filters:
             branches:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+build
+vendor
+.devdeps
+.submodules
+.idea
+.micropython-deps
+.circuitpython-deps
+.ampy
+.venv
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ venv.bak/
 .circuitpy-deps
 .micropython-deps
 .devdeps
+.docker_base
 
 # Pycharms cruft
 .idea

--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -1,0 +1,21 @@
+# vim: ft=dockerfile
+
+# Not using python:3.7 here because team-gcc-arm-embedded/ppa does not support
+# Ubuntu Cosmic or Debian Stretch, and Alpine, bizarrely, does not seem to
+# package GCC cross compilers
+FROM ubuntu:bionic
+
+# Set up PPAs we'll need for Python and for GCC ARM
+RUN apt-get update && apt-get install -y software-properties-common
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN add-apt-repository ppa:team-gcc-arm-embedded/ppa
+
+# Install Python
+RUN apt-get update && apt-get install -y python3.7 python3.7-dev build-essential pkg-config libffi-dev curl
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3.7
+# Downgrade pip to work around https://github.com/pypa/pipenv/issues/2924
+RUN python3.7 -m pip install pip==18.0
+RUN python3.7 -m pip install pipenv==2018.7.1
+
+# Install KMK CI and/or build-time dependencies
+RUN apt-get install -y gcc-arm-embedded gettext ssh wget unzip rsync git locales libusb-dev


### PR DESCRIPTION
This backports from topic-docker the base image, which we can now use in
Circle to MASSIVELY speed up our CI situation. This at least caches all the Linux-level dependencies (Python, GCC, etc. etc.) and should shave 3-5 minutes off each build stage.

It also merges the lint and test stages for simplicity's sake.

The base image can currently only be pushed by @klardotsh as nobody else
has access to the Docker Hub org, but that can change in the future.

Not finishing up `topic-docker` or #46 just yet because I need to do some Makefile foolery to ensure we are not redistributing the Nordic BLE stack within our Docker images, which I'm _pretty_ sure is a violation of their licensing terms (thus why MicroPython and CircuitPython both call out to a bash script to pull those firmware blobs at build time).