### PR TITLE
fix keypad matrix init and unguarded debug print.

### DIFF
--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -297,7 +297,8 @@ class KMKKeyboard:
 
     def _init_matrix(self):
         if self.matrix is None:
-            print('Initialising matrix scanner from self.matrix_scanner')
+            if self.debug_enabled:
+                print('Initialising matrix scanner from self.matrix_scanner')
             self.matrix = self.matrix_scanner(
                 cols=self.col_pins,
                 rows=self.row_pins,
@@ -307,7 +308,8 @@ class KMKKeyboard:
                 ),
             )
         else:
-            print('Matrix scanner already set, not overwriting.')
+            if self.debug_enabled:
+                print('Matrix scanner already set, not overwriting.')
 
         return self
 

--- a/kmk/scanners/native_keypad_scanner.py
+++ b/kmk/scanners/native_keypad_scanner.py
@@ -42,7 +42,9 @@ def keypad_matrix(row_pins, col_pins, direction=DiodeOrientation.COLUMNS):
     pin_map = [
         (row, col) for row in range(len(row_pins)) for col in range(len(col_pins))
     ]
-    kp = keypad.KeyMatrix(row_pins, col_pins, direction == DiodeOrientation.COLUMNS)
+    kp = keypad.KeyMatrix(
+        row_pins, col_pins, columns_to_anodes=(direction == DiodeOrientation.COLUMNS)
+    )
     return NativeKeypadScanner(pin_map, kp)
 
 


### PR DESCRIPTION
keypad needs diode direction as name argument, and debug output wasn't conditional.