### PR TITLE
Literally this is all that is needed to restore functionality (GESC)

### DIFF
--- a/kmk/handlers/stock.py
+++ b/kmk/handlers/stock.py
@@ -51,9 +51,6 @@ def gesc_pressed(key, state, KC, *args, **kwargs):
     GESC_TRIGGERS = {KC.LSHIFT, KC.RSHIFT, KC.LGUI, KC.RGUI}
 
     if GESC_TRIGGERS.intersection(state.keys_pressed):
-        # First, release GUI if already pressed
-        state.keys_pressed.discard(KC.LGUI)
-        state.keys_pressed.discard(KC.RGUI)
         state.config._send_hid()
         # if Shift is held, KC_GRAVE will become KC_TILDE on OS level
         state.keys_pressed.add(KC.GRAVE)


### PR DESCRIPTION
QMK allows configuration which we don't currently have any of to allow unbreaking of OS keybinds, but without any workarounds, this is literally what it is with QMK. We don't need to throw away MOD4/Super/Win Resolves #114 