### PR TITLE
fix doc typos and switched description for keycodes NUBS and NUHS

### DIFF
--- a/boards/atreus62/README.md
+++ b/boards/atreus62/README.md
@@ -9,7 +9,7 @@ kb.py is designed to work with the Teensy 4.1
 Retailers (USA)  
 [Atreus62](https://shop.profetkeyboards.com/product/atreus62-keyboard)  
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [RGB](https://github.com/KMKfw/kmk_firmware/tree/master/docs/rgb.md) Light it up
 - [Encoder](https://github.com/KMKfw/kmk_firmware/tree/master/docs/encoder.md) Twist control for all the things

--- a/boards/boardsource/3x4/README.md
+++ b/boards/boardsource/3x4/README.md
@@ -9,5 +9,5 @@ kb.py is designed to work with the nice!nano
 Retailers (USA)  
 [Boardsource](https://boardsource.xyz/store/5ecc2008eee64242946c98c1)  
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.

--- a/boards/boardsource/4x12/README.md
+++ b/boards/boardsource/4x12/README.md
@@ -13,9 +13,9 @@ Retailers (USA)
 Low profile 4x12  
 [Boardsource](https://boardsource.xyz/store/5ecb7dad86879c9a0c22db32)  
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [MediaKeys](https://github.com/KMKfw/kmk_firmware/tree/master/docs/media_keys.md) Control volume and other media functions
 
-Common Extentions
+Common Extensions
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/boards/boardsource/5x12/README.md
+++ b/boards/boardsource/5x12/README.md
@@ -13,9 +13,9 @@ Retailers (USA)
 Low Profile 5x12
 [Boardsource](https://boardsource.xyz/store/5ecb822386879c9a0c22db84)  
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [MediaKeys](https://github.com/KMKfw/kmk_firmware/tree/master/docs/media_keys.md) Control volume and other media functions
 
-Common Extentions
+Common Extensions
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/boards/boardsource/microdox/README.md
+++ b/boards/boardsource/microdox/README.md
@@ -9,11 +9,11 @@ kb.py is designed to work with the nice!nano
 Retailers (USA)  
 [Boardsource](https://boardsource.xyz/store/5f2e7e4a2902de7151494f92)  
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [BLE_Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves without wires
 - [ModTap](https://github.com/KMKfw/kmk_firmware/tree/master/docs/modtap.md) Allows mod keys to act as different keys when tapped.
 
-Common Extentions
+Common Extensions
 - [Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves using a wire
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/boards/crkbd/README.md
+++ b/boards/crkbd/README.md
@@ -17,11 +17,11 @@ Corne
 Corne LP  
 [Boardsource](https://boardsource.xyz/store/5f2efc462902de7151495057)  
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [RGB](https://github.com/KMKfw/kmk_firmware/tree/master/docs/rgb.md) Light it up
 - [BLE_Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves without wires
 
-Common Extentions
+Common Extensions
 - [Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves using a wire
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/boards/ergo_travel/README.md
+++ b/boards/ergo_travel/README.md
@@ -11,11 +11,11 @@ Hardware Availability: [PCB & Case Source](https://github.com/jpconstantineau/Er
 Retailers (USA)  
 [Boardsource](https://boardsource.xyz/store/5eed23430883e03ef9a69d6a)  
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [BLE_Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves without wires
 - [MediaKeys](https://github.com/KMKfw/kmk_firmware/tree/master/docs/media_keys.md) Control volume and other media functions
 
-Common Extentions
+Common Extensions
 - [Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves using a wire
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/boards/fourtypercentclub/gherkin/README.md
+++ b/boards/fourtypercentclub/gherkin/README.md
@@ -8,10 +8,10 @@ kb.py is designed to work with the nice!nano
 
 Hardware Availability: [Gherkin project on 40% Keyboards](http://www.40percent.club/2016/11/gherkin.html)
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [ModTap](https://github.com/KMKfw/kmk_firmware/tree/master/docs/modtap.md) Allows mod keys to act as different keys when tapped.
 - [LED](https://github.com/KMKfw/kmk_firmware/tree/master/docs/led.md) Light your keys up
 
-Common Extentions
+Common Extensions
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/boards/fourtypercentclub/luddite/README.md
+++ b/boards/fourtypercentclub/luddite/README.md
@@ -9,10 +9,10 @@ kb_converter.py is designed to work with an itsybitsy with converter board found
 
 Hardware Availability: [Luddite project on 40% Keyboards](http://www.40percent.club/search/label/luddite)
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [RGB](https://github.com/KMKfw/kmk_firmware/tree/master/docs/rgb.md) RGB underglow
 - [LED](https://github.com/KMKfw/kmk_firmware/tree/master/docs/led.md) Light your keys up
 
-Common Extentions
+Common Extensions
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/boards/keebio/iris/README.md
+++ b/boards/keebio/iris/README.md
@@ -5,11 +5,11 @@ A split keyboard with a 4x6 layout with additional 4 thumb buttons
 kb.py is designed to work with the nice!nano
 kb_converter.py is designed to work with an itsybitsy with converter board found [here](https://github.com/KMKfw/kmk_firmware/tree/master/hardware)
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [RGB](https://github.com/KMKfw/kmk_firmware/tree/master/docs/rgb.md) Light it up
 - [BLE_Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves without wires
 
-Common Extentions
+Common Extensions
 - [Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves using a wire
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/boards/keebio/levinson/README.md
+++ b/boards/keebio/levinson/README.md
@@ -5,11 +5,11 @@ A split keyboard with a 4x6 layout
 kb.py is designed to work with the nice!nano
 kb_converter.py is designed to work with an itsybitsy with converter board found [here](https://github.com/KMKfw/kmk_firmware/tree/master/hardware)
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [RGB](https://github.com/KMKfw/kmk_firmware/tree/master/docs/rgb.md) Light it up
 - [BLE_Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves without wires
 
-Common Extentions
+Common Extensions
 - [Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves using a wire
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/boards/keebio/nyquist/README.md
+++ b/boards/keebio/nyquist/README.md
@@ -6,11 +6,11 @@ kb.py is designed to work with the nice!nano
 kb_converter.py is designed to work with an itsybitsy with converter board found [here](https://github.com/KMKfw/kmk_firmware/tree/master/hardware)
 
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [RGB](https://github.com/KMKfw/kmk_firmware/tree/master/docs/rgb.md) Light it up
 - [BLE_Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves without wires
 
-Common Extentions
+Common Extensions
 - [Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves using a wire
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/boards/lily58/README.md
+++ b/boards/lily58/README.md
@@ -10,11 +10,11 @@ kb.py is designed to work with the nice!nano
 Retailers (USA)  
 [Boardsource](https://boardsource.xyz/store/5ec9df84c6b834480de6c3d0)  
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [RGB](https://github.com/KMKfw/kmk_firmware/tree/master/docs/rgb.md) Light it up
 - [BLE_Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves without wires
 
-Common Extentions
+Common Extensions
 - [Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves using a wire
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/boards/reviung39/README.md
+++ b/boards/reviung39/README.md
@@ -11,10 +11,10 @@ Hardware Availability: [PCB & Case Data](https://github.com/gtips/reviung)
 Retailers (USA)  
 [Boardsource](https://boardsource.xyz/store/5ecb734486879c9a0c22dab3)  
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [RGB](https://github.com/KMKfw/kmk_firmware/tree/master/docs/rgb.md) Light it up
 - [ModTap](https://github.com/KMKfw/kmk_firmware/tree/master/docs/modtap.md) Allows mod keys to act as different keys when tapped.
 
-Common Extentions
+Common Extensions
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/boards/reviung41/README.md
+++ b/boards/reviung41/README.md
@@ -11,10 +11,10 @@ Hardware Availability: [PCB & Case Data](https://github.com/gtips/reviung/tree/m
 Retailers (USA)  
 [Boardsource](https://boardsource.xyz/store/5f2ef1b52bf5e8714a60f613)  
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [RGB](https://github.com/KMKfw/kmk_firmware/tree/master/docs/rgb.md) Light it up
 - [ModTap](https://github.com/KMKfw/kmk_firmware/tree/master/docs/modtap.md) Allows mod keys to act as different keys when tapped.
 
-Common Extentions
+Common Extensions
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/boards/rhymestone/README.md
+++ b/boards/rhymestone/README.md
@@ -9,11 +9,11 @@ kb.py is designed to work with the nice!nano
 Retailers (USA)  
 [Boardsource](https://boardsource.xyz/store/5ecb6aee86879c9a0c22da89)  
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [BLE_Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves without wires
 - [ModTap](https://github.com/KMKfw/kmk_firmware/tree/master/docs/modtap.md) Allows mod keys to act as different keys when tapped.
 
-Common Extentions
+Common Extensions
 - [Split](https://github.com/KMKfw/kmk_firmware/tree/master/docs/split.md) Connects halves using a wire
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/boards/tg4x/README.md
+++ b/boards/tg4x/README.md
@@ -9,9 +9,9 @@ kb.py is designed to work with the nice!nano
 Retailers (USA)  
 [Boardsource](https://boardsource.xyz/store/5eff7ead037395179221b90c)  
 
-Extentions enabled by default  
+Extensions enabled by default  
 - [Layers](https://github.com/KMKfw/kmk_firmware/tree/master/docs/layers.md) Need more keys than switches? Use layers.
 - [RGB](https://github.com/KMKfw/kmk_firmware/tree/master/docs/rgb.md) Light it up
 
-Common Extentions
+Common Extensions
 - [Power](https://github.com/KMKfw/kmk_firmware/tree/master/docs/power.md) Powersaving features for battery life

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -169,8 +169,8 @@
 
 |Key                     |Aliases                       |Description            |
 |------------------------|------------------------------|-----------------------|
-|`KC.NONUS_HASH`         |`KC.NUHS`                     |ISO Right of LSHIFT    |
-|`KC.NONUS_BSLASH`       |`KC.NUBS`                     |ISO Left of Return     |
+|`KC.NONUS_HASH`         |`KC.NUHS`                     |ISO Left of Return     |
+|`KC.NONUS_BSLASH`       |`KC.NUBS`                     |ISO Right of LSHIFT    |
 |`KC.APPLICATION`        |`KC.APP`,`KC.SEL`,`KC.WINMENU`|Menu Key (Near RCTRL)  |
 |`KC.INT1`               |`KC.RO`                       |                       |
 |`KC.INT2`               |`KC.KANA`                     |                       |

--- a/docs/rgb.md
+++ b/docs/rgb.md
@@ -21,8 +21,8 @@ Changing the **Hue** cycles around the circle.
 Changing the **Saturation** moves between the inner and outer sections of the wheel, affecting the intensity of the color.
 Changing the **Value** sets the overall brightness.
 
-## Enabling the extention
-The only required values that you need to give the RGB extention would be the pixel pin, and the number of pixels/LED's. If using a split keyboard, this number is per side, and not the total of both sides.
+## Enabling the extension
+The only required values that you need to give the RGB extension would be the pixel pin, and the number of pixels/LED's. If using a split keyboard, this number is per side, and not the total of both sides.
 ```python
 from kmk.extensions.RGB import RGB
 from kb import rgb_pixel_pin  # This can be imported or defined manually

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -444,7 +444,7 @@ class KMKKeyboard:
                 ext.during_bootup(self)
             except Exception:
                 if self.debug_enabled:
-                    print('Failed to load extention', ext)
+                    print('Failed to load extension', ext)
 
         self._init_matrix()
 


### PR DESCRIPTION
Just noticed the word extension is misspelled on several occasions. Also the description for the two ISO-layout keys are switched