### PR TITLE
[BLE] Add support to change BLE name from KMKKeyboard.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ mnt2/
 kmk/release_info.py
 kmk/release_info.mpy
 *.mpy
+.vscode

--- a/kmk/ble.py
+++ b/kmk/ble.py
@@ -14,19 +14,20 @@ BLE_APPEARANCE_HID_KEYBOARD = 961
 
 
 class BLEHID(AbstractHID):
-    def post_init(self):
+    def post_init(self, ble_name='KMK Keyboard', **kwargs):
         self.devices = {}
 
         hid = HIDService()
 
         advertisement = ProvideServicesAdvertisement(hid)
         advertisement.appearance = BLE_APPEARANCE_HID_KEYBOARD
-        scan_response = Advertisement()
-        scan_response.complete_name = 'KMK Keyboard'
 
         ble = BLERadio()
+        ble.name = ble_name
+        # ble.tx_power = 2
+
         if not ble.connected:
-            ble.start_advertising(advertisement, scan_response)
+            ble.start_advertising(advertisement)
             while not ble.connected:
                 pass
 

--- a/kmk/hid.py
+++ b/kmk/hid.py
@@ -41,7 +41,7 @@ HID_REPORT_SIZES = {
 class AbstractHID:
     REPORT_BYTES = 8
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         self._evt = bytearray(self.REPORT_BYTES)
         self.report_device = memoryview(self._evt)[0:1]
         self.report_device[0] = HIDReportTypes.KEYBOARD
@@ -55,7 +55,7 @@ class AbstractHID:
         self.report_mods = memoryview(self._evt)[1:2]
         self.report_non_mods = memoryview(self._evt)[3:]
 
-        self.post_init()
+        self.post_init(**kwargs)
 
     def __repr__(self):
         return '{}(REPORT_BYTES={})'.format(self.__class__.__name__, self.REPORT_BYTES)
@@ -191,7 +191,7 @@ class AbstractHID:
 class USBHID(AbstractHID):
     REPORT_BYTES = 9
 
-    def post_init(self):
+    def post_init(self, **kwargs):
         self.devices = {}
 
         for device in usb_hid.devices:

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -191,7 +191,7 @@ class KMKKeyboard:
         else:
             return busio.UART(tx=pin, rx=None, timeout=timeout)
 
-    def go(self, hid_type=HIDModes.USB):
+    def go(self, hid_type=HIDModes.USB, **kwargs):
         assert self.keymap, 'must define a keymap with at least one row'
         assert self.row_pins, 'no GPIO pins defined for matrix rows'
         assert self.col_pins, 'no GPIO pins defined for matrix columns'
@@ -225,7 +225,7 @@ class KMKKeyboard:
         elif hid_type == HIDModes.BLE:
             self.hid_helper = BLEHID
 
-        self._hid_helper_inst = self.hid_helper()
+        self._hid_helper_inst = self.hid_helper(**kwargs)
 
         # Split keyboard Init
         if self.split_type is not None:

--- a/user_keymaps/dzervas/lab68.py
+++ b/user_keymaps/dzervas/lab68.py
@@ -70,4 +70,4 @@ keyboard.keymap = [
 ]
 
 if __name__ == '__main__':
-    keyboard.go(hid_type=HIDModes.BLE)
+    keyboard.go(hid_type=HIDModes.BLE, ble_name='Lab68')


### PR DESCRIPTION
The following can be used to change advertising BLE name:

```python
    keyboard.go(hid_type=HIDModes.BLE, ble_name='Lab68')
```

Also I'm passing keyword arguments from `KMKKeyboard.go` to `KMKKeyboard.hid_helper()` to allow for various possible configurations later on (USB pid/vid, bluetooth stuff, etc.)