### PR TITLE
Introduce rotary encoder

### DIFF
--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -23,7 +23,7 @@ class KMKKeyboard:
 
     row_pins = None
     col_pins = None
-    rotaries = None
+    rotaries = []
     diode_orientation = None
     matrix_scanner = MatrixScanner
     uart_buffer = []
@@ -191,7 +191,7 @@ class KMKKeyboard:
             self.coord_mapping = []
 
             rows_to_calc = len(self.row_pins)
-            cols_to_calc = len(self.col_pins)
+            cols_to_calc = len(self.col_pins) + len(self.rotaries)
 
             if self.split_offsets:
                 rows_to_calc *= 2

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -23,6 +23,7 @@ class KMKKeyboard:
 
     row_pins = None
     col_pins = None
+    rotaries = None
     diode_orientation = None
     matrix_scanner = MatrixScanner
     uart_buffer = []
@@ -70,6 +71,7 @@ class KMKKeyboard:
             'leader_timeout={} '
             'hid_helper={} '
             'extra_data_pin={} '
+            'rotaries={} '
             'split_offsets={} '
             'split_flip={} '
             'target_side={} '
@@ -95,6 +97,7 @@ class KMKKeyboard:
             self.leader_timeout,
             self.hid_helper.__name__,
             self.extra_data_pin,
+            self.rotaries,
             self.split_offsets,
             self.split_flip,
             self.target_side,
@@ -264,6 +267,7 @@ class KMKKeyboard:
             rows=self.row_pins,
             diode_orientation=self.diode_orientation,
             rollover_cols_every_rows=getattr(self, 'rollover_cols_every_rows', None),
+            rotaries=self.rotaries,
         )
 
         # Compile string leader sequences

--- a/kmk/matrix.py
+++ b/kmk/matrix.py
@@ -32,8 +32,7 @@ class MatrixScanner:
         # When the encoder is incremented column n from the last column and row
         # 1 is pressed and when decremented row 2 - n is the index of the encoder.
         if rotaries:
-            if self.len_rows < 2:
-                raise ValueError('There are less than 2 rows but there are rotary encoders, which need 2 or more rows')
+            assert self.len_rows > 2, 'There are less than 2 rows but there are rotary encoders, which need 2 or more rows'
 
             self.len_cols += len(rotaries)
 
@@ -43,7 +42,7 @@ class MatrixScanner:
         # repr() hackery is because CircuitPython Pin objects are not hashable
         unique_pins = {repr(c) for c in cols} | {repr(r) for r in rows}
         assert (
-            len(unique_pins) == self.len_cols + self.len_rows
+            len(unique_pins) + len(rotaries) == self.len_cols + self.len_rows
         ), 'Cannot use a pin as both a column and row'
         del unique_pins
 
@@ -92,7 +91,7 @@ class MatrixScanner:
         for pin in self.inputs:
             pin.switch_to_input(pull=digitalio.Pull.DOWN)
 
-        self.rotaries = { x: x.position for x in rotaries }
+        self.rotaries = [ {'obj': x, 'lastpos': x.position, 'state': 0} for x in rotaries ]
 
         self.rollover_cols_every_rows = rollover_cols_every_rows
         if self.rollover_cols_every_rows is None:
@@ -155,13 +154,39 @@ class MatrixScanner:
 
             opin.value = False
             if any_changed:
-                break
+                return self.report
 
-        for r, lastpos in self.rotaries:
-            if r.position == lastpos:
+        if not self.rotaries:
+            return
+
+        index = -1
+        for encoder in self.rotaries:
+            index += 1
+            newpos = encoder['obj'].position
+
+            if (newpos == encoder['lastpos'] and encoder['state'] == 0) or \
+                (newpos > encoder['lastpos'] and encoder['state'] > 0) or \
+                (newpos < encoder['lastpos'] and encoder['state'] < 0):
+                encoder['lastpos'] = newpos
                 continue
 
-            any_changed = True
+            self.report[1] = self.len_cols - index - 1
 
-        if any_changed:
+            if newpos == encoder['lastpos']:
+                self.report[0] = 0 if encoder['state'] > 0 else 1
+                self.report[2] = False
+
+                encoder['state'] = 0
+            elif newpos > encoder['lastpos']:
+                self.report[0] = 0
+                self.report[2] = True
+
+                encoder['state'] = 1
+            elif newpos < encoder['lastpos']:
+                self.report[0] = 1
+                self.report[2] = True
+
+                encoder['state'] = -1
+
+            encoder['lastpos'] = newpos
             return self.report

--- a/kmk/matrix.py
+++ b/kmk/matrix.py
@@ -124,17 +124,12 @@ class MatrixScanner:
             # known position - so that multiple steps can be evaluated at a time
             newpos = encoder['obj'].position
 
-            if (
-                (newpos == encoder['lastpos'] and encoder['state'] == 0)
-                or (newpos > encoder['lastpos'] and encoder['state'] > 0)
-                or (newpos < encoder['lastpos'] and encoder['state'] < 0)
-            ):
-                encoder['lastpos'] += encoder['state']
+            if newpos == encoder['lastpos'] and encoder['state'] == 0:
                 continue
 
             self.report[1] = self.len_cols - index - 1
 
-            if newpos == encoder['lastpos']:
+            if newpos == encoder['lastpos'] or (newpos != encoder['lastpos'] and encoder['state'] != 0):
                 self.report[0] = 0 if encoder['state'] > 0 else 1
                 self.report[2] = False
                 encoder['state'] = 0
@@ -207,5 +202,6 @@ class MatrixScanner:
                 ba_idx += 1
 
             opin.value = False
+            # print("[scan_for_changes][matrix][total]", monotonic() - starttime)
             if any_changed:
                 return self.report

--- a/kmk/matrix.py
+++ b/kmk/matrix.py
@@ -127,7 +127,7 @@ class MatrixScanner:
             if newpos == encoder['lastpos'] and encoder['state'] == 0:
                 continue
 
-            self.report[1] = self.len_cols - index - 1
+            self.report[1] = self.len_cols - (len(self.rotaries) - index)
 
             if newpos == encoder['lastpos'] or (newpos != encoder['lastpos'] and encoder['state'] != 0):
                 self.report[0] = 0 if encoder['state'] > 0 else 1

--- a/user_keymaps/dzervas/lab68.py
+++ b/user_keymaps/dzervas/lab68.py
@@ -11,7 +11,7 @@ from kmk.matrix import DiodeOrientation
 
 # DEBUG_ENABLE = True
 
-i2c = busio.I2C(scl=board.SCL, sda=board.SDA, frequency=100000)
+i2c = busio.I2C(scl=board.SCL, sda=board.SDA, frequency=1700000)
 mcp = MCP23017(i2c, address=0x20)
 keyboard = KMKKeyboard()
 

--- a/user_keymaps/dzervas/lab68.py
+++ b/user_keymaps/dzervas/lab68.py
@@ -1,6 +1,7 @@
 import board
 import busio
 from digitalio import DigitalInOut, Direction, Pull
+from rotaryio import IncrementalEncoder
 
 from adafruit_mcp230xx.mcp23017 import MCP23017
 from kmk.hid import HIDModes
@@ -24,13 +25,14 @@ keyboard.debug_enabled = True
 keyboard.col_pins = (mcp.get_pin(8), mcp.get_pin(9), mcp.get_pin(10), mcp.get_pin(11), mcp.get_pin(12), mcp.get_pin(13), mcp.get_pin(14), mcp.get_pin(15), mcp.get_pin(4), mcp.get_pin(5), mcp.get_pin(6), mcp.get_pin(7), mcp.get_pin(3), mcp.get_pin(2), mcp.get_pin(1))
 keyboard.row_pins = (board.D7, board.D6, board.D5, board.D3, board.D2)
 keyboard.diode_orientation = DiodeOrientation.COLUMNS
+keyboard.rotaries = [IncrementalEncoder(board.A4, board.A5)]
 
 keyboard.keymap = [
     # Qwerty
     # ,--------------------------------------------------------------------------------------------------------.
-    # |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  |   -  |   =  | Bksp | Del  |
+    # |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  |   -  |   =  | Bksp | Del  | VolUp
     # |------+------+------+------+------+------+------+------+------+------+------+------+------+------+------|
-    # | Tab  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  |   [  |   ]  |   \  | PgUp |
+    # | Tab  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  |   [  |   ]  |   \  | PgUp | VolDn
     # |------+------+------+------+------+-------------+------+------+------+------+------+------+------+------|
     # | Esc  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |   '  |      |Enter | PgDn |
     # |------+------+------+------+------+------+------+------+------+------+------+------+------+------+------|
@@ -39,11 +41,11 @@ keyboard.keymap = [
     # | Ctrl | GUI |  Alt  |      |      |Space |      |      |  Fn  | Alt  | Ctrl | Left |      | Down | Right|
     # `------------------------------------------------------------------------------------------+------+------'
     [
-        KC.GRV,  KC.N1,   KC.N2,   KC.N3,   KC.N4,     KC.N5,   KC.N6,   KC.N7,   KC.N8,   KC.N9,   KC.N0,   KC.MINS, KC.EQUAL, KC.BSPC,   KC.DEL,
-        KC.TAB,  KC.Q,    KC.W,    KC.E,    KC.R,      KC.T,    KC.Y,    KC.U,    KC.I,    KC.O,    KC.P,    KC.LBRC, KC.RBRC,  KC.BSLASH, KC.PGUP,
-        KC.ESC,  KC.A,    KC.S,    KC.D,    KC.F,      KC.G,    KC.H,    KC.J,    KC.K,    KC.L,    KC.SCLN, KC.QUOT, XXXXXXX,  KC.ENTER,  KC.PGDN,
-        KC.LSFT, KC.Z,    KC.X,    KC.C,    KC.V,      KC.B,    KC.N,    KC.M,    KC.COMM, KC.DOT,  KC.SLSH, KC.RSFT, XXXXXXX,  KC.UP,     KC.INS,
-        KC.LCTL, KC.LGUI, KC.LALT, XXXXXXX, XXXXXXX,   KC.SPC,  XXXXXXX, XXXXXXX, FN,      KC.RALT, KC.RCTL, KC.LEFT, XXXXXXX,  KC.DOWN,   KC.RIGHT,
+        KC.GRV,  KC.N1,   KC.N2,   KC.N3,   KC.N4,     KC.N5,   KC.N6,   KC.N7,   KC.N8,   KC.N9,   KC.N0,   KC.MINS, KC.EQUAL, KC.BSPC,   KC.DEL,   KC.VOLU,
+        KC.TAB,  KC.Q,    KC.W,    KC.E,    KC.R,      KC.T,    KC.Y,    KC.U,    KC.I,    KC.O,    KC.P,    KC.LBRC, KC.RBRC,  KC.BSLASH, KC.PGUP,  KC.VOLD,
+        KC.ESC,  KC.A,    KC.S,    KC.D,    KC.F,      KC.G,    KC.H,    KC.J,    KC.K,    KC.L,    KC.SCLN, KC.QUOT, XXXXXXX,  KC.ENTER,  KC.PGDN,  XXXXXXX,
+        KC.LSFT, KC.Z,    KC.X,    KC.C,    KC.V,      KC.B,    KC.N,    KC.M,    KC.COMM, KC.DOT,  KC.SLSH, KC.RSFT, XXXXXXX,  KC.UP,     KC.INS,   XXXXXXX,
+        KC.LCTL, KC.LGUI, KC.LALT, XXXXXXX, XXXXXXX,   KC.SPC,  XXXXXXX, XXXXXXX, FN,      KC.RALT, KC.RCTL, KC.LEFT, XXXXXXX,  KC.DOWN,   KC.RIGHT, XXXXXXX,
     ],
 
 
@@ -61,14 +63,14 @@ keyboard.keymap = [
     # `------------------------------------------------------------------------------------------+------+------'
     # CLR: Clear bonds
     [
-        XXXXXXX, KC.F1,   KC.F2,   KC.F3,   KC.F4,    KC.F5,   KC.F6,   KC.F7,   KC.F8,   KC.F9,   KC.F10,  KC.F11,    KC.F12,  XXXXXXX, KC.BT_CLR,
-        KC.TAB,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, KC.PSCR, XXXXXXX, KC.PAUSE,  _______, XXXXXXX, _______,
-        KC.ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,   XXXXXXX, XXXXXXX, _______,
-        KC.LSFT, XXXXXXX, KC.MPLY, KC.MSTP, KC.MPRV,  KC.MNXT, KC.VOLD, KC.VOLU, KC.MUTE, XXXXXXX, XXXXXXX, KC.RSFT,   XXXXXXX, _______, XXXXXXX,
-        KC.LCTL, KC.LGUI, KC.LALT, XXXXXXX, XXXXXXX,  KC.SPC,  XXXXXXX, XXXXXXX, FN,      KC.RALT, KC.RCTL, KC.BT_PRV, XXXXXXX, _______, KC.BT_NXT,
+        XXXXXXX, KC.F1,   KC.F2,   KC.F3,   KC.F4,    KC.F5,   KC.F6,   KC.F7,   KC.F8,   KC.F9,   KC.F10,  KC.F11,    KC.F12,  XXXXXXX, KC.BT_CLR, XXXXXXX,
+        KC.TAB,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, KC.PSCR, XXXXXXX, KC.PAUSE,  _______, XXXXXXX, _______,   XXXXXXX,
+        KC.ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,   XXXXXXX, XXXXXXX, _______,   XXXXXXX,
+        KC.LSFT, XXXXXXX, KC.MPLY, KC.MSTP, KC.MPRV,  KC.MNXT, KC.VOLD, KC.VOLU, KC.MUTE, XXXXXXX, XXXXXXX, KC.RSFT,   XXXXXXX, _______, XXXXXXX,   XXXXXXX,
+        KC.LCTL, KC.LGUI, KC.LALT, XXXXXXX, XXXXXXX,  KC.SPC,  XXXXXXX, XXXXXXX, FN,      KC.RALT, KC.RCTL, XXXXXXX,   XXXXXXX, _______, XXXXXXX,   XXXXXXX,
     ],
 ]
 
 if __name__ == '__main__':
-    keyboard.go(hid_type=HIDModes.BLE, ble_name='Lab68')
-    # keyboard.go(hid_type=HIDModes.USB)
+    # keyboard.go(hid_type=HIDModes.BLE, ble_name='Lab68')
+    keyboard.go(hid_type=HIDModes.USB)

--- a/user_keymaps/dzervas/lab68.py
+++ b/user_keymaps/dzervas/lab68.py
@@ -41,8 +41,8 @@ keyboard.keymap = [
     # | Ctrl | GUI |  Alt  |      |      |Space |      |      |  Fn  | Alt  | Ctrl | Left |      | Down | Right|
     # `------------------------------------------------------------------------------------------+------+------'
     [
-        KC.GRV,  KC.N1,   KC.N2,   KC.N3,   KC.N4,     KC.N5,   KC.N6,   KC.N7,   KC.N8,   KC.N9,   KC.N0,   KC.MINS, KC.EQUAL, KC.BSPC,   KC.DEL,   KC.VOLU,
-        KC.TAB,  KC.Q,    KC.W,    KC.E,    KC.R,      KC.T,    KC.Y,    KC.U,    KC.I,    KC.O,    KC.P,    KC.LBRC, KC.RBRC,  KC.BSLASH, KC.PGUP,  KC.VOLD,
+        KC.GRV,  KC.N1,   KC.N2,   KC.N3,   KC.N4,     KC.N5,   KC.N6,   KC.N7,   KC.N8,   KC.N9,   KC.N0,   KC.MINS, KC.EQUAL, KC.BSPC,   KC.DEL,   KC.RIGHT,
+        KC.TAB,  KC.Q,    KC.W,    KC.E,    KC.R,      KC.T,    KC.Y,    KC.U,    KC.I,    KC.O,    KC.P,    KC.LBRC, KC.RBRC,  KC.BSLASH, KC.PGUP,  KC.LEFT,
         KC.ESC,  KC.A,    KC.S,    KC.D,    KC.F,      KC.G,    KC.H,    KC.J,    KC.K,    KC.L,    KC.SCLN, KC.QUOT, XXXXXXX,  KC.ENTER,  KC.PGDN,  XXXXXXX,
         KC.LSFT, KC.Z,    KC.X,    KC.C,    KC.V,      KC.B,    KC.N,    KC.M,    KC.COMM, KC.DOT,  KC.SLSH, KC.RSFT, XXXXXXX,  KC.UP,     KC.INS,   XXXXXXX,
         KC.LCTL, KC.LGUI, KC.LALT, XXXXXXX, XXXXXXX,   KC.SPC,  XXXXXXX, XXXXXXX, FN,      KC.RALT, KC.RCTL, KC.LEFT, XXXXXXX,  KC.DOWN,   KC.RIGHT, XXXXXXX,
@@ -63,9 +63,9 @@ keyboard.keymap = [
     # `------------------------------------------------------------------------------------------+------+------'
     # CLR: Clear bonds
     [
-        XXXXXXX, KC.F1,   KC.F2,   KC.F3,   KC.F4,    KC.F5,   KC.F6,   KC.F7,   KC.F8,   KC.F9,   KC.F10,  KC.F11,    KC.F12,  XXXXXXX, KC.BT_CLR, XXXXXXX,
-        KC.TAB,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, KC.PSCR, XXXXXXX, KC.PAUSE,  _______, XXXXXXX, _______,   XXXXXXX,
-        KC.ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,   XXXXXXX, XXXXXXX, _______,   XXXXXXX,
+        KC.TAB,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, KC.PSCR, XXXXXXX, KC.PAUSE,  _______, XXXXXXX, KC.HOME,   KC.VOLD,
+        XXXXXXX, KC.F1,   KC.F2,   KC.F3,   KC.F4,    KC.F5,   KC.F6,   KC.F7,   KC.F8,   KC.F9,   KC.F10,  KC.F11,    KC.F12,  XXXXXXX, KC.BT_CLR, KC.VOLU,
+        KC.ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,   XXXXXXX, XXXXXXX, KC.END,    XXXXXXX,
         KC.LSFT, XXXXXXX, KC.MPLY, KC.MSTP, KC.MPRV,  KC.MNXT, KC.VOLD, KC.VOLU, KC.MUTE, XXXXXXX, XXXXXXX, KC.RSFT,   XXXXXXX, _______, XXXXXXX,   XXXXXXX,
         KC.LCTL, KC.LGUI, KC.LALT, XXXXXXX, XXXXXXX,  KC.SPC,  XXXXXXX, XXXXXXX, FN,      KC.RALT, KC.RCTL, XXXXXXX,   XXXXXXX, _______, XXXXXXX,   XXXXXXX,
     ],

--- a/user_keymaps/dzervas/lab68.py
+++ b/user_keymaps/dzervas/lab68.py
@@ -20,9 +20,9 @@ XXXXXXX = KC.NO
 
 FN = KC.MO(1)
 
-keyboard.debug_enabled = True
+# keyboard.debug_enabled = True
 
-keyboard.col_pins = (mcp.get_pin(8), mcp.get_pin(9), mcp.get_pin(10), mcp.get_pin(11), mcp.get_pin(12), mcp.get_pin(13), mcp.get_pin(14), mcp.get_pin(15), mcp.get_pin(4), mcp.get_pin(5), mcp.get_pin(6), mcp.get_pin(7), mcp.get_pin(3), mcp.get_pin(2), mcp.get_pin(1))
+keyboard.col_pins = (mcp.get_pin(8), mcp.get_pin(9), mcp.get_pin(10), mcp.get_pin(11), mcp.get_pin(12), mcp.get_pin(13), mcp.get_pin(14), mcp.get_pin(15), mcp.get_pin(4), mcp.get_pin(5), mcp.get_pin(6), mcp.get_pin(7), mcp.get_pin(3), mcp.get_pin(2), mcp.get_pin(1), )
 keyboard.row_pins = (board.D7, board.D6, board.D5, board.D3, board.D2)
 keyboard.diode_orientation = DiodeOrientation.COLUMNS
 keyboard.rotaries = [IncrementalEncoder(board.A4, board.A5)]


### PR DESCRIPTION
Closes #79.

The way I introduced the new encoder is a bit bizarre, but the overhead is almost nothing and can be used on different layers, etc.

To add an encoder (more than one are supported), `keyboard.rotaries` should be populated with the `rotaryio.IncrementalEncoder` objects (array), like so:

```py
from rotaryio import IncrementalEncoder
keyboard.rotaries = [IncrementalEncoder(board.A4, board.A5)]
```

It may not be the best in terms of user-friendlyness, but it's just two lines and easy enough.
Now to define which keys are pressed when the encoder is turned right or left, an additional column should be added to each layout (will be skipped during regular matrix scan) for each encoder. The first (top-most) row key is pressed when the wheel turns right (position is incremented) and the second (from the top) is pressed when the wheel turns left (position is decremented), like so:

```py
keyboard.keymap = [
    # Qwerty
    # ,--------------------------------------------------------------------------------------------------------.
    # |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  |   -  |   =  | Bksp | Del  | Right
    # |------+------+------+------+------+------+------+------+------+------+------+------+------+------+------|
    # | Tab  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  |   [  |   ]  |   \  | PgUp | Left
    # |------+------+------+------+------+-------------+------+------+------+------+------+------+------+------|
    # | Esc  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |   '  |      |Enter | PgDn |
    # |------+------+------+------+------+------+------+------+------+------+------+------+------+------+------|
    # | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |Shift |      |  Up  | Ins  |
    # |------+------+------+------+------+------+------+------+------+------+------+------+------+------+------|
    # | Ctrl | GUI |  Alt  |      |      |Space |      |      |  Fn  | Alt  | Ctrl | Left |      | Down | Right|
    # `------------------------------------------------------------------------------------------+------+------'
    [
        KC.GRV,  KC.N1,   KC.N2,   KC.N3,   KC.N4,     KC.N5,   KC.N6,   KC.N7,   KC.N8,   KC.N9,   KC.N0,   KC.MINS, KC.EQUAL, KC.BSPC,   KC.DEL,   KC.RIGHT,
        KC.TAB,  KC.Q,    KC.W,    KC.E,    KC.R,      KC.T,    KC.Y,    KC.U,    KC.I,    KC.O,    KC.P,    KC.LBRC, KC.RBRC,  KC.BSLASH, KC.PGUP,  KC.LEFT,
        KC.ESC,  KC.A,    KC.S,    KC.D,    KC.F,      KC.G,    KC.H,    KC.J,    KC.K,    KC.L,    KC.SCLN, KC.QUOT, XXXXXXX,  KC.ENTER,  KC.PGDN,  XXXXXXX,
        KC.LSFT, KC.Z,    KC.X,    KC.C,    KC.V,      KC.B,    KC.N,    KC.M,    KC.COMM, KC.DOT,  KC.SLSH, KC.RSFT, XXXXXXX,  KC.UP,     KC.INS,   XXXXXXX,
        KC.LCTL, KC.LGUI, KC.LALT, XXXXXXX, XXXXXXX,   KC.SPC,  XXXXXXX, XXXXXXX, FN,      KC.RALT, KC.RCTL, KC.LEFT, XXXXXXX,  KC.DOWN,   KC.RIGHT, XXXXXXX,
```

(Note the rightmost column. It's beyond my keyboards matrix. In the above example, when I rotate right, the right key is pressed and left when I rotate left. It's very convenient BTW...

On every step, the apparent key is pressed and then unpressed, so if you very quickly turn the wheel to the left 10 steps, the second key from the right-most column will be pressed AND unpressed 10 times - this of course introduces some lag on very fast turns, but not much, also no keypress is lost.

To add more encoders, just add more objects to `keyboard.rotaries` and more columns. In a 15 column keyboard, first rotary will use 16th column, 2nd rotary 17th, etc.

The performance impact is minimal (printed time taken to scan the rotaries and it's mostly less than a millisecond), though I'm a bit worried about the memory impact due to the way I wrote the implementation.