### PR TITLE
Fix two way uart

### DIFF
--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -278,16 +278,8 @@ class Split(Module):
     def _send_uart(self, update):
         # Change offsets depending on where the data is going to match the correct
         # matrix location of the receiever
-        if self._is_target:
-            if self.split_target_left:
-                update[1] += self.split_offset
-            else:
-                update[1] -= self.split_offset
-        else:
-            if self.split_target_left:
-                update[1] += self.split_offset
-            else:
-                update[1] -= self.split_offset
+        if self.split_side == SplitSide.RIGHT:
+            update[1] += self.split_offset
 
         if self._uart is not None:
             # Add a header byte the data

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -108,7 +108,7 @@ class Split(Module):
         self.split_offset = len(keyboard.col_pins)
 
         if self.split_type == SplitType.UART and self.data_pin is not None:
-            if self._is_target:
+            if self._is_target or not self.uart_flip:
                 self._uart = busio.UART(
                     tx=self.data_pin2, rx=self.data_pin, timeout=self._uart_interval
                 )
@@ -143,7 +143,7 @@ class Split(Module):
         if keyboard.matrix_update:
             if self.split_type == SplitType.UART and self._is_target:
                 pass  # explicit pass just for dev sanity...
-            elif self.split_type == SplitType.UART and (
+            if self.split_type == SplitType.UART and (
                 self.data_pin2 or not self._is_target
             ):
                 self._send_uart(keyboard.matrix_update)


### PR DESCRIPTION
These are the changes I made to use two way UART on my RP2040 Corne.  I added a check on `uart_flip` to support crossing TX and RX in hardware.  I added a header byte to the front of each UART message to confirm that the pin is not floating.  I only apply the `split_offset` when sending from right to left.  