### PR TITLE
fix monocolor LED

### DIFF
--- a/kmk/extensions/led.py
+++ b/kmk/extensions/led.py
@@ -1,4 +1,4 @@
-import pulseio
+import pwmio
 
 from math import e, exp, pi, sin
 
@@ -27,7 +27,7 @@ class LED(Extension):
         val=100,
     ):
         try:
-            self._led = pulseio.PWMOut(led_pin)
+            self._led = pwmio.PWMOut(led_pin)
         except Exception as e:
             print(e)
             raise InvalidExtensionEnvironment(


### PR DESCRIPTION
I was getting this error while trying to run LED extension :
Starting
'module' object has no attribute 'PWMout'
Traceback (most recent call last):
  File "code.py", line 67, in <module>
  File "kmk/extensions/led.py", line 34, in __init__
InvalidExtensionEnvironment: Unable to create pulseio.PWMOut() instance with provided led_pin

Code done running.

This was due to using wrong module for PWMOut attribute.