### PR TITLE
implement keyboard lock status reader API

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -9,6 +9,7 @@ extensions are
 
 - [International](international.md): Adds international keycodes
 - [LED](led.md): Adds backlight support. This is for monocolor backlight, not RGB
+- [LockStatus](lock_status.md): Exposes host-side locks like caps or num lock.
 - [MediaKeys](media_keys.md): Adds support for media keys such as volume
 - [RGB](rgb.md): RGB lighting for underglow. Will work on most matrix RGB as will
 be treated the same as underglow.

--- a/docs/lock_status.md
+++ b/docs/lock_status.md
@@ -1,0 +1,23 @@
+# Lock Status
+This extension exposes host-side locks like caps or num lock.
+
+## Enabling the extension
+```python
+from kmk.extensions.lock_status import LockStatus
+
+locks = LockStatus()
+keyboard.extensions.append(locks)
+
+```
+
+## Read Lock Status
+Lock states can be retrieved with getter methods and are truth valued -- `True`
+when the lock is enabled and `False` otherwise.
+
+|Method                    |Description |
+|--------------------------|------------|
+|`locks.get_caps_lock() `  |Num Lock    |
+|`locks.get_caps_lock() `  |Caps Lock   |
+|`locks.get_scroll_lock() `|Scroll Lock |
+|`locks.get_compose() `    |Compose     |
+|`locks.get_kana() `       |Kana        |

--- a/kmk/extensions/lock_status.py
+++ b/kmk/extensions/lock_status.py
@@ -1,0 +1,64 @@
+import usb_hid
+
+from kmk.extensions import Extension
+from kmk.hid import HIDUsage
+
+
+class LockCode:
+    NUMLOCK = 0x01
+    CAPSLOCK = 0x02
+    SCROLLLOCK = 0x04
+    COMPOSE = 0x08
+    KANA = 0x10
+    RESERVED = 0x20
+
+
+class LockStatus(Extension):
+    def __init__(self):
+        self.report = 0x00
+        self.hid = None
+        for device in usb_hid.devices:
+            if device.usage == HIDUsage.KEYBOARD:
+                self.hid = device
+
+    def __repr__(self):
+        return ('LockStatus(report={})').format(self.report)
+
+    def during_bootup(self, sandbox):
+        return
+
+    def before_matrix_scan(self, sandbox):
+        return
+
+    def after_matrix_scan(self, sandbox):
+        return
+
+    def before_hid_send(self, sandbox):
+        return
+
+    def after_hid_send(self, sandbox):
+        report = self.hid.get_last_received_report()
+        if report[0] != self.report:
+            self.report = report[0]
+        return
+
+    def on_powersave_enable(self, sandbox):
+        return
+
+    def on_powersave_disable(self, sandbox):
+        return
+
+    def get_num_lock(self):
+        return bool(self.report & LockCode.NUMLOCK)
+
+    def get_caps_lock(self):
+        return bool(self.report & LockCode.CAPSLOCK)
+
+    def get_scroll_lock(self):
+        return bool(self.report & LockCode.SCROLLLOCK)
+
+    def get_compose(self):
+        return bool(self.report & LockCode.COMPOSE)
+
+    def get_kana(self):
+        return bool(self.report & LockCode.KANA)

--- a/kmk/modules/encoder.py
+++ b/kmk/modules/encoder.py
@@ -15,7 +15,9 @@ class Encoder:
     def __init__(self, pin_a, pin_b, pin_button=None, is_inverted=False):
         self.pin_a = EncoderPin(pin_a)
         self.pin_b = EncoderPin(pin_b)
-        self.pin_button = EncoderPin(pin_button, button_type=True) if pin_button is not None else None
+        self.pin_button = (
+            EncoderPin(pin_button, button_type=True) if pin_button is not None else None
+        )
         self.is_inverted = is_inverted
 
         self._state = (self.pin_a.get_value(), self.pin_b.get_value())


### PR DESCRIPTION
This extension exposes host-side locks like caps or num lock.
example:
```python
import digitalio

from kmk.extensions.lock_status import LockStatus

locks = LockStatus()
keyboard.extensions.append(locks)

led_clock = digitalio.DigitalInOut(board.GP25) # change to pin of LED
led_clock.direction = digitalio.Direction.OUTPUT

# somewhere in a loop:
if locks.get_caps_lock():
    led_cap_lock.value = 1
else:
    led_cap_lock.value = 0
```