### PR TITLE
Add QMK equivalent attributes of DiodeOrientation

### DIFF
--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -33,7 +33,7 @@ keyboard = KMKKeyboard()
 
 keyboard.col_pins = (board.GP0,)
 keyboard.row_pins = (board.GP1,)
-keyboard.diode_orientation = DiodeOrientation.COLUMNS
+keyboard.diode_orientation = DiodeOrientation.COL2ROW
 
 keyboard.keymap = [
     [KC.A,]

--- a/docs/config_and_keymap.md
+++ b/docs/config_and_keymap.md
@@ -40,7 +40,7 @@ from kmk.matrix import DiodeOrientation
 col_pins = (board.SCK, board.MOSI, board.MISO, board.RX, board.TX, board.D4)
 row_pins = (board.D10, board.D11, board.D12, board.D13, board.D9, board.D6, board.D5, board.SCL)
 rollover_cols_every_rows = 4
-diode_orientation = DiodeOrientation.COLUMNS
+diode_orientation = DiodeOrientation.COL2ROW
 ```
 
 The pins should be based on whatever CircuitPython calls pins on your particular
@@ -52,7 +52,7 @@ print(dir(board))
 ```
 
 > Note: `rollover_cols_every_rows` is only supported with
-> `DiodeOrientation.COLUMNS`, not `DiodeOrientation.ROWS`. It is used for boards
+> `DiodeOrientation.COLUMNS`/`DiodeOrientation.COL2ROW`, not `DiodeOrientation.ROWS`/`DiodeOrientation.ROW2COL`. It is used for boards
 > such as the Planck Rev6 which reuse column pins to simulate a 4x12 matrix in
 > the form of an 8x6 matrix
 

--- a/docs/ja/Getting_Started.md
+++ b/docs/ja/Getting_Started.md
@@ -43,7 +43,7 @@ keyboard = KMKKeyboard()
 
 keyboard.col_pins = (board.GP0,)
 keyboard.row_pins = (board.GP1,)
-keyboard.diode_orientation = DiodeOrientation.COLUMNS
+keyboard.diode_orientation = DiodeOrientation.COL2ROW
 
 keyboard.keymap = [
     [KC.A,]

--- a/docs/porting_to_kmk.md
+++ b/docs/porting_to_kmk.md
@@ -20,7 +20,7 @@ colums and the diode direction (if any), should be defined like this
 ```python
     row_pins = [board.p0_31, board.p0_29, board.p0_02, board.p1_15]
     col_pins = [board.p0_22, board.p0_24, board.p1_00, board.p0_11, board.p1_04]
-    diode_orientation = DiodeOrientation.COLUMNS
+    diode_orientation = DiodeOrientation.COL2ROW
 ```
 
 ## Additional pins for extensions

--- a/docs/ptBR/Getting_Started.md
+++ b/docs/ptBR/Getting_Started.md
@@ -47,7 +47,7 @@ keyboard = KMKKeyboard()
 
 keyboard.col_pins = (board.GP0,)
 keyboard.row_pins = (board.GP1,)
-keyboard.diode_orientation = DiodeOrientation.COLUMNS
+keyboard.diode_orientation = DiodeOrientation.COL2ROW
 
 keyboard.keymap = [
     [KC.A,]

--- a/docs/ptBR/config_and_keymap.md
+++ b/docs/ptBR/config_and_keymap.md
@@ -41,7 +41,7 @@ from kmk.matrix import DiodeOrientation
 col_pins = (board.SCK, board.MOSI, board.MISO, board.RX, board.TX, board.D4)
 row_pins = (board.D10, board.D11, board.D12, board.D13, board.D9, board.D6, board.D5, board.SCL)
 rollover_cols_every_rows = 4
-diode_orientation = DiodeOrientation.COLUMNS
+diode_orientation = DiodeOrientation.COL2ROW
 ```
 
 Os pinos devem ser baseados naquilo que o CircuitPython chama de pinos na sua
@@ -54,7 +54,7 @@ print(dir(board))
 ```
 
 > Note: `rollover_cols_every_rows` só é suportado com
-> `DiodeOrientation.COLUMNS`, não `DiodeOrientation.ROWS`. Este é usado em
+> `DiodeOrientation.COLUMNS`/`DiodeOrientation.COL2ROW`, não `DiodeOrientation.ROWS`/`DiodeOrientation.ROW2COL`. Este é usado em
 > placas como a Planck Rev6 que reusa pinos de coluna para simular uma matriz
 > 4x12 na forma de uma matriz 8x6.
 

--- a/docs/ptBR/porting_to_kmk.md
+++ b/docs/ptBR/porting_to_kmk.md
@@ -24,7 +24,7 @@ forma:
 ```python
     row_pins = [board.p0_31, board.p0_29, board.p0_02, board.p1_15]
     col_pins = [board.p0_22, board.p0_24, board.p1_00, board.p0_11, board.p1_04]
-    diode_orientation = DiodeOrientation.COLUMNS
+    diode_orientation = DiodeOrientation.COL2ROW
 ```
 
 ## Pinos Adicionais para Extensões

--- a/kmk/matrix.py
+++ b/kmk/matrix.py
@@ -10,10 +10,14 @@ class DiodeOrientation:
     Orientation of diodes on handwired boards. You can think of:
     COLUMNS = vertical
     ROWS = horizontal
+
+    COL2ROW and ROW2COL are equivalent to their meanings in QMK.
     '''
 
     COLUMNS = 0
     ROWS = 1
+    COL2ROW = COLUMNS
+    ROW2COL = ROWS
 
 
 class MatrixScanner:


### PR DESCRIPTION
IMO the existing `DiodeOrientation` names are somewhat confusing, the names used in QMK are unambiguous and likely to be more familiar with anyone coming from QMK.

Support for the old definitions remains for compatibility, but docs have been updated to point to the more familiar naming.