### PR TITLE
MCP23017 support & lab68 user keymap

### DIFF
--- a/kmk/matrix.py
+++ b/kmk/matrix.py
@@ -46,12 +46,32 @@ class MatrixScanner:
         # https://github.com/adafruit/Adafruit_CircuitPython_MCP230xx/blob/3f04abbd65ba5fa938fcb04b99e92ae48a8c9406/adafruit_mcp230xx/digital_inout.py#L33
 
         if self.diode_orientation == DiodeOrientation.COLUMNS:
-            self.outputs = [x if x.__class__.__name__ is "DigitalInOut" else digitalio.DigitalInOut(x) for x in cols]
-            self.inputs = [x if x.__class__.__name__ is "DigitalInOut" else digitalio.DigitalInOut(x) for x in rows]
+            self.outputs = [
+                x
+                if x.__class__.__name__ is 'DigitalInOut'
+                else digitalio.DigitalInOut(x)
+                for x in cols
+            ]
+            self.inputs = [
+                x
+                if x.__class__.__name__ is 'DigitalInOut'
+                else digitalio.DigitalInOut(x)
+                for x in rows
+            ]
             self.translate_coords = True
         elif self.diode_orientation == DiodeOrientation.ROWS:
-            self.outputs = [x if x.__class__.__name__ is "DigitalInOut" else digitalio.DigitalInOut(x) for x in rows]
-            self.inputs = [x if x.__class__.__name__ is "DigitalInOut" else digitalio.DigitalInOut(x) for x in cols]
+            self.outputs = [
+                x
+                if x.__class__.__name__ is 'DigitalInOut'
+                else digitalio.DigitalInOut(x)
+                for x in rows
+            ]
+            self.inputs = [
+                x
+                if x.__class__.__name__ is 'DigitalInOut'
+                else digitalio.DigitalInOut(x)
+                for x in cols
+            ]
             self.translate_coords = False
         else:
             raise ValueError(

--- a/kmk/matrix.py
+++ b/kmk/matrix.py
@@ -41,13 +41,17 @@ class MatrixScanner:
 
         self.diode_orientation = diode_orientation
 
+        # __class__.__name__ is used instead of isinstance as the MCP230xx lib
+        # does not use the digitalio.DigitalInOut, but rather a self defined one:
+        # https://github.com/adafruit/Adafruit_CircuitPython_MCP230xx/blob/3f04abbd65ba5fa938fcb04b99e92ae48a8c9406/adafruit_mcp230xx/digital_inout.py#L33
+
         if self.diode_orientation == DiodeOrientation.COLUMNS:
-            self.outputs = [digitalio.DigitalInOut(x) for x in cols]
-            self.inputs = [digitalio.DigitalInOut(x) for x in rows]
+            self.outputs = [x if x.__class__.__name__ is "DigitalInOut" else digitalio.DigitalInOut(x) for x in cols]
+            self.inputs = [x if x.__class__.__name__ is "DigitalInOut" else digitalio.DigitalInOut(x) for x in rows]
             self.translate_coords = True
         elif self.diode_orientation == DiodeOrientation.ROWS:
-            self.outputs = [digitalio.DigitalInOut(x) for x in rows]
-            self.inputs = [digitalio.DigitalInOut(x) for x in cols]
+            self.outputs = [x if x.__class__.__name__ is "DigitalInOut" else digitalio.DigitalInOut(x) for x in rows]
+            self.inputs = [x if x.__class__.__name__ is "DigitalInOut" else digitalio.DigitalInOut(x) for x in cols]
             self.translate_coords = False
         else:
             raise ValueError(

--- a/user_keymaps/dzervas/lab68.py
+++ b/user_keymaps/dzervas/lab68.py
@@ -1,12 +1,30 @@
-from kmk.boards.converter.keebio.nyquist_r2 import KMKKeyboard
-from kmk.keys import KC
+import board
+import busio
 
+from digitalio import DigitalInOut, Direction, Pull
+from adafruit_mcp230xx.mcp23017 import MCP23017
+
+from kmk.kmk_keyboard import KMKKeyboard
+from kmk.keys import KC
+from kmk.matrix import DiodeOrientation
+
+
+# DEBUG_ENABLE = True
+
+i2c = busio.I2C(scl=board.SCL, sda=board.SDA, frequency=100000)
+mcp = MCP23017(i2c, address=0x20)
 keyboard = KMKKeyboard()
 
 _______ = KC.TRNS
 XXXXXXX = KC.NO
 
 FN = KC.MO(1)
+
+keyboard.debug_enabled = True
+
+keyboard.col_pins = (mcp.get_pin(0), mcp.get_pin(1), mcp.get_pin(2), mcp.get_pin(3), mcp.get_pin(4), mcp.get_pin(5), mcp.get_pin(5), mcp.get_pin(6), mcp.get_pin(7), mcp.get_pin(8), mcp.get_pin(9), mcp.get_pin(10), mcp.get_pin(11), mcp.get_pin(12), mcp.get_pin(13), mcp.get_pin(14))
+keyboard.row_pins = (board.D7, board.D6, board.D5, board.D3, board.D2)
+keyboard.diode_orientation = DiodeOrientation.COLUMNS
 
 keyboard.keymap = [
     # Qwerty
@@ -26,7 +44,7 @@ keyboard.keymap = [
         KC.TAB,  KC.Q,    KC.W,    KC.E,    KC.R,      KC.T,    KC.Y,    KC.U,    KC.I,    KC.O,    KC.P,    KC.LBRC, KC.RBRC,  KC.BSLASH, KC.PGUP,
         KC.ESC,  KC.A,    KC.S,    KC.D,    KC.F,      KC.G,    KC.H,    KC.J,    KC.K,    KC.L,    KC.SCLN, KC.QUOT, XXXXXXX,  KC.ENTER,  KC.PGDN,
         KC.LSFT, KC.Z,    KC.X,    KC.C,    KC.V,      KC.B,    KC.N,    KC.M,    KC.COMM, KC.DOT,  KC.SLSH, KC.RSFT, XXXXXXX,  KC.UP,     KC.INS,
-        KC.LCTL, KC.LGUI, KC.LALT, XXXXXXX, XXXXXXX,   KC.SPC,  XXXXXXX, XXXXXXX, FN,      KC.ALT,  KC.RCTL, KC.LEFT, XXXXXXX,  KC.DOWN,   KC.RIGHT,
+        KC.LCTL, KC.LGUI, KC.LALT, XXXXXXX, XXXXXXX,   KC.SPC,  XXXXXXX, XXXXXXX, FN,      KC.RALT, KC.RCTL, KC.LEFT, XXXXXXX,  KC.DOWN,   KC.RIGHT,
     ],
 
 
@@ -48,7 +66,7 @@ keyboard.keymap = [
         KC.TAB,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, KC.PSCR, XXXXXXX, KC.PAUSE, _______, XXXXXXX, _______,
         KC.ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, _______,
         KC.LSFT, XXXXXXX, KC.MPLY, KC.MSTP, KC.MPRV,  KC.MNXT, KC.VOLD, KC.VOLU, KC.MUTE, XXXXXXX, XXXXXXX, KC.RSFT,  XXXXXXX, _______, XXXXXXX,
-        KC.LCTL, KC.LGUI, KC.LALT, XXXXXXX, XXXXXXX,  KC.SPC,  XXXXXXX, XXXXXXX, FN,      KC.ALT,  KC.RCTL, _______,  XXXXXXX, _______, _______,
+        KC.LCTL, KC.LGUI, KC.LALT, XXXXXXX, XXXXXXX,  KC.SPC,  XXXXXXX, XXXXXXX, FN,      KC.RALT, KC.RCTL, _______,  XXXXXXX, _______, _______,
     ],
 ]
 

--- a/user_keymaps/dzervas/lab68.py
+++ b/user_keymaps/dzervas/lab68.py
@@ -1,13 +1,12 @@
 import board
 import busio
-
 from digitalio import DigitalInOut, Direction, Pull
+
 from adafruit_mcp230xx.mcp23017 import MCP23017
-
-from kmk.kmk_keyboard import KMKKeyboard
+from kmk.hid import HIDModes
 from kmk.keys import KC
+from kmk.kmk_keyboard import KMKKeyboard
 from kmk.matrix import DiodeOrientation
-
 
 # DEBUG_ENABLE = True
 
@@ -71,4 +70,4 @@ keyboard.keymap = [
 ]
 
 if __name__ == '__main__':
-    keyboard.go()
+    keyboard.go(hid_type=HIDModes.BLE)

--- a/user_keymaps/dzervas/lab68.py
+++ b/user_keymaps/dzervas/lab68.py
@@ -1,0 +1,56 @@
+from kmk.boards.converter.keebio.nyquist_r2 import KMKKeyboard
+from kmk.keys import KC
+
+keyboard = KMKKeyboard()
+
+_______ = KC.TRNS
+XXXXXXX = KC.NO
+
+FN = KC.MO(1)
+
+keyboard.keymap = [
+    # Qwerty
+    # ,--------------------------------------------------------------------------------------------------------.
+    # |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  |   -  |   =  | Bksp | Del  |
+    # |------+------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+    # | Tab  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  |   [  |   ]  |   \  | PgUp |
+    # |------+------+------+------+------+-------------+------+------+------+------+------+------+------+------|
+    # | Esc  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |   '  |      |Enter | PgDn |
+    # |------+------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+    # | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |Shift |      |  Up  | Ins  |
+    # |------+------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+    # | Ctrl | GUI |  Alt  |      |      |Space |      |      |  Fn  | Alt  | Ctrl | Left |      | Down | Right|
+    # `------------------------------------------------------------------------------------------+------+------'
+    [
+        KC.GRV,  KC.N1,   KC.N2,   KC.N3,   KC.N4,     KC.N5,   KC.N6,   KC.N7,   KC.N8,   KC.N9,   KC.N0,   KC.MINS, KC.EQUAL, KC.BSPC,   KC.DEL,
+        KC.TAB,  KC.Q,    KC.W,    KC.E,    KC.R,      KC.T,    KC.Y,    KC.U,    KC.I,    KC.O,    KC.P,    KC.LBRC, KC.RBRC,  KC.BSLASH, KC.PGUP,
+        KC.ESC,  KC.A,    KC.S,    KC.D,    KC.F,      KC.G,    KC.H,    KC.J,    KC.K,    KC.L,    KC.SCLN, KC.QUOT, XXXXXXX,  KC.ENTER,  KC.PGDN,
+        KC.LSFT, KC.Z,    KC.X,    KC.C,    KC.V,      KC.B,    KC.N,    KC.M,    KC.COMM, KC.DOT,  KC.SLSH, KC.RSFT, XXXXXXX,  KC.UP,     KC.INS,
+        KC.LCTL, KC.LGUI, KC.LALT, XXXXXXX, XXXXXXX,   KC.SPC,  XXXXXXX, XXXXXXX, FN,      KC.ALT,  KC.RCTL, KC.LEFT, XXXXXXX,  KC.DOWN,   KC.RIGHT,
+    ],
+
+
+    # Functions
+    # ,--------------------------------------------------------------------------------------------------------.
+    # |      |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |      | CLR* |
+    # |------+------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+    # | Tab  |      |      |      |      |      |      |      |      |Print |      |Pause | Calc |      | BrUp |
+    # |------+------+------+------+------+-------------+------+------+------+------+------+------+------+------|
+    # | Esc  |      |      |      |      |      |      |      |      |      |      |      |      |      | BrDn |
+    # |------+------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+    # | Shift|      | Play | Stop | Prev | Next | VolDn| VolUp| Mute |      |      |Shift |      |LedUp |      |
+    # |------+------+------+------+------+------+------+------+------+------+------+------+------+------+------|
+    # | Ctrl | GUI |  Alt  |      |      |Space |      |      |  Fn  | Alt  | Ctrl | BTPrv|      |LedDn | BTNxt|
+    # `------------------------------------------------------------------------------------------+------+------'
+    # CLR: Clear bonds
+    [
+        XXXXXXX, KC.F1,   KC.F2,   KC.F3,   KC.F4,    KC.F5,   KC.F6,   KC.F7,   KC.F8,   KC.F9,   KC.F10,  KC.F11,   KC.F12,  XXXXXXX, _______,
+        KC.TAB,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, KC.PSCR, XXXXXXX, KC.PAUSE, _______, XXXXXXX, _______,
+        KC.ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, _______,
+        KC.LSFT, XXXXXXX, KC.MPLY, KC.MSTP, KC.MPRV,  KC.MNXT, KC.VOLD, KC.VOLU, KC.MUTE, XXXXXXX, XXXXXXX, KC.RSFT,  XXXXXXX, _______, XXXXXXX,
+        KC.LCTL, KC.LGUI, KC.LALT, XXXXXXX, XXXXXXX,  KC.SPC,  XXXXXXX, XXXXXXX, FN,      KC.ALT,  KC.RCTL, _______,  XXXXXXX, _______, _______,
+    ],
+]
+
+if __name__ == '__main__':
+    keyboard.go()


### PR DESCRIPTION
There is some `matrix` hackery to be able to pass a `DigitalInOut` instead of a pin to columns/rows. This is required as MCP23017 (IO expander) does not expose the `Pin`s.

Also I added my keymap for lab68 - the keyboard that I'm making: https://github.com/dzervas/lab68