### PR TITLE
Scanner interface rework

### DIFF
--- a/boards/boardsource/microdox/kb.py
+++ b/boards/boardsource/microdox/kb.py
@@ -15,10 +15,15 @@ class KMKKeyboard(_KMKKeyboard):
     i2c = board.I2C
     powersave_pin = board.P0_13
 
+    # NOQA
     coord_mapping = []
-    coord_mapping.extend(ic(0, x) for x in range(10))
-    coord_mapping.extend(ic(1, x) for x in range(10))
-    coord_mapping.extend(ic(2, x) for x in range(10))
+    coord_mapping.extend(ic(0, x, 5) for x in range(5))
+    coord_mapping.extend(ic(4, x, 5) for x in range(5))
+    coord_mapping.extend(ic(1, x, 5) for x in range(5))
+    coord_mapping.extend(ic(5, x, 5) for x in range(5))
+    coord_mapping.extend(ic(2, x, 5) for x in range(5))
+    coord_mapping.extend(ic(6, x, 5) for x in range(5))
 
     # And now, to handle R3, which at this point is down to just six keys
-    coord_mapping.extend(ic(3, x) for x in range(3, 9))
+    coord_mapping.extend(ic(3, x, 5) for x in range(2, 5))
+    coord_mapping.extend(ic(7, x, 5) for x in range(0, 3))

--- a/boards/crkbd/kb.py
+++ b/boards/crkbd/kb.py
@@ -22,9 +22,13 @@ class KMKKeyboard(_KMKKeyboard):
     powersave_pin = board.P0_13
 
     coord_mapping = []
-    coord_mapping.extend(ic(0, x) for x in range(12))
-    coord_mapping.extend(ic(1, x) for x in range(12))
-    coord_mapping.extend(ic(2, x) for x in range(12))
+    coord_mapping.extend(ic(0, x, 6) for x in range(6))
+    coord_mapping.extend(ic(4, x, 6) for x in range(6))
+    coord_mapping.extend(ic(1, x, 6) for x in range(6))
+    coord_mapping.extend(ic(5, x, 6) for x in range(6))
+    coord_mapping.extend(ic(2, x, 6) for x in range(6))
+    coord_mapping.extend(ic(6, x, 6) for x in range(6))
 
     # And now, to handle R3, which at this point is down to just six keys
-    coord_mapping.extend(ic(3, x) for x in range(3, 9))
+    coord_mapping.extend(ic(3, x, 6) for x in range(3, 6))
+    coord_mapping.extend(ic(7, x, 6) for x in range(0, 3))

--- a/boards/crkbd/kb_rp2040.py
+++ b/boards/crkbd/kb_rp2040.py
@@ -21,9 +21,13 @@ class KMKKeyboard(_KMKKeyboard):
     i2c = board.I2C
 
     coord_mapping = []
-    coord_mapping.extend(ic(0, x) for x in range(12))
-    coord_mapping.extend(ic(1, x) for x in range(12))
-    coord_mapping.extend(ic(2, x) for x in range(12))
+    coord_mapping.extend(ic(0, x, 6) for x in range(6))
+    coord_mapping.extend(ic(4, x, 6) for x in range(6))
+    coord_mapping.extend(ic(1, x, 6) for x in range(6))
+    coord_mapping.extend(ic(5, x, 6) for x in range(6))
+    coord_mapping.extend(ic(2, x, 6) for x in range(6))
+    coord_mapping.extend(ic(6, x, 6) for x in range(6))
 
     # And now, to handle R3, which at this point is down to just six keys
-    coord_mapping.extend(ic(3, x) for x in range(3, 9))
+    coord_mapping.extend(ic(3, x, 6) for x in range(3, 6))
+    coord_mapping.extend(ic(7, x, 6) for x in range(0, 3))

--- a/boards/ergo_travel/kb.py
+++ b/boards/ergo_travel/kb.py
@@ -24,10 +24,15 @@ class KMKKeyboard(_KMKKeyboard):
     i2c = board.I2C
     powersave_pin = board.P0_13
 
+    # NOQA
     coord_mapping = []
-    coord_mapping.extend(ic(0, x) for x in range(14))
-    coord_mapping.extend(ic(1, x) for x in range(14))
-    coord_mapping.extend(ic(2, x) for x in range(14))
+    coord_mapping.extend(ic(0, x, 7) for x in range(7))
+    coord_mapping.extend(ic(4, x, 7) for x in range(7))
+    coord_mapping.extend(ic(1, x, 7) for x in range(7))
+    coord_mapping.extend(ic(5, x, 7) for x in range(7))
+    coord_mapping.extend(ic(2, x, 7) for x in range(7))
+    coord_mapping.extend(ic(6, x, 7) for x in range(7))
 
     # And now, to handle R3, which at this point is down to just six keys
-    coord_mapping.extend(ic(3, x) for x in range(3, 12))
+    coord_mapping.extend(ic(3, x, 7) for x in range(0, 6))
+    coord_mapping.extend(ic(7, x, 7) for x in range(1, 7))

--- a/boards/keebio/iris/kb.py
+++ b/boards/keebio/iris/kb.py
@@ -24,9 +24,12 @@ class KMKKeyboard(_KMKKeyboard):
     powersave_pin = board.P0_13
 
     coord_mapping = []
-    coord_mapping.extend(ic(0, x) for x in range(12))
-    coord_mapping.extend(ic(1, x) for x in range(12))
-    coord_mapping.extend(ic(2, x) for x in range(12))
+    coord_mapping.extend(ic(0, x, 6) for x in range(6))
+    coord_mapping.extend(ic(4, x, 6) for x in range(6))
+    coord_mapping.extend(ic(1, x, 6) for x in range(6))
+    coord_mapping.extend(ic(5, x, 6) for x in range(6))
+    coord_mapping.extend(ic(2, x, 6) for x in range(6))
+    coord_mapping.extend(ic(6, x, 6) for x in range(6))
 
     # Buckle up friends, the bottom row of this keyboard is wild, and making
     # our layouts match, visually, what the keyboard looks like, requires some
@@ -36,10 +39,11 @@ class KMKKeyboard(_KMKKeyboard):
     # just like the above three rows, however, visually speaking, the
     # top-right thumb cluster button (when looking at the left-half PCB)
     # is more inline with R3, so we'll jam that key (and its mirror) in here
-    coord_mapping.extend(ic(3, x) for x in range(6))
-    coord_mapping.append(ic(4, 2))
-    coord_mapping.append(ic(4, 9))
-    coord_mapping.extend(ic(3, x) for x in range(6, 12))  # Now, the rest of R3
+    coord_mapping.extend(ic(3, x, 6) for x in range(6))
+    coord_mapping.append(ic(4, 2, 6))
+    coord_mapping.append(ic(8, 3, 6))
+    coord_mapping.extend(ic(7, x, 6) for x in range(6))  # Now, the rest of R3
 
     # And now, to handle R4, which at this point is down to just six keys
-    coord_mapping.extend(ic(4, x) for x in range(3, 9))
+    coord_mapping.extend(ic(4, x, 6) for x in range(3, 6))
+    coord_mapping.extend(ic(8, x, 6) for x in range(0, 3))

--- a/boards/keebio/iris/kb_converter.py
+++ b/boards/keebio/iris/kb_converter.py
@@ -24,9 +24,12 @@ class KMKKeyboard(_KMKKeyboard):
     led_pin = board.D7
 
     coord_mapping = []
-    coord_mapping.extend(ic(0, x) for x in range(12))
-    coord_mapping.extend(ic(1, x) for x in range(12))
-    coord_mapping.extend(ic(2, x) for x in range(12))
+    coord_mapping.extend(ic(0, x, 6) for x in range(6))
+    coord_mapping.extend(ic(4, x, 6) for x in range(6))
+    coord_mapping.extend(ic(1, x, 6) for x in range(6))
+    coord_mapping.extend(ic(5, x, 6) for x in range(6))
+    coord_mapping.extend(ic(2, x, 6) for x in range(6))
+    coord_mapping.extend(ic(6, x, 6) for x in range(6))
 
     # Buckle up friends, the bottom row of this keyboard is wild, and making
     # our layouts match, visually, what the keyboard looks like, requires some
@@ -36,10 +39,11 @@ class KMKKeyboard(_KMKKeyboard):
     # just like the above three rows, however, visually speaking, the
     # top-right thumb cluster button (when looking at the left-half PCB)
     # is more inline with R3, so we'll jam that key (and its mirror) in here
-    coord_mapping.extend(ic(3, x) for x in range(6))
-    coord_mapping.append(ic(4, 2))
-    coord_mapping.append(ic(4, 9))
-    coord_mapping.extend(ic(3, x) for x in range(6, 12))  # Now, the rest of R3
+    coord_mapping.extend(ic(3, x, 6) for x in range(6))
+    coord_mapping.append(ic(4, 2, 6))
+    coord_mapping.append(ic(8, 3, 6))
+    coord_mapping.extend(ic(7, x, 6) for x in range(6))  # Now, the rest of R3
 
     # And now, to handle R4, which at this point is down to just six keys
-    coord_mapping.extend(ic(4, x) for x in range(3, 9))
+    coord_mapping.extend(ic(4, x, 6) for x in range(3, 6))
+    coord_mapping.extend(ic(8, x, 6) for x in range(0, 3))

--- a/boards/klarank.py
+++ b/boards/klarank.py
@@ -37,10 +37,10 @@ class KMKKeyboard(_KMKKeyboard):
     diode_orientation = DiodeOrientation.COLUMNS
 
     coord_mapping = []
-    coord_mapping.extend(ic(0, x) for x in range(12))
-    coord_mapping.extend(ic(1, x) for x in range(12))
-    coord_mapping.extend(ic(2, x) for x in range(12))
-    coord_mapping.extend(ic(3, r3_swap(x)) for x in range(12))
+    coord_mapping.extend(ic(0, x, 12) for x in range(12))
+    coord_mapping.extend(ic(1, x, 12) for x in range(12))
+    coord_mapping.extend(ic(2, x, 12) for x in range(12))
+    coord_mapping.extend(ic(3, r3_swap(x), 12) for x in range(12))
 
     layers_ext = Layers()
     modules = [layers_ext]

--- a/boards/lily58/kb.py
+++ b/boards/lily58/kb.py
@@ -23,10 +23,15 @@ class KMKKeyboard(_KMKKeyboard):
     powersave_pin = board.P0_13
 
     coord_mapping = []
-    coord_mapping.extend(ic(0, x) for x in range(12))
-    coord_mapping.extend(ic(1, x) for x in range(12))
-    coord_mapping.extend(ic(2, x) for x in range(12))
-    coord_mapping.extend(ic(3, x) for x in range(12))
+    coord_mapping.extend(ic(0, x, 6) for x in range(6))
+    coord_mapping.extend(ic(4, x, 6) for x in range(6))
+    coord_mapping.extend(ic(1, x, 6) for x in range(6))
+    coord_mapping.extend(ic(5, x, 6) for x in range(6))
+    coord_mapping.extend(ic(2, x, 6) for x in range(6))
+    coord_mapping.extend(ic(6, x, 6) for x in range(6))
+    coord_mapping.extend(ic(3, x, 6) for x in range(6))
+    coord_mapping.extend(ic(7, x, 6) for x in range(6))
 
     # And now, to handle R4, which at this point is down to just ten keys
-    coord_mapping.extend(ic(4, x) for x in range(1, 11))
+    coord_mapping.extend(ic(4, x, 6) for x in range(1, 6))
+    coord_mapping.extend(ic(8, x, 6) for x in range(0, 5))

--- a/boards/lunakey_pico/kb.py
+++ b/boards/lunakey_pico/kb.py
@@ -11,7 +11,13 @@ class KMKKeyboard(_KMKKeyboard):
     diode_orientation = DiodeOrientation.COLUMNS
 
     coord_mapping = []
-    coord_mapping.extend(ic(0, x) for x in range(12))
-    coord_mapping.extend(ic(1, x) for x in range(12))
-    coord_mapping.extend(ic(2, x) for x in range(12))
-    coord_mapping.extend(ic(3, x) for x in range(2, 10))
+    coord_mapping.extend(ic(0, x, 6) for x in range(6))
+    coord_mapping.extend(ic(4, x, 6) for x in range(6))
+    coord_mapping.extend(ic(1, x, 6) for x in range(6))
+    coord_mapping.extend(ic(5, x, 6) for x in range(6))
+    coord_mapping.extend(ic(2, x, 6) for x in range(6))
+    coord_mapping.extend(ic(6, x, 6) for x in range(6))
+
+    # And now, to handle R3, which at this point is down to just six keys
+    coord_mapping.extend(ic(3, x, 6) for x in range(2, 6))
+    coord_mapping.extend(ic(7, x, 6) for x in range(0, 4))

--- a/boards/reviung41/kb.py
+++ b/boards/reviung41/kb.py
@@ -30,9 +30,9 @@ class KMKKeyboard(_KMKKeyboard):
     powersave_pin = board.P0_13
 
     coord_mapping = []
-    coord_mapping.extend(ic(0, x) for x in range(12))
-    coord_mapping.extend(ic(1, x) for x in range(12))
-    coord_mapping.extend(ic(2, x) for x in range(12))
+    coord_mapping.extend(ic(0, x, 12) for x in range(12))
+    coord_mapping.extend(ic(1, x, 12) for x in range(12))
+    coord_mapping.extend(ic(2, x, 12) for x in range(12))
 
     # And now, to handle R3, which at this point is down to just five keys
-    coord_mapping.extend(ic(3, x) for x in range(5))
+    coord_mapping.extend(ic(3, x, 12) for x in range(5))

--- a/docs/porting_to_kmk.md
+++ b/docs/porting_to_kmk.md
@@ -49,9 +49,19 @@ from kmk.matrix import intify_coordinate as ic
     coord_mapping.extend(ic(6, x, 6) for x in range(6))
     # And now, to handle R3, which at this point is down to just six keys
     coord_mapping.extend(ic(3, x, 6) for x in range(3, 6))
-    coord_mapping.extend(ic(7, x, 6) for x in range(6, 9))
+    coord_mapping.extend(ic(7, x, 6) for x in range(0, 3))
 ```
 
+`intify_coordinate` is the traditional way to generate key positions.
+Here's an equivalent, maybe visually more explanatory version:
+```python
+coord_mapping = [
+ 0,  1,  2,  3,  4,  5,  24, 25, 26, 27, 28, 29,
+ 6,  7,  8,  9, 10, 11,  30, 31, 32, 33, 34, 35,
+12, 13, 14, 15, 16, 17,  36, 37, 38, 39, 40, 41,
+            21, 22, 23,  42, 43, 44,
+]
+```
 
 ## Keymaps
 Keymaps are organized as a list of lists. Keycodes are added for every key on 

--- a/docs/porting_to_kmk.md
+++ b/docs/porting_to_kmk.md
@@ -34,16 +34,22 @@ If your keyboard is not built electrically as a square (though most are), you ca
 provide a mapping directly. An example of this is the 
 [Corne](https://github.com/foostan/crkbd). That has 12 colums for 3 rows, and 6 
 colums for the bottom row. Split keyboards count as the total keyboard, not per 
-side. That would look like this
+side, the right side being offset by the number of keys on the left side, as if
+the rows were stacked.
+That would look like this
 ```python
 from kmk.matrix import intify_coordinate as ic
 
     coord_mapping = []
-    coord_mapping.extend(ic(0, x) for x in range(12))
-    coord_mapping.extend(ic(1, x) for x in range(12))
-    coord_mapping.extend(ic(2, x) for x in range(12))
+    coord_mapping.extend(ic(0, x, 6) for x in range(6))
+    coord_mapping.extend(ic(4, x, 6) for x in range(6))
+    coord_mapping.extend(ic(1, x, 6) for x in range(6))
+    coord_mapping.extend(ic(5, x, 6) for x in range(6))
+    coord_mapping.extend(ic(2, x, 6) for x in range(6))
+    coord_mapping.extend(ic(6, x, 6) for x in range(6))
     # And now, to handle R3, which at this point is down to just six keys
-    coord_mapping.extend(ic(3, x) for x in range(3, 9))
+    coord_mapping.extend(ic(3, x, 6) for x in range(3, 6))
+    coord_mapping.extend(ic(7, x, 6) for x in range(6, 9))
 ```
 
 

--- a/docs/ptBR/porting_to_kmk.md
+++ b/docs/ptBR/porting_to_kmk.md
@@ -55,7 +55,18 @@ from kmk.matrix import intify_coordinate as ic
     coord_mapping.extend(ic(6, x, 6) for x in range(6))
     # And now, to handle R3, which at this point is down to just six keys
     coord_mapping.extend(ic(3, x, 6) for x in range(3, 6))
-    coord_mapping.extend(ic(7, x, 6) for x in range(6, 9))
+    coord_mapping.extend(ic(7, x, 6) for x in range(0, 3))
+```
+
+`intify_coordinate` é a maneira tradicional de gerar posições-chave.
+Aqui está uma versão equivalente, talvez visualmente mais explicativa:
+```python
+coord_mapping = [
+ 0,  1,  2,  3,  4,  5,  24, 25, 26, 27, 28, 29,
+ 6,  7,  8,  9, 10, 11,  30, 31, 32, 33, 34, 35,
+12, 13, 14, 15, 16, 17,  36, 37, 38, 39, 40, 41,
+            21, 22, 23,  42, 43, 44,
+]
 ```
 
 ## Keymaps

--- a/docs/ptBR/porting_to_kmk.md
+++ b/docs/ptBR/porting_to_kmk.md
@@ -47,11 +47,15 @@ total, não por parte separada. Isto seria mais ou menos assim:
 from kmk.matrix import intify_coordinate as ic
 
     coord_mapping = []
-    coord_mapping.extend(ic(0, x) for x in range(12))
-    coord_mapping.extend(ic(1, x) for x in range(12))
-    coord_mapping.extend(ic(2, x) for x in range(12))
+    coord_mapping.extend(ic(0, x, 6) for x in range(6))
+    coord_mapping.extend(ic(4, x, 6) for x in range(6))
+    coord_mapping.extend(ic(1, x, 6) for x in range(6))
+    coord_mapping.extend(ic(5, x, 6) for x in range(6))
+    coord_mapping.extend(ic(2, x, 6) for x in range(6))
+    coord_mapping.extend(ic(6, x, 6) for x in range(6))
     # And now, to handle R3, which at this point is down to just six keys
-    coord_mapping.extend(ic(3, x) for x in range(3, 9))
+    coord_mapping.extend(ic(3, x, 6) for x in range(3, 6))
+    coord_mapping.extend(ic(7, x, 6) for x in range(6, 9))
 ```
 
 ## Keymaps

--- a/kmk/modules/tapdance.py
+++ b/kmk/modules/tapdance.py
@@ -51,7 +51,7 @@ class TapDance(Module):
                     keyboard.hid_pending = True
                     keyboard._send_hid()
                     keyboard.set_timeout(
-                        False, lambda: keyboard.process_key(key, is_pressed, None, None)
+                        False, lambda: keyboard.process_key(key, is_pressed)
                     )
                     return None
 


### PR DESCRIPTION
This replaces the current matrix scanners update object.
Instead of the implementation specific bytearray, there's a `KeyEvent` object inspired by circuitpythons version for their `keypad` library. Main difference to the current implementation is that keys are identified by a single number, instead of row and column.
Outstanding efforts to provide more/different scanners would benefit from this abstraction.

The code has been tested with a monolithic keyboard, and a split using UART. I don't expect there to be issues with BLE, but someone with a wireless split has to confirm.

The only breaking change is in the signature of `intifiy_coordinates`:
```python
intifiy_coordinates(row, column, number_of_columns)
```
I updated the only appearance of ic in the documentation, but I don't own a corne, so I'm half-guessing.
This is also somthing I'd appreciate help verifying.

For reference: this is more or less complimentary to #262. It's been a while since the last update though, and my previous branch is now stale, messy and broke split communication. I understand that this is a big, singular commit, but it's almost impossible to make it more atomic.
