### PR TITLE
Literally hurting performance now. Needs removed

### DIFF
--- a/kmk/firmware.py
+++ b/kmk/firmware.py
@@ -23,7 +23,6 @@ import kmk.types  # isort:skip
 import kmk.util  # isort:skip
 
 import busio  # isort:skip
-import gc  # isort:skip
 
 import supervisor  # isort:skip
 from kmk.consts import LeaderMode, UnicodeMode  # isort:skip
@@ -223,5 +222,3 @@ class Firmware:
 
             if self.debug_enabled and state_changed:
                 print('New State: {}'.format(self._state._to_dict()))
-
-            gc.collect()


### PR DESCRIPTION
This has been tested to HURT performance quite a lot. While animations are running, I was hitting a border of performance that I could not roll keys. With this one line change, almost all of it is solved. I recommend testing this branch before accepting, but I don't think that we still need this. If we do, than we will have to change limits as without this, performance can get very bad in some situations even with "plenty" of ram free.