### PR TITLE
Add LeaderMode.TIMEOUT (QMK default Leader mode)

### DIFF
--- a/kmk/consts.py
+++ b/kmk/consts.py
@@ -150,7 +150,7 @@ class UnicodeModes:
 
 
 class LeaderMode:
-    DEFAULT = 0
-    DEFAULT_ACTIVE = 1
+    TIMEOUT = 0
+    TIMEOUT_ACTIVE = 1
     ENTER = 2
     ENTER_ACTIVE = 3

--- a/kmk/matrix.py
+++ b/kmk/matrix.py
@@ -98,12 +98,13 @@ class MatrixScanner:
                     self.report[2] = new_val
                     self.state[ba_idx] = new_val
                     any_changed = True
-
-                    yield self.report
+                    break
 
                 ba_idx += 1
 
             opin.value(False)
+            if any_changed:
+                break
 
-        if not any_changed:
-            yield None
+        if any_changed:
+            return self.report

--- a/user_keymaps/klardotsh/klarank_featherm4.py
+++ b/user_keymaps/klardotsh/klarank_featherm4.py
@@ -1,5 +1,5 @@
 from kmk.boards.klarank import Firmware
-from kmk.consts import UnicodeModes
+from kmk.consts import LeaderMode, UnicodeModes
 from kmk.keycodes import KC
 from kmk.keycodes import generate_leader_dictionary_seq as glds
 from kmk.macros.simple import send_string
@@ -45,6 +45,7 @@ emoticons = cuss({
 
 WPM = send_string("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Bibendum arcu vitae elementum curabitur vitae nunc sed. Facilisis sed odio morbi quis.")
 
+keyboard.leader_mode = LeaderMode.TIMEOUT
 keyboard.leader_dictionary = {
     glds('hello'): send_string('hello world from kmk macros'),
     glds('wpm'): WPM,


### PR DESCRIPTION
This allows leader sequences to "time out" rather than requiring an
Enter keypress to end.

This also rolls back some unnecessary changes from #72 to the matrix
scanner for performance reasons.

In theory we can use this in the future for Tap Dance support (#40)

Resolves #1
Resolves #37