### PR TITLE
fix lock_status on secondary split

### DIFF
--- a/kmk/extensions/lock_status.py
+++ b/kmk/extensions/lock_status.py
@@ -37,9 +37,10 @@ class LockStatus(Extension):
         return
 
     def after_hid_send(self, sandbox):
-        report = self.hid.get_last_received_report()
-        if report[0] != self.report:
-            self.report = report[0]
+        if self.hid:
+            report = self.hid.get_last_received_report()
+            if report[0] != self.report:
+                self.report = report[0]
         return
 
     def on_powersave_enable(self, sandbox):


### PR DESCRIPTION
The lock status extionsion is throwing exceptions on split secondaries.
Turns out you can't recieve and read HID reports if there's no HID. May need further refactoring with bi-directional split communication, once implemented.