### PR TITLE
Override LED creation in the RGB extension.

### DIFF
--- a/docs/rgb.md
+++ b/docs/rgb.md
@@ -147,3 +147,29 @@ Make sure that your board supports LED backlight by checking for a line with
 `PIXEL_PIN`. If it does not, you can add it to your keymap.  If you added the
 LED's yourself, you will also need to set `num_pixels` to the number of
 installed LED's in total.
+
+
+## Alternate LED chipsets
+
+Not all RGB LEDs are compatible with Neopixels. To support these, the RGB
+extension accepts an instance of a `Pixelbuf`-compatible object as an optional
+parameter. If supplied, `pixel_pin` is ignored and the supplied Pixelbuf is
+used instead of creating a Neopixel object. Note that you still need to pass
+the LED string parameters to the RGB extension so that it can manage animations
+correctly.
+
+This works easily with APA102 ("DotStar") LEDs, but for most other RGB LED
+chipsets you will need to provide a wrapper to match the expected interface.
+
+A simple example using APA102:
+```python
+import adafruit_dotstar
+from kmk.extensions.RGB import RGB
+from kb import rgb_pixel_pin  # This can be imported or defined manually
+
+_LED_COUNT=12
+pixels = adafruit_dotstar.DotStar(board.SCK, board.MOSI, _LED_COUNT)
+
+rgb_ext = RGB(pixel_pin=0, pixels=pixels, num_pixels=_LED_COUNT)
+keyboard.extensions.append(rgb_ext)
+```

--- a/kmk/extensions/rgb.py
+++ b/kmk/extensions/rgb.py
@@ -48,13 +48,17 @@ class RGB(Extension):
         user_animation=None,
         disable_auto_write=False,
         loopcounter=0,
+        pixels=None,
     ):
-        self.neopixel = neopixel.NeoPixel(
-            pixel_pin,
-            num_pixels,
-            pixel_order=rgb_order,
-            auto_write=not disable_auto_write,
-        )
+        if pixels is None:
+            self.pixels = neopixel.NeoPixel(
+                pixel_pin,
+                num_pixels,
+                pixel_order=rgb_order,
+                auto_write=not disable_auto_write,
+            )
+        else:
+            self.pixels = pixels
 
         self.rgbw = bool(len(rgb_order) == 4)
 
@@ -244,7 +248,7 @@ class RGB(Extension):
         :param val:
         :param index: Index of LED/Pixel
         '''
-        if self.neopixel:
+        if self.pixels:
             if self.rgbw:
                 self.set_rgb(self.hsv_to_rgbw(hue, sat, val), index)
             else:
@@ -257,7 +261,7 @@ class RGB(Extension):
         :param sat:
         :param val:
         '''
-        if self.neopixel:
+        if self.pixels:
             if self.rgbw:
                 self.set_rgb_fill(self.hsv_to_rgbw(hue, sat, val))
             else:
@@ -269,20 +273,20 @@ class RGB(Extension):
         :param rgb: RGB or RGBW
         :param index: Index of LED/Pixel
         '''
-        if self.neopixel and 0 <= index <= self.num_pixels - 1:
-            self.neopixel[index] = rgb
+        if self.pixels and 0 <= index <= self.num_pixels - 1:
+            self.pixels[index] = rgb
             if not self.disable_auto_write:
-                self.neopixel.show()
+                self.pixels.show()
 
     def set_rgb_fill(self, rgb):
         '''
         Takes an RGB or RGBW and displays it on all LEDs/Neopixels
         :param rgb: RGB or RGBW
         '''
-        if self.neopixel:
-            self.neopixel.fill(rgb)
+        if self.pixels:
+            self.pixels.fill(rgb)
             if not self.disable_auto_write:
-                self.neopixel.show()
+                self.pixels.show()
 
     def increase_hue(self, step=None):
         '''
@@ -403,15 +407,15 @@ class RGB(Extension):
         '''
         Turns off all LEDs/Neopixels without changing stored values
         '''
-        if self.neopixel:
+        if self.pixels:
             self.set_hsv_fill(0, 0, 0)
 
     def show(self):
         '''
         Turns on all LEDs/Neopixels without changing stored values
         '''
-        if self.neopixel:
-            self.neopixel.show()
+        if self.pixels:
+            self.pixels.show()
 
     def animate(self):
         '''


### PR DESCRIPTION
Adds an optional `pixels=` parameter to the RGB extension to allow an alternate LED driver to be used. Includes documentation with example code, but no implementation (yet).

This is split out from #262 for simplicity's sake. The Pimoroni boards will be in a future PR once these changes land, as they depend on both this PR and #329. 