### PR TITLE
kmk.consts: rename UnicodeModes => UnicodeMode

### DIFF
--- a/docs/keymap.md
+++ b/docs/keymap.md
@@ -63,7 +63,7 @@ You can further define a bunch of other stuff:
   console. This is very rarely needed, but can provide very valuable information
   if you need to open an issue.
 
-- `unicode_mode` from `kmk.consts.UnicodeModes`, which defines the default
+- `unicode_mode` from `kmk.consts.UnicodeMode`, which defines the default
   operating system implementation to use for unicode sequences (see examples
   below, or `unicode.md`. This can be changed after boot with a key (see
   `keycodes.md`)
@@ -86,7 +86,7 @@ features:
 
 ```python
 from kmk.boards.klarank import Firmware
-from kmk.consts import UnicodeModes
+from kmk.consts import UnicodeMode
 from kmk.keycodes import KC
 from kmk.keycodes import generate_leader_dictionary_seq as glds
 from kmk.macros.simple import send_string
@@ -95,7 +95,7 @@ from kmk.macros.unicode import compile_unicode_string_sequences as cuss
 keyboard = Firmware()
 
 keyboard.debug_enabled = True
-keyboard.unicode_mode = UnicodeModes.LINUX
+keyboard.unicode_mode = UnicodeMode.LINUX
 
 _______ = KC.TRNS
 xxxxxxx = KC.NO

--- a/docs/unicode.md
+++ b/docs/unicode.md
@@ -16,16 +16,16 @@ Before using unicode mode, you will need to set your platform. This can be done 
 You can use both in cases where you want to use one operating system, but occasionally use another.
 This allows you to change modes on the fly without having to change your keymap.
 
-	unicode_mode = UnicodeModes.LINUX
+	unicode_mode = UnicodeMode.LINUX
 	Or
 	keymap = [...KC.UC_MODE_LINUX,...]
 
 
 ### Unicode Modes:
 On Linux IBUS is required, and on Windows, requires [WinCompose](https://github.com/samhocevar/wincompose)
-- Linux : UnicodeModes.LINUX or UnicodeModes.IBUS
-- Mac:    UnicodeModes.MACOS or UnicodeModes.OSX or UnicodeModes.RALT
-- Windows: UnicodeModes.WINC
+- Linux : UnicodeMode.LINUX or UnicodeMode.IBUS
+- Mac:    UnicodeMode.MACOS or UnicodeMode.OSX or UnicodeMode.RALT
+- Windows: UnicodeMode.WINC
 
 A note for IBUS users on Linux. This mode is not enabled by default, and will need to be turned on for this to work.
 This works on X11, though if you are on Wayland, or in some GTK apps, it MAY work, but is not supported.

--- a/kmk/consts.py
+++ b/kmk/consts.py
@@ -142,7 +142,7 @@ class DiodeOrientation:
     ROWS = 1
 
 
-class UnicodeModes:
+class UnicodeMode:
     NOOP = 0
     LINUX = IBUS = 1
     MACOS = OSX = RALT = 2

--- a/kmk/firmware.py
+++ b/kmk/firmware.py
@@ -38,7 +38,7 @@ import busio
 import gc
 
 import supervisor
-from kmk.consts import LeaderMode, UnicodeModes
+from kmk.consts import LeaderMode, UnicodeMode
 from kmk.hid import USB_HID
 from kmk.internal_state import InternalState
 from kmk.matrix import MatrixScanner
@@ -53,7 +53,7 @@ class Firmware:
     col_pins = None
     diode_orientation = None
 
-    unicode_mode = UnicodeModes.NOOP
+    unicode_mode = UnicodeMode.NOOP
     tap_time = 300
     leader_mode = LeaderMode.TIMEOUT
     leader_dictionary = {}

--- a/kmk/keycodes.py
+++ b/kmk/keycodes.py
@@ -5,7 +5,7 @@ except ImportError:
     # MicroPython, it doesn't exist
     from ucollections import namedtuple
 
-from kmk.consts import UnicodeModes
+from kmk.consts import UnicodeMode
 from kmk.types import AttrDict
 
 FIRST_KMK_INTERNAL_KEYCODE = 1000
@@ -548,12 +548,12 @@ class KMK(KeycodeCategory):
         '''
         return UnicodeModeKeycode.from_mode_const(mode)
 
-    KC_UC_MODE_NOOP = KC_UC_DISABLE = UnicodeModeKeycode.from_mode_const(UnicodeModes.NOOP)
-    KC_UC_MODE_LINUX = KC_UC_MODE_IBUS = UnicodeModeKeycode.from_mode_const(UnicodeModes.IBUS)
+    KC_UC_MODE_NOOP = KC_UC_DISABLE = UnicodeModeKeycode.from_mode_const(UnicodeMode.NOOP)
+    KC_UC_MODE_LINUX = KC_UC_MODE_IBUS = UnicodeModeKeycode.from_mode_const(UnicodeMode.IBUS)
     KC_UC_MODE_MACOS = KC_UC_MODE_OSX = KC_UC_MODE_RALT = UnicodeModeKeycode.from_mode_const(
-        UnicodeModes.RALT,
+        UnicodeMode.RALT,
     )
-    KC_UC_MODE_WINC = UnicodeModeKeycode.from_mode_const(UnicodeModes.WINC)
+    KC_UC_MODE_WINC = UnicodeModeKeycode.from_mode_const(UnicodeMode.WINC)
 
     @staticmethod
     def KC_MACRO_SLEEP_MS(ms):

--- a/kmk/macros/unicode.py
+++ b/kmk/macros/unicode.py
@@ -1,4 +1,4 @@
-from kmk.consts import UnicodeModes
+from kmk.consts import UnicodeMode
 from kmk.keycodes import (Common, Macro, Modifiers,
                           generate_codepoint_keysym_seq)
 from kmk.macros.simple import simple_key_sequence
@@ -43,11 +43,11 @@ def unicode_codepoint_sequence(codepoints):
     ]
 
     def _unicode_sequence(state):
-        if state.unicode_mode == UnicodeModes.IBUS:
+        if state.unicode_mode == UnicodeMode.IBUS:
             yield from _ibus_unicode_sequence(kc_macros, state)
-        elif state.unicode_mode == UnicodeModes.RALT:
+        elif state.unicode_mode == UnicodeMode.RALT:
             yield from _ralt_unicode_sequence(kc_macros, state)
-        elif state.unicode_mode == UnicodeModes.WINC:
+        elif state.unicode_mode == UnicodeMode.WINC:
             yield from _winc_unicode_sequence(kc_macros, state)
 
     return Macro(keydown=_unicode_sequence)

--- a/user_keymaps/kdb424/klanck.py
+++ b/user_keymaps/kdb424/klanck.py
@@ -1,4 +1,4 @@
-from kmk.consts import DiodeOrientation, UnicodeModes
+from kmk.consts import DiodeOrientation, UnicodeMode
 from kmk.keycodes import KC
 from kmk.keycodes import generate_leader_dictionary_seq as glds
 from kmk.macros.simple import send_string
@@ -15,7 +15,7 @@ keyboard.diode_orientation = DiodeOrientation.COLUMNS
 
 
 # ------------------User level config variables ---------------------------------------
-keyboard.unicode_mode = UnicodeModes.LINUX
+keyboard.unicode_mode = UnicodeMode.LINUX
 keyboard.tap_time = 350
 keyboard.leader_timeout = 2000
 keyboard.debug_enabled = False

--- a/user_keymaps/kdb424/levinson_m4.py
+++ b/user_keymaps/kdb424/levinson_m4.py
@@ -1,7 +1,7 @@
 import board
 import busio
 
-from kmk.consts import DiodeOrientation, LeaderMode, UnicodeModes
+from kmk.consts import DiodeOrientation, LeaderMode, UnicodeMode
 from kmk.keycodes import KC
 from kmk.keycodes import generate_leader_dictionary_seq as glds
 from kmk.macros.simple import send_string
@@ -24,7 +24,7 @@ keyboard.uart = keyboard.init_uart(tx=board.TX, rx=board.RX)
 
 # ------------------User level config variables ---------------------------------------
 keyboard.leader_mode = LeaderMode.TIMEOUT
-keyboard.unicode_mode = UnicodeModes.LINUX
+keyboard.unicode_mode = UnicodeMode.LINUX
 keyboard.tap_time = 150
 keyboard.leader_timeout = 2000
 keyboard.debug_enabled = True

--- a/user_keymaps/klardotsh/klarank_featherm4.py
+++ b/user_keymaps/klardotsh/klarank_featherm4.py
@@ -1,5 +1,5 @@
 from kmk.boards.klarank import Firmware
-from kmk.consts import LeaderMode, UnicodeModes
+from kmk.consts import LeaderMode, UnicodeMode
 from kmk.keycodes import KC
 from kmk.keycodes import generate_leader_dictionary_seq as glds
 from kmk.macros.simple import send_string
@@ -8,7 +8,7 @@ from kmk.macros.unicode import compile_unicode_string_sequences as cuss
 keyboard = Firmware()
 
 keyboard.debug_enabled = True
-keyboard.unicode_mode = UnicodeModes.LINUX
+keyboard.unicode_mode = UnicodeMode.LINUX
 keyboard.tap_time = 750
 
 emoticons = cuss({


### PR DESCRIPTION
This brings this naming into consistency with both fellow consts in the
same file (ex. LeaderMode is singular) as well as the variables in which
the consts are usually used (usually a `Firmware.unicode_mode` attribute
in a keymap).