### PR TITLE
Split BLE fixes

### DIFF
--- a/kmk/handlers/stock.py
+++ b/kmk/handlers/stock.py
@@ -112,3 +112,14 @@ def hid_switch(key, keyboard, *args, **kwargs):
     )
     keyboard._init_hid()
     return keyboard
+
+
+def ble_refresh(key, keyboard, *args, **kwargs):
+    from kmk.hid import HIDModes
+
+    if keyboard.hid_type != HIDModes.BLE:
+        return keyboard
+
+    keyboard._hid_helper.stop_advertising()
+    keyboard._hid_helper.start_advertising()
+    return keyboard

--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -165,6 +165,8 @@ class KeyAttrDict(AttrDict):
             )
         elif key in ('HID_SWITCH', 'HID'):
             make_key(names=('HID_SWITCH', 'HID'), on_press=handlers.hid_switch)
+        elif key in ('BLE_REFRESH'):
+            make_key(names=('BLE_REFRESH',), on_press=handlers.ble_refresh)
         else:
             maybe_key = first_truthy(
                 key,

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -263,7 +263,7 @@ class Split(Module):
 
     def ble_rescan_timer(self):
         '''If true, the rescan timer is up'''
-        return bool(check_deadline(ticks_ms(), self._ble_last_scan) > 5000)
+        return not bool(check_deadline(ticks_ms(), self._ble_last_scan, 5000))
 
     def ble_time_reset(self):
         '''Resets the rescan timer'''

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -5,10 +5,10 @@ from supervisor import runtime, ticks_ms
 
 from storage import getmount
 
+from kmk.hid import HIDModes
 from kmk.kmktime import check_deadline
 from kmk.matrix import intify_coordinate
 from kmk.modules import Module
-from kmk.hid import HIDModes
 
 
 class SplitSide:
@@ -92,7 +92,7 @@ class Split(Module):
                 self._ble = keyboard._hid_helper.ble
             else:
                 self._ble = self.BLERadio()
-            self._ble.name = name
+                self._ble.name = name
         else:
             # Try to guess data pins if not supplied
             if not self.data_pin:
@@ -208,7 +208,6 @@ class Split(Module):
         '''Validates the correct number of BLE connections'''
         self._previous_connection_count = self._connection_count
         self._connection_count = len(self._ble.connections)
-        print(self._connection_count)
         if self._is_target:
             if self._advertising or not self._check_if_split_connected():
                 self._target_advertise()
@@ -231,7 +230,7 @@ class Split(Module):
         bleio_connection = self._ble.connections[0]._bleio_connection
         connection_services = bleio_connection.discover_remote_services()
         for service in connection_services:
-            if str(service.uuid).startswith('UUID(\'adaf0001'):
+            if str(service.uuid).startswith("UUID('adaf0001"):
                 self._split_connected = True
                 return True
         return False


### PR DESCRIPTION
I couldn't make split BLE working so I started diving in it. Unfortunately I encountered many dead ends (like issues with PC Bluetooth adapter) and I couldn't recognize the simplest issue.
First commit is one line change which fixes a bug a make the split BLE useable for me.

Second commit are changes which were made around some other issues I encountered while testing:
- advertising was done till `self._connection_count < 2` condition is solved and it won't happen if you you are using Split BLE with USB HID (don't know if anybody ever tries it but...)
- while target (left) half was looking for the second (right) one, it was hanging for few seconds - theoretically you won't use only one half, but on the other - why not? I imagine left split gaming with right half saving the battery. I tried moving the connection check to the background
- the check of `self._connection_count == 1` doesn't tell if we're connected to PC and not other half or vice versa. I tried implementing a check, but the only thing I could find was `bleio_connection.discover_remote_services()` which I'm not sure if is reliable method
- I added `BLE_REFRESH` button code, because HID advertising was becoming sometimes stuck for me; I haven't noticed any BLE keybindings existing and they could be could idea (but for example, such refresh should probably not only restart advertising, but also connection)

Creating as draft, as we really need to talk about it design wise and check on multiple configuration.