### PR TITLE
Multiple led pwm targets (see #273)

### DIFF
--- a/docs/led.md
+++ b/docs/led.md
@@ -2,28 +2,42 @@
 Want your keyboard to shine? Add some lights!
 
 ## Enabling the extension
-The only required values that you need to give the LED extension would be the 
-pixel pin, and the number of pixels/LED's. If using a split keyboard, this number
-is per side, and not the total of both sides.
+The only required values that you need to give the LED extension would be the
+`led_pin`. It can either be a single board pin, or a list of pins for multiple
+LED's.
 ```python
-from kmk.extensions.RGB import RGB
-from kb import led_pin  # This can be imported or defined manually
+from kmk.extensions.LED import LED
+import board
 
-led_ext = LED(led_pin=led_pin)
+led_ext = LED(led_pin=[board.GP0, board.GP1])
 keyboard.extensions.append(led_ext)
 ```
- 
+
 ## [Keycodes]
 
 |Key                          |Aliases            |Description                 |
 |-----------------------------|-------------------|----------------------------|
-|`KC.LED_TOG`                 |                   |Toggles LED's               |
-|`KC.LED_INC`                 |                   |Increase Brightness         |
-|`KC.LED_DEC`                 |                   |Decrease Brightness         |
+|`KC.LED_TOG()`               |                   |Toggles LED's               |
+|`KC.LED_INC()`               |                   |Increase Brightness         |
+|`KC.LED_DEC()`               |                   |Decrease Brightness         |
+|`KC.LED_SET()`               |                   |Set Brightness              |
 |`KC.LED_ANI`                 |                   |Increase animation speed    |
 |`KC.LED_AND`                 |                   |Decrease animation speed    |
 |`KC.LED_MODE_PLAIN`          |`LED_M_P`          |Static LED's                |
 |`KC.LED_MODE_BREATHE`        |`LED_M_B`          |Breathing animation         |
+
+Keycodes with arguments can affect all, or a selection of LED's.
+```python
+# toggle all LEDs
+LED_TOG_ALL = KC.LED_TOG()
+
+# increase brightness of first LED
+LED_INC_0   = KC.LED_INC(0)
+
+# decrease brightness of second and third LED
+LED_DEC_1_2 = KC.LED_DEC(1,2)
+
+```
 
 ## Configuration
 All of these values can be set by default for when the keyboard boots.
@@ -36,6 +50,7 @@ led_ext = LED(
     breathe_center=1.5,
     animation_mode=AnimationModes.STATIC,
     animation_speed=1,
+    user_animation=None,
     val=100,
     )
 ```

--- a/kmk/extensions/led.py
+++ b/kmk/extensions/led.py
@@ -9,6 +9,7 @@ from kmk.utils import clamp
 class LEDKeyMeta:
     def __init__(self, *leds):
         self.leds = leds
+        self.brightness = None
 
 
 class AnimationModes:
@@ -73,6 +74,11 @@ class LED(Extension):
             names=('LED_DEC',),
             validator=self._led_key_validator,
             on_press=self._key_led_dec,
+        )
+        make_argumented_key(
+            names=('LED_SET',),
+            validator=self._led_set_key_validator,
+            on_press=self._key_led_set,
         )
         make_key(names=('LED_ANI',), on_press=self._key_led_ani)
         make_key(names=('LED_AND',), on_press=self._key_led_and)
@@ -220,6 +226,11 @@ class LED(Extension):
 >>>>>>> c7bdb7c (apply suggested changes)
         return LEDKeyMeta(*leds)
 
+    def _led_set_key_validator(self, brightness, *leds):
+        meta = self._led_key_validator(*leds)
+        meta.brightness = brightness
+        return meta
+
     def _key_led_tog(self, *args, **kwargs):
         if self.animation_mode == AnimationModes.STATIC_STANDBY:
             self.animation_mode = AnimationModes.STATIC
@@ -231,6 +242,9 @@ class LED(Extension):
 
     def _key_led_dec(self, key, *args, **kwargs):
         self.decrease_brightness(leds=key.meta.leds)
+
+    def _key_led_set(self, key, *args, **kwargs):
+        self.set_brightness(percent=key.meta.brightness, leds=key.meta.leds)
 
     def _key_led_ani(self, *args, **kwargs):
         self.increase_ani()

--- a/kmk/extensions/led.py
+++ b/kmk/extensions/led.py
@@ -216,14 +216,9 @@ class LED(Extension):
             self.off()
 
     def _led_key_validator(self, *leds):
-<<<<<<< HEAD
         if leds:
             for led in leds:
                 assert self._leds[led]
-=======
-        for led in leds:
-            self._leds[led]
->>>>>>> c7bdb7c (apply suggested changes)
         return LEDKeyMeta(*leds)
 
     def _led_set_key_validator(self, brightness, *leds):

--- a/kmk/extensions/led.py
+++ b/kmk/extensions/led.py
@@ -3,10 +3,7 @@ from math import e, exp, pi, sin
 
 from kmk.extensions import Extension, InvalidExtensionEnvironment
 from kmk.keys import make_argumented_key, make_key
-
-
-def _clamp(x):
-    return min(max(0, x), 100)
+from kmk.utils import clamp
 
 
 class LEDKeyMeta:
@@ -34,12 +31,13 @@ class LED(Extension):
         user_animation=None,
         val=100,
     ):
-        self._leds = []
         try:
-            if not isinstance(led_pin, list):
-                led_pin = [led_pin]
-            for pin in led_pin:
-                self._leds.append(pwmio.PWMOut(pin))
+            pins_iter = iter(led_pin)
+        except TypeError:
+            pins_iter = [led_pin]
+
+        try:
+            self._leds = [pwmio.PWMOut(pin) for pin in pins_iter]
         except Exception as e:
             print(e)
             raise InvalidExtensionEnvironment(
@@ -143,7 +141,7 @@ class LED(Extension):
         leds = leds or range(0, len(self._leds))
         for i in leds:
             brightness = int(self._leds[i].duty_cycle / 65535 * 100) + step
-            self.set_brightness(_clamp(brightness), [i])
+            self.set_brightness(clamp(brightness), [i])
 
     def increase_brightness(self, step=None, leds=None):
         if step is None:
@@ -212,9 +210,14 @@ class LED(Extension):
             self.off()
 
     def _led_key_validator(self, *leds):
+<<<<<<< HEAD
         if leds:
             for led in leds:
                 assert self._leds[led]
+=======
+        for led in leds:
+            self._leds[led]
+>>>>>>> c7bdb7c (apply suggested changes)
         return LEDKeyMeta(*leds)
 
     def _key_led_tog(self, *args, **kwargs):

--- a/kmk/extensions/led.py
+++ b/kmk/extensions/led.py
@@ -42,7 +42,7 @@ class LED(Extension):
         except Exception as e:
             print(e)
             raise InvalidExtensionEnvironment(
-                f'Unable to create pwmio.PWMOut() instance with provided led_pin "{pin}"'
+                'Unable to create pwmio.PWMOut() instance with provided led_pin'
             )
 
         self._brightness = 0

--- a/kmk/utils.py
+++ b/kmk/utils.py
@@ -1,0 +1,2 @@
+def clamp(x, bottom=0, top=100):
+    return min(max(bottom, x), top)


### PR DESCRIPTION
LED module argument `led_pin` accepts pin objects or lists of pin objects (free backwards compatibility).
Toggle, increase, and decrease are promoted to argumented keys (sadly not backwards compatible). Didn't yet figure out if we can make a `maybe_argumented_key`.
Increasing/Decreasing brightness of all LEDs doesn't reset brightness levels, but steps each LED brightness by the provided step value.

Pending:
* add `KC.LED_SET(value, *leds)` key
* documentation

usage example:
```python
# single LED
rgb_ext = RGB(
    led_pin = board.GP20
)
# multiple LEDs
rgb_ext = RGB(
    led_pin = [board.GP20, board.GP21, board.GP22]
)

# toggle all LEDs
LED_TOG_ALL = KC.LED_TOG()
# increase brightness of first LED
LED_INC_0 = KC.LED_INC(0)
# decrease brightness of second and third LED
LED_DEC_1_2 = KC.LED_DEC(1,2)
```