### PR TITLE
Basic BLE functionality

### DIFF
--- a/kmk/ble.py
+++ b/kmk/ble.py
@@ -1,0 +1,60 @@
+from adafruit_ble import BLERadio
+from adafruit_ble.advertising import Advertisement
+from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+from adafruit_ble.services.standard.hid import HIDService
+
+from kmk.hid import AbstractHID, HIDUsage, HIDUsagePage, HIDReportTypes, HID_REPORT_SIZES
+
+
+BLE_APPEARANCE_HID_KEYBOARD = 961
+
+
+class BLEHID(AbstractHID):
+    def post_init(self):
+        self.devices = {}
+
+        hid = HIDService()
+ 
+        advertisement = ProvideServicesAdvertisement(hid)
+        advertisement.appearance = BLE_APPEARANCE_HID_KEYBOARD
+        scan_response = Advertisement()
+        scan_response.complete_name = "KMK Keyboard"
+        
+        ble = BLERadio()
+        if not ble.connected:
+            ble.start_advertising(advertisement, scan_response)
+            while not ble.connected:
+                pass
+
+        for device in hid.devices:
+            us = device.usage
+            up = device.usage_page
+
+            if up == HIDUsagePage.CONSUMER and us == HIDUsage.CONSUMER:
+                self.devices[HIDReportTypes.CONSUMER] = device
+                continue
+
+            if up == HIDUsagePage.KEYBOARD and us == HIDUsage.KEYBOARD:
+                self.devices[HIDReportTypes.KEYBOARD] = device
+                continue
+
+            if up == HIDUsagePage.MOUSE and us == HIDUsage.MOUSE:
+                self.devices[HIDReportTypes.MOUSE] = device
+                continue
+
+            if up == HIDUsagePage.SYSCONTROL and us == HIDUsage.SYSCONTROL:
+                self.devices[HIDReportTypes.SYSCONTROL] = device
+                continue
+
+    def hid_send(self, evt):
+        # int, can be looked up in HIDReportTypes
+        reporting_device_const = self.report_device[0]
+
+        report_size = HID_REPORT_SIZES[reporting_device_const]
+
+        while (len(evt) < report_size + 1):
+            evt.append(0)
+        
+        return self.devices[reporting_device_const].send_report(
+            evt[1 : report_size + 1]
+        )

--- a/kmk/ble.py
+++ b/kmk/ble.py
@@ -2,9 +2,13 @@ from adafruit_ble import BLERadio
 from adafruit_ble.advertising import Advertisement
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
 from adafruit_ble.services.standard.hid import HIDService
-
-from kmk.hid import AbstractHID, HIDUsage, HIDUsagePage, HIDReportTypes, HID_REPORT_SIZES
-
+from kmk.hid import (
+    HID_REPORT_SIZES,
+    AbstractHID,
+    HIDReportTypes,
+    HIDUsage,
+    HIDUsagePage,
+)
 
 BLE_APPEARANCE_HID_KEYBOARD = 961
 
@@ -14,12 +18,12 @@ class BLEHID(AbstractHID):
         self.devices = {}
 
         hid = HIDService()
- 
+
         advertisement = ProvideServicesAdvertisement(hid)
         advertisement.appearance = BLE_APPEARANCE_HID_KEYBOARD
         scan_response = Advertisement()
-        scan_response.complete_name = "KMK Keyboard"
-        
+        scan_response.complete_name = 'KMK Keyboard'
+
         ble = BLERadio()
         if not ble.connected:
             ble.start_advertising(advertisement, scan_response)
@@ -52,9 +56,9 @@ class BLEHID(AbstractHID):
 
         report_size = HID_REPORT_SIZES[reporting_device_const]
 
-        while (len(evt) < report_size + 1):
+        while len(evt) < report_size + 1:
             evt.append(0)
-        
+
         return self.devices[reporting_device_const].send_report(
             evt[1 : report_size + 1]
         )

--- a/kmk/hid.py
+++ b/kmk/hid.py
@@ -1,5 +1,10 @@
 import usb_hid
 
+from adafruit_ble import BLERadio
+from adafruit_ble.advertising import Advertisement
+from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+from adafruit_ble.services.standard.hid import HIDService
+
 from kmk.keys import FIRST_KMK_INTERNAL_KEY, ConsumerKey, ModifierKey
 
 
@@ -224,7 +229,51 @@ class USBHID(AbstractHID):
 
 
 class BLEHID(AbstractHID):
-    def __init__(self, *args, **kwargs):
-        raise NotImplementedError(
-            'BLE HID is not supported by upstream CircuitPython yet'
+    def post_init(self):
+        self.devices = {}
+
+        hid = HIDService()
+ 
+        advertisement = ProvideServicesAdvertisement(hid)
+        advertisement.appearance = 961
+        scan_response = Advertisement()
+        scan_response.complete_name = "KMK Keyboard"
+        
+        ble = BLERadio()
+        if not ble.connected:
+            ble.start_advertising(advertisement, scan_response)
+            while not ble.connected:
+                pass
+
+        for device in hid.devices:
+            us = device.usage
+            up = device.usage_page
+
+            if up == HIDUsagePage.CONSUMER and us == HIDUsage.CONSUMER:
+                self.devices[HIDReportTypes.CONSUMER] = device
+                continue
+
+            if up == HIDUsagePage.KEYBOARD and us == HIDUsage.KEYBOARD:
+                self.devices[HIDReportTypes.KEYBOARD] = device
+                continue
+
+            if up == HIDUsagePage.MOUSE and us == HIDUsage.MOUSE:
+                self.devices[HIDReportTypes.MOUSE] = device
+                continue
+
+            if up == HIDUsagePage.SYSCONTROL and us == HIDUsage.SYSCONTROL:
+                self.devices[HIDReportTypes.SYSCONTROL] = device
+                continue
+
+    def hid_send(self, evt):
+        # int, can be looked up in HIDReportTypes
+        reporting_device_const = self.report_device[0]
+
+        report_size = HID_REPORT_SIZES[reporting_device_const]
+
+        while (len(evt) < report_size + 1):
+            evt.append(0)
+        
+        return self.devices[reporting_device_const].send_report(
+            evt[1 : report_size + 1]
         )

--- a/kmk/hid.py
+++ b/kmk/hid.py
@@ -1,10 +1,5 @@
 import usb_hid
 
-from adafruit_ble import BLERadio
-from adafruit_ble.advertising import Advertisement
-from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
-from adafruit_ble.services.standard.hid import HIDService
-
 from kmk.keys import FIRST_KMK_INTERNAL_KEY, ConsumerKey, ModifierKey
 
 
@@ -225,55 +220,4 @@ class USBHID(AbstractHID):
 
         return self.devices[reporting_device_const].send_report(
             evt[1 : HID_REPORT_SIZES[reporting_device_const] + 1]
-        )
-
-
-class BLEHID(AbstractHID):
-    def post_init(self):
-        self.devices = {}
-
-        hid = HIDService()
- 
-        advertisement = ProvideServicesAdvertisement(hid)
-        advertisement.appearance = 961
-        scan_response = Advertisement()
-        scan_response.complete_name = "KMK Keyboard"
-        
-        ble = BLERadio()
-        if not ble.connected:
-            ble.start_advertising(advertisement, scan_response)
-            while not ble.connected:
-                pass
-
-        for device in hid.devices:
-            us = device.usage
-            up = device.usage_page
-
-            if up == HIDUsagePage.CONSUMER and us == HIDUsage.CONSUMER:
-                self.devices[HIDReportTypes.CONSUMER] = device
-                continue
-
-            if up == HIDUsagePage.KEYBOARD and us == HIDUsage.KEYBOARD:
-                self.devices[HIDReportTypes.KEYBOARD] = device
-                continue
-
-            if up == HIDUsagePage.MOUSE and us == HIDUsage.MOUSE:
-                self.devices[HIDReportTypes.MOUSE] = device
-                continue
-
-            if up == HIDUsagePage.SYSCONTROL and us == HIDUsage.SYSCONTROL:
-                self.devices[HIDReportTypes.SYSCONTROL] = device
-                continue
-
-    def hid_send(self, evt):
-        # int, can be looked up in HIDReportTypes
-        reporting_device_const = self.report_device[0]
-
-        report_size = HID_REPORT_SIZES[reporting_device_const]
-
-        while (len(evt) < report_size + 1):
-            evt.append(0)
-        
-        return self.devices[reporting_device_const].send_report(
-            evt[1 : report_size + 1]
         )

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -7,9 +7,9 @@ import busio
 import gc
 
 from kmk import led, rgb
+from kmk.ble import BLEHID
 from kmk.consts import KMK_RELEASE, LeaderMode, UnicodeMode
 from kmk.hid import USBHID, AbstractHID, HIDModes
-from kmk.ble import BLEHID
 from kmk.internal_state import InternalState
 from kmk.keys import KC
 from kmk.kmktime import sleep_ms

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -8,7 +8,8 @@ import gc
 
 from kmk import led, rgb
 from kmk.consts import KMK_RELEASE, LeaderMode, UnicodeMode
-from kmk.hid import BLEHID, USBHID, AbstractHID, HIDModes
+from kmk.hid import USBHID, AbstractHID, HIDModes
+from kmk.ble import BLEHID
 from kmk.internal_state import InternalState
 from kmk.keys import KC
 from kmk.kmktime import sleep_ms


### PR DESCRIPTION
I've implemented basic BLE functionality. Before merging it should be considered that to get it to run on a Adafruit Feather nRF52840 Express I had to increase `upervisor.set_next_stack_limit(4096 + 1024)` in `boot.py` to 4096 + 4096 and compile everything to mpy files. So at least on that hardware memory limits seem to be pretty tight