### PR TITLE
Fix _find_key_in_map callings

### DIFF
--- a/kmk/modules/layers.py
+++ b/kmk/modules/layers.py
@@ -73,13 +73,13 @@ class Layers(HoldTap):
             # on interrupt: key must be translated here, because it was asigned
             # before the layer shift happend.
             if state.activated == ActivationType.INTERRUPTED:
-                current_key = keyboard._find_key_in_map(int_coord, None, None)
+                current_key = keyboard._find_key_in_map(int_coord)
 
         return current_key
 
     def send_key_buffer(self, keyboard):
         for (int_coord, old_key) in self.key_buffer:
-            new_key = keyboard._find_key_in_map(int_coord, None, None)
+            new_key = keyboard._find_key_in_map(int_coord)
 
             # adding keys late to _coordkeys_pressed isn't pretty,
             # but necessary to mitigate race conditions when multiple


### PR DESCRIPTION
KC.MT(), typing the specified key would occasionally stop with the following error

```
  ファイル "main.py", 行 86, in <module>
  ファイル "/lib/kmk/kmk_keyboard.py", 行 408, in go
  ファイル "/lib/kmk/kmk_keyboard.py", 行 458, in _main_loop
  ファイル "/lib/kmk/kmk_keyboard.py", 行 115, in _handle_matrix_report
  ファイル "/lib/kmk/kmk_keyboard.py", 行 181, in _on_matrix_changed
  ファイル "/lib/kmk/kmk_keyboard.py", 行 189, in process_key
  ファイル "/lib/kmk/keys.py", 行 429, in on_release
  ファイル "/lib/kmk/modules/layers.py", 行 21, in curried
  ファイル "/lib/kmk/modules/holdtap.py", 行 113, in ht_released
  ファイル "/lib/kmk/modules/layers.py", 行 82, in send_key_buffer
TypeError: function takes 2 positional arguments but 4 were given
```

As the error message says, it seems that there are too many arguments to call `_find_key_in_map`.