### PR TITLE
Refactor split module

### DIFF
--- a/docs/ptBR/split_keyboards.md
+++ b/docs/ptBR/split_keyboards.md
@@ -47,7 +47,6 @@ split = Split(
     uart_interval=20,  # Sets the uarts delay. Lower numbers draw more power
     data_pin=None,  # The primary data pin to talk to the secondary device with
     data_pin2=None,  # Second uart pin to allow 2 way communication
-    target_left=True,  # Assumes that left will be the one on USB. Set to folse if it will be the right
     uart_flip=True,  # Reverses the RX and TX pins if both are provided
 )
 

--- a/docs/split_keyboards.md
+++ b/docs/split_keyboards.md
@@ -39,7 +39,6 @@ split = Split(
     uart_interval=20,  # Sets the uarts delay. Lower numbers draw more power
     data_pin=None,  # The primary data pin to talk to the secondary device with
     data_pin2=None,  # Second uart pin to allow 2 way communication
-    target_left=True,  # Assumes that left will be the one on USB. Set to folse if it will be the right
     uart_flip=True,  # Reverses the RX and TX pins if both are provided
     use_pio=False,  # Use RP2040 PIO implementation of UART. Required if you want to use other pins than RX/TX
 )

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -1,11 +1,8 @@
 '''Enables splitting keyboards wirelessly or wired'''
-import busio
 from micropython import const
-from supervisor import runtime, ticks_ms
 
 from storage import getmount
 
-from kmk.kmktime import check_deadline
 from kmk.matrix import KeyEvent, intify_coordinate
 from kmk.modules import Module
 
@@ -23,7 +20,7 @@ class SplitType:
 
 
 class Split(Module):
-    '''Enables splitting keyboards wirelessly, or wired'''
+    '''Enables splitting keyboards wirelessly, or wired. Wrapper around other Split modules.'''
 
     def __init__(
         self,
@@ -34,83 +31,93 @@ class Split(Module):
         uart_interval=20,
         data_pin=None,
         data_pin2=None,
-        target_left=True,
         uart_flip=True,
         use_pio=False,
         debug_enabled=False,
     ):
-        self._is_target = True
-        self._uart_buffer = []
-        self.split_flip = split_flip
-        self.split_side = split_side
-        self.split_type = split_type
-        self.split_target_left = split_target_left
-        self.split_offset = None
-        self.data_pin = data_pin
-        self.data_pin2 = data_pin2
-        self.target_left = target_left
-        self.uart_flip = uart_flip
-        self._use_pio = use_pio
-        self._uart = None
-        self._uart_interval = uart_interval
-        self._debug_enabled = debug_enabled
-        self.uart_header = bytearray([0xB2])  # Any non-zero byte should work
 
-        if self.split_type == SplitType.BLE:
-            try:
-                from adafruit_ble import BLERadio
-                from adafruit_ble.advertising.standard import (
-                    ProvideServicesAdvertisement,
+        if split_type == SplitType.UART:
+            if use_pio:
+                from kmk.transports.pio_split import PioSplit
+
+                self.protocol = PioSplit(
+                    split_flip=split_flip,
+                    split_side=split_side,
+                    split_target_left=split_target_left,
+                    uart_interval=uart_interval,
+                    data_pin=data_pin,
+                    data_pin2=data_pin2,
+                    uart_flip=uart_flip,
                 )
-                from adafruit_ble.services.nordic import UARTService
+            else:
+                from kmk.transports.uart_split import UartSplit
 
-                self.ProvideServicesAdvertisement = ProvideServicesAdvertisement
-                self.UARTService = UARTService
-            except ImportError:
-                print('BLE Import error')
-                return  # BLE isn't supported on this platform
-            self._ble = BLERadio()
-            self._ble_last_scan = ticks_ms() - 5000
-            self._connection_count = 0
-            self._uart_connection = None
-            self._advertisment = None
-            self._advertising = False
-            self._psave_enable = False
+                self.protocol = UartSplit(
+                    split_flip=split_flip,
+                    split_side=split_side,
+                    split_target_left=split_target_left,
+                    uart_interval=uart_interval,
+                    data_pin=data_pin,
+                    data_pin2=data_pin2,
+                    uart_flip=uart_flip,
+                )
+        elif split_type == SplitType.BLE:
+            from kmk.transports.ble_split import BleSplit
 
-        if self._use_pio:
-            from kmk.transports.pio_uart import PIO_UART
-
-            self.PIO_UART = PIO_UART
+            self.protocol = BleSplit(
+                split_flip=split_flip,
+                split_side=split_side,
+                split_target_left=split_target_left,
+                uart_interval=uart_interval,
+                debug_enabled=debug_enabled,
+            )
+        elif split_type == SplitType.I2C:
+            raise NotImplementedError
+        elif split_type == SplitType.ONEWIRE:
+            raise NotImplementedError
 
     def during_bootup(self, keyboard):
-        # Set up name for target side detection and BLE advertisment
-        name = str(getmount('/').label)
-        if self.split_type == SplitType.BLE:
-            self._ble.name = name
-        else:
-            # Try to guess data pins if not supplied
-            if not self.data_pin:
-                self.data_pin = keyboard.data_pin
+        self.protocol.during_bootup(keyboard)
 
-        # if split side was given, find master from split_side.
-        if self.split_side == SplitSide.LEFT:
-            self._is_target = bool(self.split_target_left)
-        elif self.split_side == SplitSide.RIGHT:
-            self._is_target = not bool(self.split_target_left)
-        else:
-            # Detect split side from name
-            if (
-                self.split_type == SplitType.UART
-                or self.split_type == SplitType.ONEWIRE
-            ):
-                self._is_target = runtime.usb_connected
-            elif self.split_type == SplitType.BLE:
-                self._is_target = name.endswith('L') == self.split_target_left
+    def before_matrix_scan(self, keyboard):
+        self.protocol.before_matrix_scan(keyboard)
 
-            if name.endswith('L'):
-                self.split_side = SplitSide.LEFT
-            elif name.endswith('R'):
-                self.split_side = SplitSide.RIGHT
+    def after_matrix_scan(self, keyboard):
+        self.protocol.after_matrix_scan(keyboard)
+
+    def before_hid_send(self, keyboard):
+        self.protocol.before_hid_send(keyboard)
+
+    def after_hid_send(self, keyboard):
+        self.protocol.after_hid_send(keyboard)
+
+    def on_powersave_enable(self, keyboard):
+        self.protocol.on_powersave_enable(keyboard)
+
+    def on_powersave_disable(self, keyboard):
+        self.protocol.on_powersave_disable(keyboard)
+
+
+class AbstractSplit(Module):
+    def __init__(
+        self,
+        *,
+        split_flip=True,
+        split_side=None,
+        split_target_left=True,
+    ):
+        self._is_target = True
+        self.split_flip = split_flip
+        self.split_side = split_side
+        self.split_target_left = split_target_left
+        self.split_offset = None
+
+        self.UPDATE_SIZE = 2
+        # Headers differentiate updates types
+        self.MATRIX_HEADER = bytearray([0xB2])
+
+    def during_bootup(self, keyboard):
+        self._detect_sides_and_target()
 
         if not self._is_target:
             keyboard._hid_send_enabled = False
@@ -118,22 +125,48 @@ class Split(Module):
         if self.split_offset is None:
             self.split_offset = len(keyboard.col_pins) * len(keyboard.row_pins)
 
-        if self.split_type == SplitType.UART and self.data_pin is not None:
-            if self._is_target or not self.uart_flip:
-                if self._use_pio:
-                    self._uart = self.PIO_UART(tx=self.data_pin2, rx=self.data_pin)
-                else:
-                    self._uart = busio.UART(
-                        tx=self.data_pin2, rx=self.data_pin, timeout=self._uart_interval
-                    )
-            else:
-                if self._use_pio:
-                    self._uart = self.PIO_UART(tx=self.data_pin, rx=self.data_pin2)
-                else:
-                    self._uart = busio.UART(
-                        tx=self.data_pin, rx=self.data_pin2, timeout=self._uart_interval
-                    )
+        self._fill_missing_coord_mapping(keyboard)
 
+        if self.split_side == SplitSide.RIGHT:
+            keyboard.matrix.offset = self.split_offset
+
+    def before_matrix_scan(self, keyboard):
+        raise NotImplementedError('subclasses must override before_matrix_scan()!')
+
+    def after_matrix_scan(self, keyboard):
+        raise NotImplementedError('subclasses must override after_matrix_scan()!')
+
+    def before_hid_send(self, keyboard):
+        if not self._is_target:
+            keyboard.hid_pending = False
+
+    def after_hid_send(self, keyboard):
+        pass
+
+    def on_powersave_enable(self, keyboard):
+        pass
+
+    def on_powersave_disable(self, keyboard):
+        pass
+
+    def _detect_sides_and_target(self):
+        # Set up name for target side detection
+        name = str(getmount('/').label)
+
+        # if split side was given, find master from split_side.
+        if self.split_side == SplitSide.LEFT:
+            self._is_target = bool(self.split_target_left)
+        elif self.split_side == SplitSide.RIGHT:
+            self._is_target = not bool(self.split_target_left)
+        else:
+            self._is_target = name.endswith('L') == self.split_target_left
+
+            if name.endswith('L'):
+                self.split_side = SplitSide.LEFT
+            elif name.endswith('R'):
+                self.split_side = SplitSide.RIGHT
+
+    def _fill_missing_coord_mapping(self, keyboard):
         # Attempt to sanely guess a coord_mapping if one is not provided.
         if not keyboard.coord_mapping:
             keyboard.coord_mapping = []
@@ -156,132 +189,8 @@ class Split(Module):
                         intify_coordinate(rows_to_calc + ridx, cidx, cols_to_calc)
                     )
 
-        if self.split_side == SplitSide.RIGHT:
-            keyboard.matrix.offset = self.split_offset
-
-    def before_matrix_scan(self, keyboard):
-        if self.split_type == SplitType.BLE:
-            self._check_all_connections()
-            self._receive_ble(keyboard)
-        elif self.split_type == SplitType.UART:
-            if self._is_target or self.data_pin2:
-                self._receive_uart(keyboard)
-        elif self.split_type == SplitType.ONEWIRE:
-            pass  # Protocol needs written
-        return
-
-    def after_matrix_scan(self, keyboard):
-        if keyboard.matrix_update:
-            if self.split_type == SplitType.UART and self._is_target:
-                pass  # explicit pass just for dev sanity...
-
-            if self.split_type == SplitType.UART and (
-                self.data_pin2 or not self._is_target
-            ):
-                self._send_uart(keyboard.matrix_update)
-            elif self.split_type == SplitType.BLE:
-                self._send_ble(keyboard.matrix_update)
-            elif self.split_type == SplitType.ONEWIRE:
-                pass  # Protocol needs written
-            else:
-                print('Unexpected case in after_matrix_scan')
-
-        return
-
-    def before_hid_send(self, keyboard):
-        if not self._is_target:
-            keyboard.hid_pending = False
-
-        return
-
-    def after_hid_send(self, keyboard):
-        return
-
-    def on_powersave_enable(self, keyboard):
-        if self.split_type == SplitType.BLE:
-            if self._uart_connection and not self._psave_enable:
-                self._uart_connection.connection_interval = self._uart_interval
-                self._psave_enable = True
-
-    def on_powersave_disable(self, keyboard):
-        if self.split_type == SplitType.BLE:
-            if self._uart_connection and self._psave_enable:
-                self._uart_connection.connection_interval = 11.25
-                self._psave_enable = False
-
-    def _check_all_connections(self):
-        '''Validates the correct number of BLE connections'''
-        self._connection_count = len(self._ble.connections)
-        if self._is_target and self._connection_count < 2:
-            self._target_advertise()
-        elif not self._is_target and self._connection_count < 1:
-            self._initiator_scan()
-
-    def _initiator_scan(self):
-        '''Scans for target device'''
-        self._uart = None
-        self._uart_connection = None
-        # See if any existing connections are providing UARTService.
-        self._connection_count = len(self._ble.connections)
-        if self._connection_count > 0 and not self._uart:
-            for connection in self._ble.connections:
-                if self.UARTService in connection:
-                    self._uart_connection = connection
-                    self._uart_connection.connection_interval = 11.25
-                    self._uart = self._uart_connection[self.UARTService]
-                    break
-
-        if not self._uart:
-            if self._debug_enabled:
-                print('Scanning')
-            self._ble.stop_scan()
-            for adv in self._ble.start_scan(
-                self.ProvideServicesAdvertisement, timeout=20
-            ):
-                if self._debug_enabled:
-                    print('Scanning')
-                if self.UARTService in adv.services and adv.rssi > -70:
-                    self._uart_connection = self._ble.connect(adv)
-                    self._uart_connection.connection_interval = 11.25
-                    self._uart = self._uart_connection[self.UARTService]
-                    self._ble.stop_scan()
-                    if self._debug_enabled:
-                        print('Scan complete')
-                    break
-        self._ble.stop_scan()
-
-    def _target_advertise(self):
-        '''Advertises the target for the initiator to find'''
-        self._ble.stop_advertising()
-        if self._debug_enabled:
-            print('Advertising')
-        # Uart must not change on this connection if reconnecting
-        if not self._uart:
-            self._uart = self.UARTService()
-        advertisement = self.ProvideServicesAdvertisement(self._uart)
-
-        self._ble.start_advertising(advertisement)
-
-        self.ble_time_reset()
-        while not self.ble_rescan_timer():
-            self._connection_count = len(self._ble.connections)
-            if self._connection_count > 1:
-                self.ble_time_reset()
-                if self._debug_enabled:
-                    print('Advertising complete')
-                break
-        self._ble.stop_advertising()
-
-    def ble_rescan_timer(self):
-        '''If true, the rescan timer is up'''
-        return bool(check_deadline(ticks_ms(), self._ble_last_scan) > 5000)
-
-    def ble_time_reset(self):
-        '''Resets the rescan timer'''
-        self._ble_last_scan = ticks_ms()
-
     def _serialize_update(self, update):
-        buffer = bytearray(2)
+        buffer = bytearray(self.UPDATE_SIZE)
         buffer[0] = update.key_number
         buffer[1] = update.pressed
         return buffer
@@ -290,59 +199,6 @@ class Split(Module):
         kevent = KeyEvent(key_number=update[0], pressed=update[1])
         return kevent
 
-    def _send_ble(self, update):
-        if self._uart:
-            try:
-                self._uart.write(self._serialize_update(update))
-            except OSError:
-                try:
-                    self._uart.disconnect()
-                except:  # noqa: E722
-                    if self._debug_enabled:
-                        print('UART disconnect failed')
-
-                if self._debug_enabled:
-                    print('Connection error')
-                self._uart_connection = None
-                self._uart = None
-
-    def _receive_ble(self, keyboard):
-        if self._uart is not None and self._uart.in_waiting > 0 or self._uart_buffer:
-            while self._uart.in_waiting >= 2:
-                update = self._deserialize_update(self._uart.read(2))
-                self._uart_buffer.append(update)
-            if self._uart_buffer:
-                keyboard.secondary_matrix_update = self._uart_buffer.pop(0)
-
     def _checksum(self, update):
         checksum = bytes([sum(update) & 0xFF])
-
         return checksum
-
-    def _send_uart(self, update):
-        # Change offsets depending on where the data is going to match the correct
-        # matrix location of the receiever
-        if self._uart is not None:
-            update = self._serialize_update(update)
-            self._uart.write(self.uart_header)
-            self._uart.write(update)
-            self._uart.write(self._checksum(update))
-
-    def _receive_uart(self, keyboard):
-        if self._uart is not None and self._uart.in_waiting > 0 or self._uart_buffer:
-            if self._uart.in_waiting >= 60:
-                # This is a dirty hack to prevent crashes in unrealistic cases
-                import microcontroller
-
-                microcontroller.reset()
-
-            while self._uart.in_waiting >= 4:
-                # Check the header
-                if self._uart.read(1) == self.uart_header:
-                    update = self._uart.read(2)
-
-                    # check the checksum
-                    if self._checksum(update) == self._uart.read(1):
-                        self._uart_buffer.append(self._deserialize_update(update))
-            if self._uart_buffer:
-                keyboard.secondary_matrix_update = self._uart_buffer.pop(0)

--- a/kmk/transports/ble_split.py
+++ b/kmk/transports/ble_split.py
@@ -1,0 +1,177 @@
+from supervisor import ticks_ms
+
+from storage import getmount
+
+from kmk.kmktime import check_deadline
+from kmk.modules.split import AbstractSplit
+
+
+class BleSplit(AbstractSplit):
+    '''Enables splitting keyboards wirelessly'''
+
+    def __init__(
+        self,
+        *,
+        split_flip=True,
+        split_side=None,
+        split_target_left=True,
+        uart_interval=20,
+        debug_enabled=False,
+    ):
+        super().__init__(
+            split_flip=split_flip,
+            split_side=split_side,
+            split_target_left=split_target_left,
+        )
+        self._uart_interval = uart_interval
+        self._debug_enabled = debug_enabled
+
+        self._uart = None
+        self._uart_buffer = []
+
+        # BLE imports and inits
+        try:
+            from adafruit_ble import BLERadio
+            from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+            from adafruit_ble.services.nordic import UARTService
+
+            self.ProvideServicesAdvertisement = ProvideServicesAdvertisement
+            self.UARTService = UARTService
+        except ImportError:
+            print('BLE Import error')
+            return  # BLE isn't supported on this platform
+        self._ble = BLERadio()
+        self._ble_last_scan = ticks_ms() - 5000
+        self._connection_count = 0
+        self._uart_connection = None
+        self._advertisment = None
+        self._advertising = False
+        self._psave_enable = False
+
+    def during_bootup(self, keyboard):
+        super().during_bootup(keyboard)
+
+        # Set up name for BLE advertisment
+        name = str(getmount('/').label)
+        self._ble.name = name
+
+    def before_matrix_scan(self, keyboard):
+        self._check_all_connections()
+        self._receive_ble(keyboard)
+
+    def after_matrix_scan(self, keyboard):
+        if keyboard.matrix_update:
+            self._send_ble(keyboard.matrix_update)
+
+    def on_powersave_enable(self, keyboard):
+        if self._uart_connection and not self._psave_enable:
+            self._uart_connection.connection_interval = self._uart_interval
+            self._psave_enable = True
+
+    def on_powersave_disable(self, keyboard):
+        if self._uart_connection and self._psave_enable:
+            self._uart_connection.connection_interval = 11.25
+            self._psave_enable = False
+
+    def _send_ble(self, update):
+        if self._uart:
+            try:
+                update = self._serialize_update(update)
+                self._uart.write(self.MATRIX_HEADER)
+                self._uart.write(update)
+                self._uart.write(self._checksum(update))
+            except OSError:
+                try:
+                    self._uart.disconnect()
+                except:  # noqa: E722
+                    if self._debug_enabled:
+                        print('UART disconnect failed')
+
+                if self._debug_enabled:
+                    print('Connection error')
+                self._uart_connection = None
+                self._uart = None
+
+    def _receive_ble(self, keyboard):
+        if self._uart is not None and self._uart.in_waiting > 0 or self._uart_buffer:
+            while self._uart.in_waiting >= self.UPDATE_SIZE + 2:
+                # Check the header
+                if self._uart.read(1) == self.MATRIX_HEADER:
+                    update = self._uart.read(self.UPDATE_SIZE)
+
+                    # check the checksum
+                    if self._checksum(update) == self._uart.read(1):
+                        self._uart_buffer.append(self._deserialize_update(update))
+            if self._uart_buffer:
+                keyboard.secondary_matrix_update = self._uart_buffer.pop(0)
+
+    def _check_all_connections(self):
+        '''Validates the correct number of BLE connections'''
+        self._connection_count = len(self._ble.connections)
+        if self._is_target and self._connection_count < 2:
+            self._target_advertise()
+        elif not self._is_target and self._connection_count < 1:
+            self._initiator_scan()
+
+    def _initiator_scan(self):
+        '''Scans for target device'''
+        self._uart = None
+        self._uart_connection = None
+        # See if any existing connections are providing UARTService.
+        self._connection_count = len(self._ble.connections)
+        if self._connection_count > 0 and not self._uart:
+            for connection in self._ble.connections:
+                if self.UARTService in connection:
+                    self._uart_connection = connection
+                    self._uart_connection.connection_interval = 11.25
+                    self._uart = self._uart_connection[self.UARTService]
+                    break
+
+        if not self._uart:
+            if self._debug_enabled:
+                print('Scanning')
+            self._ble.stop_scan()
+            for adv in self._ble.start_scan(
+                self.ProvideServicesAdvertisement, timeout=20
+            ):
+                if self._debug_enabled:
+                    print('Scanning')
+                if self.UARTService in adv.services and adv.rssi > -70:
+                    self._uart_connection = self._ble.connect(adv)
+                    self._uart_connection.connection_interval = 11.25
+                    self._uart = self._uart_connection[self.UARTService]
+                    self._ble.stop_scan()
+                    if self._debug_enabled:
+                        print('Scan complete')
+                    break
+        self._ble.stop_scan()
+
+    def _target_advertise(self):
+        '''Advertises the target for the initiator to find'''
+        self._ble.stop_advertising()
+        if self._debug_enabled:
+            print('Advertising')
+        # Uart must not change on this connection if reconnecting
+        if not self._uart:
+            self._uart = self.UARTService()
+        advertisement = self.ProvideServicesAdvertisement(self._uart)
+
+        self._ble.start_advertising(advertisement)
+
+        self.ble_time_reset()
+        while not self.ble_rescan_timer():
+            self._connection_count = len(self._ble.connections)
+            if self._connection_count > 1:
+                self.ble_time_reset()
+                if self._debug_enabled:
+                    print('Advertising complete')
+                break
+        self._ble.stop_advertising()
+
+    def ble_rescan_timer(self):
+        '''If true, the rescan timer is up'''
+        return not bool(check_deadline(ticks_ms(), self._ble_last_scan, 5000))
+
+    def ble_time_reset(self):
+        '''Resets the rescan timer'''
+        self._ble_last_scan = ticks_ms()

--- a/kmk/transports/pio_split.py
+++ b/kmk/transports/pio_split.py
@@ -1,0 +1,23 @@
+from kmk.modules.split import AbstractSplit
+from kmk.transports.pio_uart import PIO_UART
+from kmk.transports.uart_split import UartSplit
+
+
+class PioSplit(UartSplit):
+    '''Enables splitting wired keyboards using RP2040'''
+
+    def during_bootup(self, keyboard):
+        AbstractSplit.during_bootup(self, keyboard)
+
+        # Fallback to default data pin in keyboard config
+        if not self.data_pin:
+            self.data_pin = keyboard.data_pin
+
+        if self.data_pin is None:
+            raise Exception('UART Split requires data_pin argument')
+
+        # Init the protocol
+        if self._is_target or not self.uart_flip:
+            self._uart = PIO_UART(tx=self.data_pin2, rx=self.data_pin)
+        else:
+            self._uart = PIO_UART(tx=self.data_pin, rx=self.data_pin2)

--- a/kmk/transports/uart_split.py
+++ b/kmk/transports/uart_split.py
@@ -1,0 +1,102 @@
+import busio
+from supervisor import runtime
+
+from storage import getmount
+
+from kmk.modules.split import AbstractSplit, SplitSide
+
+
+class UartSplit(AbstractSplit):
+    '''Enables splitting wired keyboards'''
+
+    def __init__(
+        self,
+        *,
+        split_flip=True,
+        split_side=None,
+        split_target_left=True,
+        uart_interval=20,
+        data_pin=None,
+        data_pin2=None,
+        uart_flip=True,
+    ):
+        super().__init__(
+            split_flip=split_flip,
+            split_side=split_side,
+            split_target_left=split_target_left,
+        )
+        self._uart_interval = uart_interval
+        self.data_pin = data_pin
+        self.data_pin2 = data_pin2
+        self.uart_flip = uart_flip
+
+        self._uart = None
+        self._uart_buffer = []
+
+    def during_bootup(self, keyboard):
+        super().during_bootup(keyboard)
+
+        # Fallback to default data pin in keyboard config
+        if not self.data_pin:
+            self.data_pin = keyboard.data_pin
+
+        if self.data_pin is None:
+            raise Exception('UART Split requires data_pin argument')
+
+        # Init the protocol
+        if self._is_target or not self.uart_flip:
+            self._uart = busio.UART(
+                tx=self.data_pin2, rx=self.data_pin, timeout=self._uart_interval
+            )
+        else:
+            self._uart = busio.UART(
+                tx=self.data_pin, rx=self.data_pin2, timeout=self._uart_interval
+            )
+
+    def before_matrix_scan(self, keyboard):
+        if self._is_target or self.data_pin2:
+            self._receive_uart(keyboard)
+
+    def after_matrix_scan(self, keyboard):
+        if keyboard.matrix_update and (self.data_pin2 or not self._is_target):
+            self._send_uart(keyboard.matrix_update)
+
+    def _detect_sides_and_target(self):
+        name = str(getmount('/').label)
+
+        if self.split_side is None:
+            self._is_target = runtime.usb_connected
+            if name.endswith('L'):
+                self.split_side = SplitSide.LEFT
+            elif name.endswith('R'):
+                self.split_side = SplitSide.RIGHT
+        else:
+            super()._detect_sides_and_target()
+
+    def _send_uart(self, update):
+        # Change offsets depending on where the data is going to match the correct
+        # matrix location of the receiver
+        if self._uart is not None:
+            update = self._serialize_update(update)
+            self._uart.write(self.MATRIX_HEADER)
+            self._uart.write(update)
+            self._uart.write(self._checksum(update))
+
+    def _receive_uart(self, keyboard):
+        if self._uart is not None and self._uart.in_waiting > 0 or self._uart_buffer:
+            if self._uart.in_waiting >= 60:
+                # This is a dirty hack to prevent crashes in unrealistic cases
+                import microcontroller
+
+                microcontroller.reset()
+
+            while self._uart.in_waiting >= self.UPDATE_SIZE + 2:
+                # Check the header
+                if self._uart.read(1) == self.MATRIX_HEADER:
+                    update = self._uart.read(self.UPDATE_SIZE)
+
+                    # check the checksum
+                    if self._checksum(update) == self._uart.read(1):
+                        self._uart_buffer.append(self._deserialize_update(update))
+            if self._uart_buffer:
+                keyboard.secondary_matrix_update = self._uart_buffer.pop(0)


### PR DESCRIPTION
In relation to #323, I tried starting such abstraction of Split module.
The structure is following:
```
AbstractSplit
└─ UartSplit
│   └─ PioSplit
└─ BleSplit
```
I tried to extract common code to `AbstractSplit`, but also not to change any logic so far. There is still a bit of common code, but I didn't want to introduce any drastic changes yet.

It is possible now to just initialize `UartSplit()` or `PioSplit()`, but old `Split(split_type=SplitType.UART, use_pio=True)` will still work as I left it as wrapper for backward compatibility. I don't know which form would you rather see in docs. I even tested the situation where left board got new code after these changes and right board got current master and everything worked. The only drastic change is removal of `target_left` argument as it did nothing at all.

Having an opportunity, I did minor improvements of BLE. While my #328 draft got more drastic changes, here I just made minimal required changes to make BLE split work again and introduced the same header/checksum as in UartSplit. It worked on my tiny test bed.

Regarding future, I see we will probably introduce different headers, for different message type. Still I don't have clear vision how to make other modules and extensions to plug in to such messages in best way.

I'm looking forward to feedback.