### PR TITLE
Compatibility with CircuitPython 4.0.0-rc2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,7 @@ venv.bak/
 
 # Personal dev scripts
 .scripts
+
+# Mountpoints
+mnt/
+mnt2/

--- a/kmk/matrix.py
+++ b/kmk/matrix.py
@@ -73,8 +73,19 @@ class MatrixScanner:
             opin.value(True)
 
             for iidx, ipin in enumerate(self.inputs):
+                # cast to int to avoid
+                #
+                # >>> xyz = bytearray(3)
+                # >>> xyz[2] = True
+                # Traceback (most recent call last):
+                #   File "<stdin>", line 1, in <module>
+                # OverflowError: value would overflow a 1 byte buffer
+                #
+                # I haven't dived too far into what causes this, but it's
+                # almost certainly because bool types in Python aren't just
+                # aliases to int values, but are proper pseudo-types
+                new_val = int(ipin.value())
                 old_val = self.state[ba_idx]
-                new_val = ipin.value()
 
                 if old_val != new_val:
                     if self.translate_coords:
@@ -97,6 +108,7 @@ class MatrixScanner:
 
                     self.report[2] = new_val
                     self.state[ba_idx] = new_val
+
                     any_changed = True
                     break
 


### PR DESCRIPTION
This fixes a couple of critically-breaking issues and allows KMK to run on the newest release candidates of upstream CircuitPython. It does introduce one minor UX regression I'm willing to accept for the immediate time being.

- Resolves #104, our big breaker on alpha3 onwards, wherein the keyboard would send _nothing_ to the host until REPL was connected, and (due to a bug also resolved in this PR) would constantly re-poll this information on all `is_master` checks, thus killing the keyboard as soon as REPL was disconnected. This is generally related to https://github.com/adafruit/circuitpython/issues/1769, and the workaround mentioned by @dhalbert worked great in this context.

- Resolves a previously-unseen issue almost certainly introduced by the UART refactor somewhere around alpha5 (I think?), where `True` isn't serialized into an amount of space we're allowed to send anymore. Easy fix - force-cast the bools to ints before sending over the wire, and nobody has to be any the wiser.

The regression introduced here is related to the fix for #104 - `usb_hid.Device.send_report` will wait up to two seconds for the HID lane to become ready before throwing the `OSError` we expect. This means any "slave" devices in split configurations won't be available for the first two seconds after keyboard boot (I've tested this pretty heavily on my Iris, it's consistent). I'm fine with this for now - an eventual fix is likely either an upstream patch to decrease (or make configurable) that window, or a patch internally to simply delay 2s after a successful call to `send_report` (basically buffer time built into the fast, happy path to account for all the split devices that will have failed `send_report` after a 2s timeout).