### PR TITLE
always release the same key as was pressed

### DIFF
--- a/kmk/handlers/stock.py
+++ b/kmk/handlers/stock.py
@@ -8,9 +8,6 @@ def passthrough(key, keyboard, *args, **kwargs):
 def default_pressed(key, keyboard, KC, coord_int=None, coord_raw=None, *args, **kwargs):
     keyboard.hid_pending = True
 
-    if coord_int is not None:
-        keyboard._coordkeys_pressed[coord_int] = key
-
     keyboard.keys_pressed.add(key)
 
     return keyboard
@@ -21,10 +18,6 @@ def default_released(
 ):
     keyboard.hid_pending = True
     keyboard.keys_pressed.discard(key)
-
-    if coord_int is not None:
-        keyboard.keys_pressed.discard(keyboard._coordkeys_pressed.get(coord_int, None))
-        keyboard._coordkeys_pressed[coord_int] = None
 
     return keyboard
 

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -148,7 +148,19 @@ class KMKKeyboard:
             print('MatrixChange(col={} row={} pressed={})'.format(col, row, is_pressed))
 
         int_coord = intify_coordinate(row, col)
-        kc_changed = self._find_key_in_map(int_coord, row, col)
+        kc_changed = None
+        if not is_pressed:
+            kc_changed = self._coordkeys_pressed[int_coord]
+            if self.debug_enabled:
+                print('PressedKeyResolution(key={})'.format(self.state_layer_key))
+
+        if kc_changed is None:
+            kc_changed = self._find_key_in_map(int_coord, row, col)
+
+        if is_pressed:
+            self._coordkeys_pressed[int_coord] = kc_changed
+        else:
+            self._coordkeys_pressed[int_coord] = None
 
         if kc_changed is None:
             print('MatrixUndefinedCoordinate(col={} row={})'.format(col, row))


### PR DESCRIPTION
I had a problem of a layer being stuck with `MO`.

So if matrix position x has a `MO(1)` defined on layer 0 but a different key, e.g. `KC.A`, on layer 1, then the `is_pressed == True` matrix scan event will call `MO(1).on_press` and set layer 1 to be active. The `is_pressed == False` matrix scan event then will get `KC.A` from `_find_key_in_map` and call `KC.A.on_release` and there is no way to get back to layer 0.

I have changed to code to always remember the keys being pressed down and reference those same keys when the physical key is being release.

If you think about it, is there ever a case where we want to release a different keycode than was pressed?