### PR TITLE
fix bytearray.startswith not available in CircuitPython

### DIFF
--- a/kmk/hid.py
+++ b/kmk/hid.py
@@ -126,8 +126,7 @@ class AbstractHID:
         pass
 
     def send(self):
-        changed = not self._evt.startswith(self._prev_evt)
-        if changed:
+        if self._evt != self._prev_evt:
             self._prev_evt[:] = self._evt
             self.hid_send(self._evt)
 

--- a/tests/keyboard_test.py
+++ b/tests/keyboard_test.py
@@ -58,6 +58,8 @@ class KeyboardTest:
             for hid_report in hid_send_call_arg_list:
                 print(hid_report)
 
+        assert len(hid_send_call_arg_list) >= len(assert_hid_reports)
+
         for i, hid_report in enumerate(
             hid_send_call_arg_list[-len(assert_hid_reports) :]
         ):


### PR DESCRIPTION
So sorry for introducing an operation breaking bug with #288 

This will hopefully fix the issue.

@xs5871 thanks for bringing it up. Could you verify, if this fixes things and whether you notice any other problems?

I currently don't have hardware set up to test properly, which is why I added the tests in the first place. And probably relied a bit too much on those