### PR TITLE
Fix the issue #256 by changing the timing to set True to the hid_pending flag

### DIFF
--- a/docs/split_keyboards.md
+++ b/docs/split_keyboards.md
@@ -2,6 +2,7 @@
 Split keyboards are mostly the same as unsplit. Wired UART is fully supported,
 and testing of bluetooth splits, though we don't currently offer support for this.
 
+Notice that this Split module must be added after the ModTap module to the keyboard.modules.
 
 ## Wired UART
 Wired connections can use UART over 1 or 2 wires. With 2 wires, you will be able

--- a/kmk/modules/modtap.py
+++ b/kmk/modules/modtap.py
@@ -13,18 +13,17 @@ class ModTap(HoldTap):
             on_release=self.ht_released,
         )
 
-    def ht_activate_hold(self, key, keyboard, *args, **kwargs):
+    def before_hid_send(self, keyboard):
         keyboard.hid_pending = True
+
+    def ht_activate_hold(self, key, keyboard, *args, **kwargs):
         keyboard.keys_pressed.add(key.meta.mods)
 
     def ht_deactivate_hold(self, key, keyboard, *args, **kwargs):
-        keyboard.hid_pending = True
         keyboard.keys_pressed.discard(key.meta.mods)
 
     def ht_activate_tap(self, key, keyboard, *args, **kwargs):
-        keyboard.hid_pending = True
         keyboard.keys_pressed.add(key.meta.kc)
 
     def ht_deactivate_tap(self, key, keyboard, *args, **kwargs):
-        keyboard.hid_pending = True
         keyboard.keys_pressed.discard(key.meta.kc)


### PR DESCRIPTION
Fix #256.

The reason of the issue #256 is that the result of the `keyboard.hid_pending` flag value decided by the `Split.before_hid_send` is updated by the `ht_activate_tap/hold` and `ht_deactivate_tap/hold` of the ModTap class. To avoid the issue, it is necessary that these methods of the ModTap class doesn't update the `keyboard.hid_pending` value. I want to remove each code which updates the flag and move the flag updating code to the `before_hid_send` method of the ModTap class.

In addition, to avoid the issue, the Split module must be added after the ModTap module in the keyboard.modules array. We can't ensure this, therefore I want to add the description in the document for the Split module.