### PR TITLE
Fixed IS31FL3731 LEDs on keybow 2040

### DIFF
--- a/boards/pimoroni/keybow_2040/code.py
+++ b/boards/pimoroni/keybow_2040/code.py
@@ -1,8 +1,18 @@
+from is31fl3731_pixelbuf import Keybow2040Leds
 from keybow_2040 import Keybow2040
 
+from kmk.extensions.rgb import RGB, AnimationModes
 from kmk.keys import KC
 
+rgb_ext = RGB(
+    pixel_pin=0,
+    pixels=Keybow2040Leds(16),
+    num_pixels=16,
+    animation_mode=AnimationModes.BREATHING_RAINBOW,
+)
+
 keybow = Keybow2040()
+keybow.extensions = [rgb_ext]
 
 # fmt: off
 keybow.keymap = [

--- a/boards/pimoroni/keybow_2040/is31fl3731_pixelbuf.py
+++ b/boards/pimoroni/keybow_2040/is31fl3731_pixelbuf.py
@@ -1,0 +1,26 @@
+'''
+Simple PixelBuf wrapper for the IS31FL3731 controller used for the Keybow2040's RGB LEDs.
+'''
+
+import board
+
+from adafruit_is31fl3731.keybow2040 import Keybow2040 as KeybowLeds
+from adafruit_pixelbuf import PixelBuf
+
+
+class Keybow2040Leds(PixelBuf):
+    '''
+    Minimal PixelBuf wrapper for the Keybow 2040's LED array.
+    '''
+
+    def __init__(self, size: int):
+        self.leds = KeybowLeds(board.I2C())
+        self._pixels = size
+        super().__init__(size, byteorder='RGB')
+
+    def _transmit(self, buffer):
+        for pixel in range(self._pixels):
+            r = buffer[pixel * 3 + 0]
+            g = buffer[pixel * 3 + 1]
+            b = buffer[pixel * 3 + 2]
+            self.leds.pixelrgb(pixel // 4, pixel % 4, r, g, b)

--- a/boards/pimoroni/keybow_2040/keybow_2040.py
+++ b/boards/pimoroni/keybow_2040/keybow_2040.py
@@ -23,10 +23,6 @@ key switches, then adds [BOOT] in (4,0). [RESET] can't be mapped as a key.
 
 import board
 
-from adafruit_is31fl3731.keybow2040 import Keybow2040 as KeybowLeds
-from adafruit_pixelbuf import PixelBuf
-
-# from kmk.extensions.rgb import RGB
 from kmk.kmk_keyboard import KMKKeyboard
 from kmk.scanners.native_keypad_scanner import keys_scanner
 
@@ -41,36 +37,10 @@ _KEY_CFG = [
 # fmt: on
 
 
-class Keybow2040Leds(PixelBuf):
-    '''
-    Minimal PixelBuf wrapper for the Keybow 2040's LED array.
-
-    NOTE: Currently broken.
-    '''
-
-    def __init__(self, size: int):
-        self.leds = KeybowLeds(board.I2C)
-        super().__init__(size, byteorder='RGB')
-
-    def _transmit(self, buffer):
-        for pixel in range(self._pixels):
-            r = buffer[pixel * 3 + 0]
-            g = buffer[pixel * 3 + 1]
-            b = buffer[pixel * 3 + 2]
-            self.leds.pixel(pixel // 4, pixel % 4, (r, g, b))
-
-
-# rgb_ext = RGB(0, pixels=Keybow2040Leds(16), num_pixels=16)
-
-
 class Keybow2040(KMKKeyboard):
     '''
     Default keyboard config for the Keybow2040.
-
-    TODO: Map the LEDs as well.
     '''
-
-    # extensions = [rgb_ext]
 
     def __init__(self):
         self.matrix = keys_scanner(_KEY_CFG)


### PR DESCRIPTION
The IS31FL3731 that the Keybow2040 uses is actually a fairly complex beast - it can even do basic video stuff on a bunch of LEDs!

Since the adafruit driver for it has a bunch of implementation-specific stuff, using this for the keybow2040 isn't necessarily going to be directly comparable to using it in any other case so I left the wrapper class in the board directory rather than putting it somewhere shared.

Turning this into a more generic wrapper that we can use with any RGB driver is pretty trivial, to the point where it's almost not worth doing. It'll really only end up reducing the number of copied lines for by 4-5 for most cases anyway.