### PR TITLE
Split code fix/cleanup.

### DIFF
--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -399,15 +399,16 @@ class KMKKeyboard:
         for module in self.modules:
             try:
                 module.during_bootup(self)
-            except Exception:
+            except Exception as err:
                 if self.debug_enabled:
-                    print('Failed to load module', module)
+                    print('Failed to load module', err, module)
+                print()
         for ext in self.extensions:
             try:
                 ext.during_bootup(self)
-            except Exception:
+            except Exception as err:
                 if self.debug_enabled:
-                    print('Failed to load extension', ext)
+                    print('Failed to load extension', err, ext)
 
         self._init_matrix()
 

--- a/kmk/modules/encoder.py
+++ b/kmk/modules/encoder.py
@@ -132,8 +132,12 @@ class EncoderHandler(Module):
                 gpio_pins = pins[:3]
                 new_encoder = Encoder(*gpio_pins)
                 # In our case, we need to define keybord and encoder_id for callbacks
-                new_encoder.on_move_do = lambda x, bound_idx = idx: self.on_move_do(keyboard, bound_idx, x)
-                new_encoder.on_button_do = lambda x, bound_idx = idx: self.on_button_do(keyboard, bound_idx, x)
+                new_encoder.on_move_do = lambda x, bound_idx=idx: self.on_move_do(
+                    keyboard, bound_idx, x
+                )
+                new_encoder.on_button_do = lambda x, bound_idx=idx: self.on_button_do(
+                    keyboard, bound_idx, x
+                )
                 self.encoders.append(new_encoder)
         return
 

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -92,7 +92,10 @@ class Split(Module):
             self._is_target = not bool(self.split_target_left)
         else:
             # Detect split side from name
-            if self.split_type == SplitType.UART or self.split_type == SplitType.ONEWIRE:
+            if (
+                self.split_type == SplitType.UART
+                or self.split_type == SplitType.ONEWIRE
+            ):
                 self._is_target = runtime.usb_connected
             elif self.split_type == SplitType.BLE:
                 self._is_target = bool(self.split_target_left)

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -98,7 +98,7 @@ class Split(Module):
             ):
                 self._is_target = runtime.usb_connected
             elif self.split_type == SplitType.BLE:
-                self._is_target = bool(self.split_target_left)
+                self._is_target = name.endswith('L') == self.split_target_left
 
             if name.endswith('L'):
                 self.split_side = SplitSide.LEFT

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -282,6 +282,11 @@ class Split(Module):
                 keyboard.secondary_matrix_update = bytearray(self._uart_buffer.pop(0))
                 return
 
+    def _checksum(self, update):
+        checksum = bytes([sum(update) & 0xFF])
+
+        return checksum
+
     def _send_uart(self, update):
         # Change offsets depending on where the data is going to match the correct
         # matrix location of the receiever
@@ -293,6 +298,7 @@ class Split(Module):
         if self._uart is not None:
             self._uart.write(self.uart_header)
             self._uart.write(update)
+            self._uart.write(self._checksum(update))
 
     def _receive_uart(self, keyboard):
         if self._uart is not None and self._uart.in_waiting > 0 or self._uart_buffer:
@@ -302,10 +308,14 @@ class Split(Module):
 
                 microcontroller.reset()
 
-            while self._uart.in_waiting >= 4:
+            while self._uart.in_waiting >= 5:
                 # Check the header
                 if self._uart.read(1) == self.uart_header:
-                    self._uart_buffer.append(self._uart.read(3))
+                    update = self._uart.read(3)
+
+                    # check the checksum
+                    if self._checksum(update) == self._uart.read(1):
+                        self._uart_buffer.append(update)
 
             if self._uart_buffer:
                 keyboard.secondary_matrix_update = bytearray(self._uart_buffer.pop(0))

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -1,7 +1,7 @@
 '''Enables splitting keyboards wirelessly or wired'''
 import busio
 from micropython import const
-from supervisor import ticks_ms, runtime
+from supervisor import runtime, ticks_ms
 
 from storage import getmount
 
@@ -90,7 +90,8 @@ class Split(Module):
             self._is_target = bool(self.split_target_left)
         elif self.split_side == SplitSide.RIGHT:
             self._is_target = not bool(self.split_target_left)
-        else:  # Detect split side from name
+        else:
+            # Detect split side from name
             if self.split_type == SplitType.UART or self.split_type == SplitType.ONEWIRE:
                 self._is_target = runtime.usb_connected
             elif self.split_type == SplitType.BLE:
@@ -146,7 +147,7 @@ class Split(Module):
         if keyboard.matrix_update:
             if self.split_type == SplitType.UART and self._is_target:
                 pass  # explicit pass just for dev sanity...
-            
+
             if self.split_type == SplitType.UART and (
                 self.data_pin2 or not self._is_target
             ):
@@ -283,9 +284,9 @@ class Split(Module):
         # matrix location of the receiever
 
         if self.split_side == SplitSide.RIGHT:
-            #if we're on the right, we by definition are sending to the left, so we need to offset.
+            # if we're on the right, we by definition are sending to the left, so we need to offset.
             update[1] += self.split_offset
-    
+
         if self._uart is not None:
             self._uart.write(self.uart_header)
             self._uart.write(update)


### PR DESCRIPTION
…, as well as make it work nicely with ble.

@wildesteven I've taken your changes a bit further, and (I think) fixed some issues with the way that _is_target is decided in the split module, with help from @Tonasz. I would welcome a review, and hope I'm not stepping on too many toes.

I also added a bit more logging to kmk_keyboard to debug this, and considering that the rest of it does the same thing I think its relevant.

I don't know about using runtime.usb_connected to determine if usb is connected. The docs say that that is what it does but Tonasz said he thinks that it might be determining if the usb drive is enabled.

I also rearranged the order of the if block that decides what _is_target and split_side are, because starting an if block with a negative can be confusing to read. (was for me, I was confused about what order or precedence the types of connection happen in)