### PR TITLE
add ble_name option to KMKKeyboard.go method

### DIFF
--- a/docs/ble_hid.md
+++ b/docs/ble_hid.md
@@ -1,9 +1,9 @@
 # BLE HID
-Bluetooth connections help clean up the wire mess! 
+Bluetooth connections help clean up the wire mess!
 
 ## Circuitpython
-If not running KMKpython, this does require the adafruit_ble library from Adafruit. 
-This can be downloaded 
+If not running KMKpython, this does require the adafruit_ble library from Adafruit.
+This can be downloaded
 [here](https://github.com/adafruit/Adafruit_CircuitPython_BLE/tree/master/adafruit_ble).
 It is part of the [Adafruit CircuitPython Bundle](https://github.com/adafruit/Adafruit_CircuitPython_Bundle).
 Simply put this in the "root" of your circuitpython device. If unsure, it's the folder with main.py in it, and should be the first folder you see when you open the device.
@@ -14,12 +14,14 @@ To enable BLE hid, change the keyboard.go(). By default, the advertised name
 will be the name of the "flash drive". By default this is CIRCUITPY
 
 ```python
+from kmk.hid import HIDModes
+
 if __name__ == '__main__':
     keyboard.go(hid_type=HIDModes.BLE)
 ```
 
 ## Changing the advertise name
-There are two ways to change the advertising name. The first would be to 
+There are two ways to change the advertising name. The first would be to
 [change the name of the drive](https://learn.adafruit.com/welcome-to-circuitpython/the-circuitpy-drive).
 The second would be to change the keyboard.go() like this.
 

--- a/kmk/hid.py
+++ b/kmk/hid.py
@@ -52,7 +52,7 @@ HID_REPORT_SIZES = {
 class AbstractHID:
     REPORT_BYTES = 8
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         self._evt = bytearray(self.REPORT_BYTES)
         self.report_device = memoryview(self._evt)[0:1]
         self.report_device[0] = HIDReportTypes.KEYBOARD
@@ -239,11 +239,15 @@ class BLEHID(AbstractHID):
     # Hardcoded in CPy
     MAX_CONNECTIONS = const(2)
 
-    def post_init(self, ble_name=str(getmount('/').label), **kwargs):
+    def __init__(self, ble_name=str(getmount('/').label), **kwargs):
+        self.ble_name = ble_name
+        super().__init__()
+
+    def post_init(self):
         self.conn_id = -1
 
         self.ble = BLERadio()
-        self.ble.name = ble_name
+        self.ble.name = self.ble_name
         self.hid = HIDService()
         self.hid.protocol_mode = 0  # Boot protocol
 

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -52,6 +52,7 @@ class KMKKeyboard:
     _trigger_powersave_enable = False
     _trigger_powersave_disable = False
     i2c_deinit_count = 0
+    _go_args = None
 
     # this should almost always be PREpended to, replaces
     # former use of reversed_active_layers which had pointless
@@ -324,7 +325,7 @@ class KMKKeyboard:
             self._hid_helper = BLEHID
         else:
             self._hid_helper = AbstractHID
-        self._hid_helper = self._hid_helper()
+        self._hid_helper = self._hid_helper(**self._go_args)
 
     def _init_matrix(self):
         self.matrix = MatrixScanner(
@@ -426,6 +427,7 @@ class KMKKeyboard:
                     print('Failed to run post hid function in extension: ', err, ext)
 
     def go(self, hid_type=HIDModes.USB, secondary_hid_type=None, **kwargs):
+        self._go_args = kwargs
         self.hid_type = hid_type
         self.secondary_hid_type = secondary_hid_type
 


### PR DESCRIPTION
To make setting the Bluetooth advertising name work as described in ble_hid.md, I have simply passed on the args from KMKKeyboard.go to the HID constructors.