### PR TITLE
Tap Dance: Part One

### DIFF
--- a/docs/tapdance.md
+++ b/docs/tapdance.md
@@ -1,0 +1,61 @@
+# Tap Dance
+
+Tap dance is a way to allow a single physical key to work as multple logical
+keys / actions without using layers. With basic tap dance, you can trigger these
+"nested" keys or macros through a series of taps of the physical key within a
+given timeout.
+
+The resulting "logical" action works just like any other key - it can be pressed
+and immediately released, or it can be held. For example, let's take a key
+`KC.TD(KC.A, KC.B)`. If the tap dance key is tapped and released once quickly,
+the letter "a" will be sent. If it is tapped and released twice quickly, the
+letter "b" will be sent. If it is tapped once and held, the letter "a" will be
+held down until the tap dance key is released. If it is tapped and released once
+quickly, then tapped and held (both actions within the timeout window), the
+letter "b" will be held down until the tap dance key is released.
+
+To use this, you may want to define a `tap_time` value in your keyboard
+configuration. This is an integer in milliseconds, and defaults to `300`. 
+
+You'll then want to create a sequence of keys using `KC.TD(KC.SOMETHING,
+KC.SOMETHING_ELSE, MAYBE_THIS_IS_A_MACRO, WHATEVER_YO)`, and place it in your
+keymap somewhere. The only limits on how many keys can go in the sequence are,
+theoretically, the amount of RAM your MCU/board has, and how fast you can mash
+the physical key. Here's your chance to use all that button-mash video game
+experience you've built up over the years.
+
+**NOTE**: Currently our basic tap dance implementation has some limitations that
+are planned to be worked around "eventually", but for now are noteworthy:
+
+- The behavior of momentary layer switching within a tap dance sequence is
+  currently "undefined" at best, and will probably crash your keyboard. For now,
+  we strongly recommend avoiding `KC.MO` (or any other layer switch keys that
+  use momentary switch behavior - `KC.LM`, `KC.LT`, and `KC.TT`)
+
+- Super fancy stuff like sending a keypress only when the leader key is released
+  (perhaps based on how long the leader key was held) is **unsupported** - an
+  example usecase might be "tap for Home, hold for Shift"
+
+Here's an example of all this in action:
+
+```python
+# user_keymaps/some_silly_example.py
+from kmk.boards.klarank import Firmware
+from kmk.keycodes import KC
+from kmk.macros.simple import send_string
+
+keyboard = Firmware()
+
+keyboard.tap_time = 750
+
+EXAMPLE_TD = KC.TD(
+    KC.A,  # Tap once for "a"
+    KC.B,  # Tap twice for "b"
+    # Tap three times to send a raw string via macro
+    send_string('macros in a tap dance? I think yes'),
+    # Tap four times to toggle layer index 1
+    KC.TG(1),
+)
+
+keyboard.keymap = [[ ...., EXAMPLE_TD, ....], ....]
+```

--- a/kmk/firmware.py
+++ b/kmk/firmware.py
@@ -68,11 +68,11 @@ class Firmware:
 
     def _send_key(self, key):
         if not getattr(key, 'no_press', None):
-            self._state.force_keycode_down(key)
+            self._state.add_key(key)
             self._send_hid()
 
         if not getattr(key, 'no_release', None):
-            self._state.force_keycode_up(key)
+            self._state.remove_key(key)
             self._send_hid()
 
     def go(self):
@@ -117,14 +117,10 @@ class Firmware:
             if old_timeouts_len != new_timeouts_len:
                 state_changed = True
 
-            for key in self._state.pending_keys:
-                self._send_key(key)
-                self._state.pending_key_handled()
-                state_changed = True
-
-            if self._state.macro_pending:
-                for key in self._state.macro_pending(self):
-                    self._send_key(key)
+            if self._state.macros_pending:
+                for macro in self._state.macros_pending:
+                    for key in macro(self):
+                        self._send_key(key)
 
                 self._state.resolve_macro()
                 state_changed = True

--- a/kmk/keycodes.py
+++ b/kmk/keycodes.py
@@ -80,6 +80,7 @@ class RawKeycodes:
 
     KC_MACRO = 1110
     KC_MACRO_SLEEP_MS = 1111
+    KC_TAP_DANCE = 1113
 
 
 # These shouldn't have all the fancy shenanigans Keycode allows
@@ -182,6 +183,13 @@ class Macro:
 
     def on_keyup(self):
         return self.keyup() if self.keyup else None
+
+
+class TapDanceKeycode:
+    code = RawKeycodes.KC_TAP_DANCE
+
+    def __init__(self, *codes):
+        self.codes = codes
 
 
 class KeycodeCategory(type):
@@ -550,6 +558,13 @@ class KMK(KeycodeCategory):
     @staticmethod
     def KC_MACRO_SLEEP_MS(ms):
         return MacroSleepKeycode(RawKeycodes.KC_MACRO_SLEEP_MS, ms)
+
+    @staticmethod
+    def KC_TAP_DANCE(*args):
+        return TapDanceKeycode(*args)
+
+
+KMK.KC_TD = KMK.KC_TAP_DANCE
 
 
 class Layers(KeycodeCategory):

--- a/kmk/keycodes.py
+++ b/kmk/keycodes.py
@@ -364,7 +364,7 @@ class ShiftedKeycodes(KeycodeCategory):
     KC_DOUBLE_QUOTE = KC_DQUO = KC_DQT = Modifiers.KC_LSHIFT(Common.KC_QUOTE)
     KC_LEFT_ANGLE_BRACKET = KC_LABK = Modifiers.KC_LSHIFT(Common.KC_COMMA)
     KC_RIGHT_ANGLE_BRACKET = KC_RABK = Modifiers.KC_LSHIFT(Common.KC_DOT)
-    KC_QUESTION = KC_QUES = Modifiers.KC_LSHIFT(Common.KC_DOT)
+    KC_QUESTION = KC_QUES = Modifiers.KC_LSHIFT(Common.KC_SLSH)
 
 
 class FunctionKeys(KeycodeCategory):

--- a/user_keymaps/klardotsh/klarank_featherm4.py
+++ b/user_keymaps/klardotsh/klarank_featherm4.py
@@ -10,9 +10,6 @@ keyboard = Firmware()
 keyboard.debug_enabled = True
 keyboard.unicode_mode = UnicodeModes.LINUX
 
-_______ = KC.TRNS
-xxxxxxx = KC.NO
-
 emoticons = cuss({
     # Emojis
     'BEER': r'🍺',
@@ -56,12 +53,22 @@ keyboard.leader_dictionary = {
     glds('cel'): emoticons.CELEBRATORY_GLITTER,
 }
 
+_______ = KC.TRNS
+xxxxxxx = KC.NO
+HELLA_TD = KC.TD(
+    KC.A,
+    KC.B,
+    send_string('macros in a tap dance? I think yes'),
+    KC.TG(1),
+)
+
+
 keyboard.keymap = [
     [
         [KC.GESC, KC.QUOT, KC.COMM,            KC.DOT,   KC.P,     KC.Y,    KC.F,    KC.G,     KC.C,    KC.R,    KC.L,  KC.BSPC],
         [KC.TAB,  KC.A,    KC.O,               KC.E,     KC.U,     KC.I,    KC.D,    KC.H,     KC.T,    KC.N,    KC.S,  KC.ENT],
         [KC.LGUI, KC.SCLN, KC.Q,               KC.J,     KC.K,     KC.X,    KC.B,    KC.M,     KC.W,    KC.V,    KC.Z,  KC.LALT],
-        [KC.LCTL, KC.TD(KC.A, KC.B), KC.LSHIFT(KC.LGUI), KC.MO(2), KC.MO(3), KC.LSFT, KC.SPC,  KC.MO(1), KC.LEFT, KC.DOWN, KC.UP, KC.RGHT],
+        [KC.LCTL, KC.LEAD, KC.LSHIFT(KC.LGUI), KC.MO(2), KC.MO(3), KC.LSFT, KC.SPC,  KC.MO(1), KC.LEFT, KC.DOWN, KC.UP, KC.RGHT],
     ],
 
     [
@@ -79,10 +86,10 @@ keyboard.keymap = [
     ],
 
     [
-        [KC.GRV,  KC.EXLM, KC.AT,   KC.HASH, KC.DLR,  KC.PERC, KC.CIRC, KC.AMPR, KC.ASTR, KC.LPRN, KC.RPRN, KC.SLSH],
-        [KC.TAB,  xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, KC.MINS],
-        [KC.LGUI, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx],
-        [KC.LCTL, KC.DBG,  xxxxxxx, xxxxxxx, _______, _______, xxxxxxx, xxxxxxx, KC.MUTE, KC.VOLD, KC.VOLU, xxxxxxx],
+        [KC.GRV,  KC.EXLM, KC.AT,    KC.HASH, KC.DLR,  KC.PERC, KC.CIRC, KC.AMPR, KC.ASTR, KC.LPRN, KC.RPRN, KC.SLSH],
+        [KC.TAB,  xxxxxxx, xxxxxxx,  xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, KC.MINS],
+        [KC.LGUI, xxxxxxx, xxxxxxx,  xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx, xxxxxxx],
+        [KC.LCTL, KC.DBG,  HELLA_TD, xxxxxxx, _______, _______, xxxxxxx, xxxxxxx, KC.MUTE, KC.VOLD, KC.VOLU, xxxxxxx],
     ],
 ]
 

--- a/user_keymaps/klardotsh/klarank_featherm4.py
+++ b/user_keymaps/klardotsh/klarank_featherm4.py
@@ -61,7 +61,7 @@ keyboard.keymap = [
         [KC.GESC, KC.QUOT, KC.COMM,            KC.DOT,   KC.P,     KC.Y,    KC.F,    KC.G,     KC.C,    KC.R,    KC.L,  KC.BSPC],
         [KC.TAB,  KC.A,    KC.O,               KC.E,     KC.U,     KC.I,    KC.D,    KC.H,     KC.T,    KC.N,    KC.S,  KC.ENT],
         [KC.LGUI, KC.SCLN, KC.Q,               KC.J,     KC.K,     KC.X,    KC.B,    KC.M,     KC.W,    KC.V,    KC.Z,  KC.LALT],
-        [KC.LCTL, KC.LEAD, KC.LSHIFT(KC.LGUI), KC.MO(2), KC.MO(3), KC.LSFT, KC.SPC,  KC.MO(1), KC.LEFT, KC.DOWN, KC.UP, KC.RGHT],
+        [KC.LCTL, KC.TD(KC.A, KC.B), KC.LSHIFT(KC.LGUI), KC.MO(2), KC.MO(3), KC.LSFT, KC.SPC,  KC.MO(1), KC.LEFT, KC.DOWN, KC.UP, KC.RGHT],
     ],
 
     [


### PR DESCRIPTION
This implements the core of #40 by allowing multiple-use keys based on number of taps.

Notably lacking from this first pass:

- Changing `KC.TT` to use tap dance. For that matter, the behavior of `KC.MO` (a dependency of `KC.TT`) within a tap dance sequence is currently "undefined" at best, probably going to throw errors. For now, strongly recommend avoiding it.
- Support for more advanced tap dance configs (where keyup does different things based on how long the tap was held - for example, "tap for Home, hold for Shift")

I'll write up docs some time tonight after dinner, but I wanted to at least get this much opened up for PR so the code itself can be looked over.