### PR TITLE
Fix split flip

### DIFF
--- a/boards/boardsource/microdox/kb.py
+++ b/boards/boardsource/microdox/kb.py
@@ -2,7 +2,6 @@ import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
 from kmk.matrix import DiodeOrientation
-from kmk.matrix import intify_coordinate as ic
 
 
 class KMKKeyboard(_KMKKeyboard):
@@ -16,14 +15,10 @@ class KMKKeyboard(_KMKKeyboard):
     powersave_pin = board.P0_13
 
     # NOQA
-    coord_mapping = []
-    coord_mapping.extend(ic(0, x, 5) for x in range(5))
-    coord_mapping.extend(ic(4, x, 5) for x in range(5))
-    coord_mapping.extend(ic(1, x, 5) for x in range(5))
-    coord_mapping.extend(ic(5, x, 5) for x in range(5))
-    coord_mapping.extend(ic(2, x, 5) for x in range(5))
-    coord_mapping.extend(ic(6, x, 5) for x in range(5))
-
-    # And now, to handle R3, which at this point is down to just six keys
-    coord_mapping.extend(ic(3, x, 5) for x in range(2, 5))
-    coord_mapping.extend(ic(7, x, 5) for x in range(0, 3))
+    # flake8: noqa
+    coord_mapping = [
+     0,  1,  2,  3,  4,  20, 21, 22, 23, 24,
+     5,  6,  7,  8,  9,  25, 26, 27, 28, 29,
+    10, 11, 12, 13, 14,  30, 31, 32, 33, 34,
+            17, 18, 19,  35, 36, 37,
+    ]

--- a/boards/crkbd/kb.py
+++ b/boards/crkbd/kb.py
@@ -2,7 +2,6 @@ import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
 from kmk.matrix import DiodeOrientation
-from kmk.matrix import intify_coordinate as ic
 
 
 class KMKKeyboard(_KMKKeyboard):
@@ -21,14 +20,11 @@ class KMKKeyboard(_KMKKeyboard):
     i2c = board.I2C
     powersave_pin = board.P0_13
 
-    coord_mapping = []
-    coord_mapping.extend(ic(0, x, 6) for x in range(6))
-    coord_mapping.extend(ic(4, x, 6) for x in range(6))
-    coord_mapping.extend(ic(1, x, 6) for x in range(6))
-    coord_mapping.extend(ic(5, x, 6) for x in range(6))
-    coord_mapping.extend(ic(2, x, 6) for x in range(6))
-    coord_mapping.extend(ic(6, x, 6) for x in range(6))
+    # flake8: noqa
+    coord_mapping = [
+     0,  1,  2,  3,  4,  5,  29, 28, 27, 26, 25, 24,
+     6,  7,  8,  9, 10, 11,  35, 34, 33, 32, 31, 30,
+    12, 13, 14, 15, 16, 17,  41, 40, 39, 38, 37, 36,
+                21, 22, 23,  47, 46, 45,
+    ]
 
-    # And now, to handle R3, which at this point is down to just six keys
-    coord_mapping.extend(ic(3, x, 6) for x in range(3, 6))
-    coord_mapping.extend(ic(7, x, 6) for x in range(0, 3))

--- a/boards/crkbd/kb_rp2040.py
+++ b/boards/crkbd/kb_rp2040.py
@@ -2,7 +2,6 @@ import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
 from kmk.matrix import DiodeOrientation
-from kmk.matrix import intify_coordinate as ic
 
 
 class KMKKeyboard(_KMKKeyboard):
@@ -20,14 +19,10 @@ class KMKKeyboard(_KMKKeyboard):
     rgb_pixel_pin = board.D0
     i2c = board.I2C
 
-    coord_mapping = []
-    coord_mapping.extend(ic(0, x, 6) for x in range(6))
-    coord_mapping.extend(ic(4, x, 6) for x in range(6))
-    coord_mapping.extend(ic(1, x, 6) for x in range(6))
-    coord_mapping.extend(ic(5, x, 6) for x in range(6))
-    coord_mapping.extend(ic(2, x, 6) for x in range(6))
-    coord_mapping.extend(ic(6, x, 6) for x in range(6))
-
-    # And now, to handle R3, which at this point is down to just six keys
-    coord_mapping.extend(ic(3, x, 6) for x in range(3, 6))
-    coord_mapping.extend(ic(7, x, 6) for x in range(0, 3))
+    # flake8: noqa
+    coord_mapping = [
+     0,  1,  2,  3,  4,  5,  29, 28, 27, 26, 25, 24,
+     6,  7,  8,  9, 10, 11,  35, 34, 33, 32, 31, 30,
+    12, 13, 14, 15, 16, 17,  41, 40, 39, 38, 37, 36,
+                21, 22, 23,  47, 46, 45,
+    ]

--- a/boards/ergo_travel/kb.py
+++ b/boards/ergo_travel/kb.py
@@ -25,14 +25,10 @@ class KMKKeyboard(_KMKKeyboard):
     powersave_pin = board.P0_13
 
     # NOQA
-    coord_mapping = []
-    coord_mapping.extend(ic(0, x, 7) for x in range(7))
-    coord_mapping.extend(ic(4, x, 7) for x in range(7))
-    coord_mapping.extend(ic(1, x, 7) for x in range(7))
-    coord_mapping.extend(ic(5, x, 7) for x in range(7))
-    coord_mapping.extend(ic(2, x, 7) for x in range(7))
-    coord_mapping.extend(ic(6, x, 7) for x in range(7))
-
-    # And now, to handle R3, which at this point is down to just six keys
-    coord_mapping.extend(ic(3, x, 7) for x in range(0, 6))
-    coord_mapping.extend(ic(7, x, 7) for x in range(1, 7))
+    # flake8: noqa
+    coord_mapping = [
+     0,  1,  2,  3,  4,  5,  6,  34, 33, 32, 31, 30, 29, 28,
+     7,  8,  9, 10, 11, 12, 13,  41, 40, 39, 38, 37, 36, 35,
+    14, 15, 16, 17, 18, 19, 20,  48, 47, 46, 45, 44, 43, 42,
+    21, 22, 23, 24, 25, 26,          54, 53, 52, 51, 50, 49,
+    ]

--- a/boards/keebio/iris/kb.py
+++ b/boards/keebio/iris/kb.py
@@ -2,7 +2,6 @@ import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
 from kmk.matrix import DiodeOrientation
-from kmk.matrix import intify_coordinate as ic
 
 
 class KMKKeyboard(_KMKKeyboard):
@@ -23,14 +22,6 @@ class KMKKeyboard(_KMKKeyboard):
     data_pin = board.P0_20
     powersave_pin = board.P0_13
 
-    coord_mapping = []
-    coord_mapping.extend(ic(0, x, 6) for x in range(6))
-    coord_mapping.extend(ic(4, x, 6) for x in range(6))
-    coord_mapping.extend(ic(1, x, 6) for x in range(6))
-    coord_mapping.extend(ic(5, x, 6) for x in range(6))
-    coord_mapping.extend(ic(2, x, 6) for x in range(6))
-    coord_mapping.extend(ic(6, x, 6) for x in range(6))
-
     # Buckle up friends, the bottom row of this keyboard is wild, and making
     # our layouts match, visually, what the keyboard looks like, requires some
     # surgery on the bottom two rows of coords
@@ -39,11 +30,11 @@ class KMKKeyboard(_KMKKeyboard):
     # just like the above three rows, however, visually speaking, the
     # top-right thumb cluster button (when looking at the left-half PCB)
     # is more inline with R3, so we'll jam that key (and its mirror) in here
-    coord_mapping.extend(ic(3, x, 6) for x in range(6))
-    coord_mapping.append(ic(4, 2, 6))
-    coord_mapping.append(ic(8, 3, 6))
-    coord_mapping.extend(ic(7, x, 6) for x in range(6))  # Now, the rest of R3
-
-    # And now, to handle R4, which at this point is down to just six keys
-    coord_mapping.extend(ic(4, x, 6) for x in range(3, 6))
-    coord_mapping.extend(ic(8, x, 6) for x in range(0, 3))
+    # flake8: noqa
+    coord_mapping = [
+     0,  1,  2,  3,  4,  5,          36, 35, 34, 33, 32, 31,
+     6,  7,  8,  9, 10, 11,          42, 41, 40, 39, 38, 37,
+    12, 13, 14, 15, 16, 17,          48, 47, 46, 45, 44, 43,
+    18, 19, 20, 21, 22, 23, 26,  57, 54, 53, 52, 51, 50, 49,
+                28, 29, 30,          60, 59, 58,
+    ]

--- a/boards/keebio/iris/kb_converter.py
+++ b/boards/keebio/iris/kb_converter.py
@@ -2,7 +2,6 @@ import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
 from kmk.matrix import DiodeOrientation
-from kmk.matrix import intify_coordinate as ic
 
 
 class KMKKeyboard(_KMKKeyboard):
@@ -14,7 +13,7 @@ class KMKKeyboard(_KMKKeyboard):
     diode_orientation = DiodeOrientation.COLUMNS
 
     split_flip = True
-    split_offsets = (6, 6, 6, 6, 6)
+    split_offset = (6, 6, 6, 6, 6)
     split_type = 'UART'
     data_pin = board.SCL
     data_pin2 = board.SDA
@@ -22,14 +21,6 @@ class KMKKeyboard(_KMKKeyboard):
     i2c = board.I2C
     rgb_pixel_pin = board.TX
     led_pin = board.D7
-
-    coord_mapping = []
-    coord_mapping.extend(ic(0, x, 6) for x in range(6))
-    coord_mapping.extend(ic(4, x, 6) for x in range(6))
-    coord_mapping.extend(ic(1, x, 6) for x in range(6))
-    coord_mapping.extend(ic(5, x, 6) for x in range(6))
-    coord_mapping.extend(ic(2, x, 6) for x in range(6))
-    coord_mapping.extend(ic(6, x, 6) for x in range(6))
 
     # Buckle up friends, the bottom row of this keyboard is wild, and making
     # our layouts match, visually, what the keyboard looks like, requires some
@@ -39,11 +30,11 @@ class KMKKeyboard(_KMKKeyboard):
     # just like the above three rows, however, visually speaking, the
     # top-right thumb cluster button (when looking at the left-half PCB)
     # is more inline with R3, so we'll jam that key (and its mirror) in here
-    coord_mapping.extend(ic(3, x, 6) for x in range(6))
-    coord_mapping.append(ic(4, 2, 6))
-    coord_mapping.append(ic(8, 3, 6))
-    coord_mapping.extend(ic(7, x, 6) for x in range(6))  # Now, the rest of R3
-
-    # And now, to handle R4, which at this point is down to just six keys
-    coord_mapping.extend(ic(4, x, 6) for x in range(3, 6))
-    coord_mapping.extend(ic(8, x, 6) for x in range(0, 3))
+    # flake8: noqa
+    coord_mapping = [
+     0,  1,  2,  3,  4,  5,          36, 35, 34, 33, 32, 31,
+     6,  7,  8,  9, 10, 11,          42, 41, 40, 39, 38, 37,
+    12, 13, 14, 15, 16, 17,          48, 47, 46, 45, 44, 43,
+    18, 19, 20, 21, 22, 23, 26,  57, 54, 53, 52, 51, 50, 49,
+                28, 29, 30,          60, 59, 58,
+    ]

--- a/boards/lily58/kb.py
+++ b/boards/lily58/kb.py
@@ -2,7 +2,6 @@ import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
 from kmk.matrix import DiodeOrientation
-from kmk.matrix import intify_coordinate as ic
 
 
 class KMKKeyboard(_KMKKeyboard):
@@ -22,16 +21,11 @@ class KMKKeyboard(_KMKKeyboard):
     i2c = board.I2C
     powersave_pin = board.P0_13
 
-    coord_mapping = []
-    coord_mapping.extend(ic(0, x, 6) for x in range(6))
-    coord_mapping.extend(ic(4, x, 6) for x in range(6))
-    coord_mapping.extend(ic(1, x, 6) for x in range(6))
-    coord_mapping.extend(ic(5, x, 6) for x in range(6))
-    coord_mapping.extend(ic(2, x, 6) for x in range(6))
-    coord_mapping.extend(ic(6, x, 6) for x in range(6))
-    coord_mapping.extend(ic(3, x, 6) for x in range(6))
-    coord_mapping.extend(ic(7, x, 6) for x in range(6))
-
-    # And now, to handle R4, which at this point is down to just ten keys
-    coord_mapping.extend(ic(4, x, 6) for x in range(1, 6))
-    coord_mapping.extend(ic(8, x, 6) for x in range(0, 5))
+    # flake8: noqa
+    coord_mapping = [
+     0,  1,  2,  3,  4,  5,  36, 35, 34, 33, 32, 31,
+     6,  7,  8,  9, 10, 11,  42, 41, 40, 39, 38, 37,
+    12, 13, 14, 15, 16, 17,  48, 47, 46, 45, 44, 43,
+    18, 19, 20, 21, 22, 23,  54, 53, 52, 51, 50, 49,
+        26, 27, 28, 29, 30,  60, 59, 58, 57, 56,
+    ]

--- a/boards/lunakey_pico/kb.py
+++ b/boards/lunakey_pico/kb.py
@@ -2,7 +2,6 @@ import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
 from kmk.matrix import DiodeOrientation
-from kmk.matrix import intify_coordinate as ic
 
 
 class KMKKeyboard(_KMKKeyboard):
@@ -10,14 +9,10 @@ class KMKKeyboard(_KMKKeyboard):
     col_pins = (board.GP21, board.GP20, board.GP19, board.GP18, board.GP17, board.GP16)
     diode_orientation = DiodeOrientation.COLUMNS
 
-    coord_mapping = []
-    coord_mapping.extend(ic(0, x, 6) for x in range(6))
-    coord_mapping.extend(ic(4, x, 6) for x in range(6))
-    coord_mapping.extend(ic(1, x, 6) for x in range(6))
-    coord_mapping.extend(ic(5, x, 6) for x in range(6))
-    coord_mapping.extend(ic(2, x, 6) for x in range(6))
-    coord_mapping.extend(ic(6, x, 6) for x in range(6))
-
-    # And now, to handle R3, which at this point is down to just six keys
-    coord_mapping.extend(ic(3, x, 6) for x in range(2, 6))
-    coord_mapping.extend(ic(7, x, 6) for x in range(0, 4))
+    # flake8: noqa
+    coord_mapping = [
+     0,  1,  2,  3,  4,  5,  29, 28, 27, 26, 25, 24,
+     6,  7,  8,  9, 10, 11,  35, 34, 33, 32, 31, 30,
+    12, 13, 14, 15, 16, 17,  41, 40, 39, 38, 37, 36,
+                21, 22, 23,  47, 46, 45,
+    ]

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -115,10 +115,6 @@ class Split(Module):
         if not self._is_target:
             keyboard._hid_send_enabled = False
 
-        # Flips the col pins if PCB is the same but flipped on right
-        if self.split_flip and self.split_side == SplitSide.RIGHT:
-            keyboard.col_pins = list(reversed(keyboard.col_pins))
-
         if self.split_offset is None:
             self.split_offset = len(keyboard.col_pins) * len(keyboard.row_pins)
 
@@ -145,15 +141,21 @@ class Split(Module):
             rows_to_calc = len(keyboard.row_pins)
             cols_to_calc = len(keyboard.col_pins)
 
+            # Flips the col order if PCB is the same but flipped on right
+            cols_rhs = list(range(cols_to_calc))
+            if self.split_flip:
+                cols_rhs = list(reversed(cols_rhs))
+
             for ridx in range(rows_to_calc):
                 for cidx in range(cols_to_calc):
                     keyboard.coord_mapping.append(
                         intify_coordinate(ridx, cidx, cols_to_calc)
                     )
-                for cidx in range(cols_to_calc):
+                for cidx in cols_rhs:
                     keyboard.coord_mapping.append(
                         intify_coordinate(rows_to_calc + ridx, cidx, cols_to_calc)
                     )
+
         if self.split_side == SplitSide.RIGHT:
             keyboard.matrix.offset = self.split_offset
 


### PR DESCRIPTION
`Split.split_flip` stopped working after reordering of `_init_matrix` and `during_bootup` in #312.