### PR TITLE
disable hid_send on secondary split

### DIFF
--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -40,6 +40,7 @@ class KMKKeyboard:
     hid_type = HIDModes.USB
     secondary_hid_type = None
     _hid_helper = None
+    _hid_send_enabled = False
     hid_pending = False
     current_key = None
     matrix_update = None
@@ -99,7 +100,13 @@ class KMKKeyboard:
             print(self)
 
     def _send_hid(self):
-        self._hid_helper.create_report(self.keys_pressed).send()
+        if self._hid_send_enabled:
+            hid_report = self._hid_helper.create_report(self.keys_pressed)
+            try:
+                hid_report.send()
+            except KeyError as e:
+                if self.debug_enabled:
+                    print('HidNotFound(HIDReportType={})'.format(e))
         self.hid_pending = False
 
     def _handle_matrix_report(self, update=None):
@@ -272,6 +279,7 @@ class KMKKeyboard:
         else:
             self._hid_helper = AbstractHID
         self._hid_helper = self._hid_helper(**self._go_args)
+        self._hid_send_enabled = True
 
     def _init_matrix(self):
         self.matrix = self.matrix_scanner(

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -101,6 +101,9 @@ class Split(Module):
         elif self.split_side == SplitSide.RIGHT:
             self._is_target = not bool(self.split_target_left)
 
+        if not self._is_target:
+            keyboard._hid_send_enabled = False
+
         # Flips the col pins if PCB is the same but flipped on right
         if self.split_flip and self.split_side == SplitSide.RIGHT:
             keyboard.col_pins = list(reversed(keyboard.col_pins))


### PR DESCRIPTION
Potential improvement on #257, addressing #256.
Mitigates obscure ordering boundary conditions by disableing `_hid_send` entirely on a split secondary.