### PR TITLE
Add the ability to use seesaw I/O extender for scanning

### DIFF
--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -191,7 +191,7 @@ class KMKKeyboard:
         else:
             return busio.UART(tx=pin, rx=None, timeout=timeout)
 
-    def go(self, hid_type=HIDModes.USB):
+    def go(self, hid_type=HIDModes.USB, seesaw=None):
         assert self.keymap, 'must define a keymap with at least one row'
         assert self.row_pins, 'no GPIO pins defined for matrix rows'
         assert self.col_pins, 'no GPIO pins defined for matrix columns'
@@ -270,6 +270,7 @@ class KMKKeyboard:
             rows=self.row_pins,
             diode_orientation=self.diode_orientation,
             rollover_cols_every_rows=getattr(self, 'rollover_cols_every_rows', None),
+            seesaw=seesaw,
         )
 
         # Compile string leader sequences

--- a/kmk/matrix.py
+++ b/kmk/matrix.py
@@ -24,7 +24,10 @@ class MatrixScanner:
         rows,
         diode_orientation=DiodeOrientation.COLUMNS,
         rollover_cols_every_rows=None,
+        seesaw=None,
     ):
+        self.seesaw = seesaw
+
         self.len_cols = len(cols)
         self.len_rows = len(rows)
 
@@ -42,12 +45,12 @@ class MatrixScanner:
         self.diode_orientation = diode_orientation
 
         if self.diode_orientation == DiodeOrientation.COLUMNS:
-            self.outputs = [digitalio.DigitalInOut(x) for x in cols]
-            self.inputs = [digitalio.DigitalInOut(x) for x in rows]
+            self.outputs = [self._getio(x) for x in cols]
+            self.inputs = [self._getio(x) for x in rows]
             self.translate_coords = True
         elif self.diode_orientation == DiodeOrientation.ROWS:
-            self.outputs = [digitalio.DigitalInOut(x) for x in rows]
-            self.inputs = [digitalio.DigitalInOut(x) for x in cols]
+            self.outputs = [self._getio(x) for x in rows]
+            self.inputs = [self._getio(x) for x in cols]
             self.translate_coords = False
         else:
             raise ValueError(
@@ -67,6 +70,20 @@ class MatrixScanner:
         self.len_state_arrays = self.len_cols * self.len_rows
         self.state = bytearray(self.len_state_arrays)
         self.report = bytearray(3)
+
+    def _getio(self, pin):
+        '''
+        Get a DigitalInOut object for 'pin'.  If it is a simple number, then it
+        is assumed to be a pin on an attached seesaw; otherwise, it is a standard
+        DigitalInOut.
+        '''
+
+        if isinstance(pin, int):
+            import adafruit_seesaw.digitalio
+
+            return adafruit_seesaw.digitalio.DigitalIO(self.seesaw, pin)
+
+        return digitalio.DigitalInOut(pin)
 
     def scan_for_changes(self):
         '''

--- a/user_keymaps/seesaw.py
+++ b/user_keymaps/seesaw.py
@@ -1,0 +1,30 @@
+import board
+import busio
+
+import adafruit_seesaw.seesaw
+from kmk.keys import KC
+from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
+from kmk.matrix import DiodeOrientation
+
+i2c = busio.I2C(board.SCL, board.SDA)
+
+
+class KMKKeyboard(_KMKKeyboard):
+    row_pins = (board.A0, board.A1, board.A2, board.A3)
+    col_pins = (9, 10, 11, 14)
+    diode_orientation = DiodeOrientation.COLUMNS
+    rgb_pixel_pin = board.NEOPIXEL
+    rgb_num_pixels = 1
+
+
+keyboard = KMKKeyboard()
+
+keyboard.keymap = [[
+    KC.N1, KC.N2, KC.N3, KC.N4,
+    KC.N5, KC.N6, KC.N7, KC.N8,
+    KC.N9, KC.N0, KC.A,  KC.B,
+    KC.C,  KC.D,  KC.E,  KC.F]]
+
+if __name__ == '__main__':
+    seesaw = adafruit_seesaw.seesaw.Seesaw(i2c)
+    keyboard.go(seesaw=seesaw)


### PR DESCRIPTION
This is "tested" by manually creating contacts between the pins on an Itsy Bitsy M4 and the samd09 breakout.  I'm entering it in Draft status because it's a proof of concept and I don't really know how it should work, organizationally speaking, to get the seesaw instance across the layers it needs to span.

At one point I stated on chat that only pull UP was supported, but that has now been fixed in current adafruit_seesaw and pull DOWNs are available.  However, my test was arranged so that the seesaw pins were driving pins and the local pins were input pins.  This is probably preferable for performance, since it means fewer I2C transactions.

- [ ] "plumb" the seesaw object in a palatable way
- [ ] document the functionality appropriately
- [ ] benchmark that performance is okay
- [ ] provide a tested sample configuration that is properly organized