### PR TITLE
Fixed multiple encoders not working

### DIFF
--- a/kmk/modules/encoder.py
+++ b/kmk/modules/encoder.py
@@ -132,8 +132,8 @@ class EncoderHandler(Module):
                 gpio_pins = pins[:3]
                 new_encoder = Encoder(*gpio_pins)
                 # In our case, we need to define keybord and encoder_id for callbacks
-                new_encoder.on_move_do = lambda x: self.on_move_do(keyboard, idx, x)
-                new_encoder.on_button_do = lambda x: self.on_button_do(keyboard, idx, x)
+                new_encoder.on_move_do = lambda x, bound_idx = idx: self.on_move_do(keyboard, bound_idx, x)
+                new_encoder.on_button_do = lambda x, bound_idx = idx: self.on_button_do(keyboard, bound_idx, x)
                 self.encoders.append(new_encoder)
         return
 


### PR DESCRIPTION
Multiple encoders didn't work as a result of an unbound value of 'idx', the loop counter in the during_bootup method. Binding this value has fixed the issue. This has been tested on hardware (6 encoders) and is confirmed working.