### PR TITLE
Add MEH and HYPER modifiers, refactor some cruft, and banish mostly-unused InternalState.update()

### DIFF
--- a/kmk/abstract/hid.py
+++ b/kmk/abstract/hid.py
@@ -102,7 +102,11 @@ class AbstractHidHelper:
 
     def add_modifier(self, modifier):
         if isinstance(modifier, ModifierKeycode):
-            self.report_mods[0] |= modifier.code
+            if modifier.code == ModifierKeycode.FAKE_CODE:
+                for mod in modifier.has_modifiers:
+                    self.report_mods[0] |= mod
+            else:
+                self.report_mods[0] |= modifier.code
         else:
             self.report_mods[0] |= modifier
 
@@ -110,7 +114,11 @@ class AbstractHidHelper:
 
     def remove_modifier(self, modifier):
         if isinstance(modifier, ModifierKeycode):
-            self.report_mods[0] ^= modifier.code
+            if modifier.code == ModifierKeycode.FAKE_CODE:
+                for mod in modifier.has_modifiers:
+                    self.report_mods[0] ^= mod
+            else:
+                self.report_mods[0] ^= modifier.code
         else:
             self.report_mods[0] ^= modifier
 

--- a/kmk/keycodes.py
+++ b/kmk/keycodes.py
@@ -81,17 +81,33 @@ class Keycode:
 
 
 class ModifierKeycode(Keycode):
+    FAKE_CODE = -1
+
     def __call__(self, modified_code=None, no_press=None, no_release=None):
         if modified_code is None and no_press is None and no_release is None:
             return self
 
         if modified_code is not None:
-            new_keycode = Keycode(
-                modified_code.code,
-                {self.code},
-                no_press=no_press,
-                no_release=no_release,
-            )
+            if isinstance(modified_code, ModifierKeycode):
+                new_keycode = ModifierKeycode(
+                    ModifierKeycode.FAKE_CODE,
+                    set() if self.has_modifiers is None else self.has_modifiers,
+                    no_press=no_press,
+                    no_release=no_release,
+                )
+
+                if self.code != ModifierKeycode.FAKE_CODE:
+                    new_keycode.has_modifiers.add(self.code)
+
+                if modified_code.code != ModifierKeycode.FAKE_CODE:
+                    new_keycode.has_modifiers.add(modified_code.code)
+            else:
+                new_keycode = Keycode(
+                    modified_code.code,
+                    {self.code},
+                    no_press=no_press,
+                    no_release=no_release,
+                )
 
             if modified_code.has_modifiers:
                 new_keycode.has_modifiers |= modified_code.has_modifiers
@@ -103,6 +119,9 @@ class ModifierKeycode(Keycode):
             )
 
         return new_keycode
+
+    def __repr__(self):
+        return 'ModifierKeycode(code={}, has_modifiers={})'.format(self.code, self.has_modifiers)
 
 
 class ConsumerKeycode(Keycode):
@@ -219,6 +238,9 @@ class Modifiers(KeycodeCategory):
     KC_RSHIFT = KC_RSFT = ModifierKeycode(RawKeycodes.RSHIFT)
     KC_RALT = ModifierKeycode(RawKeycodes.RALT)
     KC_RGUI = KC_RCMD = KC_RWIN = ModifierKeycode(RawKeycodes.RGUI)
+
+    KC_MEH = KC_LSHIFT(KC_LALT(KC_LCTRL))
+    KC_HYPR = KC_HYPER = KC_MEH(KC_LGUI)
 
 
 class Common(KeycodeCategory):

--- a/user_keymaps/klardotsh/itsybitsy_m4_express/threethree.py
+++ b/user_keymaps/klardotsh/itsybitsy_m4_express/threethree.py
@@ -72,7 +72,7 @@ MACRO_HELLO_WORLD = simple_key_sequence([
 
 keymap = [
     [
-        [KC.GESC,              KC.A,     KC.RESET],
+        [KC.GESC,              KC.HYPR,     KC.RESET],
         [KC.MO(1),             KC.B,     KC.MUTE],
         [KC.LT(2, KC.EXCLAIM), KC.HASH,  KC.ENTER],
     ],


### PR DESCRIPTION
I can now press a free-floating HYPER in my keymap and see the appropriate codes in `xev` for press and release events. Cool.