### PR TITLE
Support for rotary encoders using `rotaryio`

### DIFF
--- a/docs/rotaryio_encoders.md
+++ b/docs/rotaryio_encoders.md
@@ -1,0 +1,50 @@
+The module `RotaryIOEncoder` is a wrapper around `rotaryio`  (see [here](https://docs.circuitpython.org/en/latest/shared-bindings/rotaryio/index.html#module-rotaryio)). `rotaryio` has a quirk: encoders must use pins that are consecutive (for example GP16 and GP17 on a Raspberry Pi pico). 
+
+`RotaryIOEncoder` supports using multiple encoders at the same time, each with its own keymap (multiple layers are allowed).
+
+Press buttons are not supported, you should include them in your matrix or wait for the `keypad` module (available in CircuitPython 7.0.0) to be integrated in KMK.
+
+The following is a complete example (you can use it as your `code.py`) of how to use `RotaryIOEncoder`. The example uses `"divisor" = 2` because it was tested using [this](https://www.adafruit.com/product/5001) scrollwheel, but for most cases `"divisor": 4` should work.
+
+```
+import board
+
+from kmk.kmk_keyboard import KMKKeyboard
+from kmk.matrix import DiodeOrientation
+from kmk.keys import KC
+from kmk.modules.rotaryio_encoder import RotaryIOEncoder
+from kmk.modules.mouse_keys import MouseKeys
+
+keyboard = KMKKeyboard()
+
+# We want to use the encoder to scroll so we need mouse keys
+keyboard.modules.append(MouseKeys())
+
+# In this example we use only one encoder, connected to the pin 16 and 16
+# of a raspberry pi pico.
+enc1 = {"pin_a": board.GP17,
+            "pin_b": board.GP16,
+            "divisor": 2,
+            "keymap": [[KC.MW_UP, KC.MW_DN],]
+            }
+
+encoders = RotaryIOEncoder((enc1,))
+
+keyboard.modules.append(encoders)
+
+# Matrix
+keyboard.diode_orientation = DiodeOrientation.COLUMNS
+keyboard.col_pins = (board.GP0,)
+keyboard.row_pins = (board.GP20,)
+
+keyboard.keymap = [
+    [
+        KC.A,
+    ],
+]
+
+keyboard.debug_enabled = False
+
+if __name__ == "__main__":
+    keyboard.go()
+```

--- a/kmk/modules/rotaryio_encoder.py
+++ b/kmk/modules/rotaryio_encoder.py
@@ -11,20 +11,9 @@ class RotaryIOEncoder(Module):
 
     def __init__(self, pin_a, pin_b, divisor=4):
         self.encoder = rotaryio.IncrementalEncoder(pin_a,pin_b,divisor)
-        self.position = self.encoder.position
+        self.old_position = self.encoder.position
+        self.change = None
         self.map = None
-
-    def on_move_do(self, keyboard, encoder_id, state):
-        if self.map:
-            layer_id = keyboard.active_layers[0]
-            # if Left, key index 0 else key index 1
-            if state['direction'] == -1:
-                key_index = 0
-            else:
-                key_index = 1
-            key = self.map[layer_id][encoder_id][key_index]
-            keyboard.tap_key(key)
-
 
     def during_bootup(self, keyboard):
         return
@@ -33,7 +22,15 @@ class RotaryIOEncoder(Module):
         '''
         Return value will be injected as an extra matrix update
         '''
-        encoder.update_state()
+
+        self.change = self.encoder.position - self.old_position
+
+        if self.change != 0:
+            layer_id = keyboard.active_layers[0]
+            key = self.map[layer_id][1 if self.change > 0 else 0]
+            keyboard.tap_key(key)
+
+        self.old_position = self.encoder.position
 
         return keyboard
 

--- a/kmk/modules/rotaryio_encoder.py
+++ b/kmk/modules/rotaryio_encoder.py
@@ -12,25 +12,23 @@ class RotaryIOEncoder(Module):
     Does not support buttons, they should be part of the keyboard matrix
     """
 
-    def __init__(self,encoders):
+    def __init__(self, encoders):
         """self.encoders is a list of dictionaries, with keys
-         "encoder": rotaryio.IncrementalEncoder objext
-         "keymap": tuple of pairs (one per layer) with the keymap
-         "pin_a":
-         "pin_b":
-         "divisor":
-        self.encoders
+        "encoder": rotaryio.IncrementalEncoder objext
+        "keymap": tuple of pairs (one per layer) with the keymap
+        "pin_a":
+        "pin_b":
+        "divisor":
         """
 
-	self.encoders = encoders
+        self.encoders = encoders
 
         for enc in self.encoders:
             # if you didn't give it explicitly you probably want divisor = 4
-            enc["divisor"] = enc.get("divisor",4)
+            enc["divisor"] = enc.get("divisor", 4)
             enc["encoder"] = rotaryio.IncrementalEncoder(
-                                        enc["pin_a"],
-                                        enc["pin_b"],
-                                        enc["divisor"])
+                enc["pin_a"], enc["pin_b"], enc["divisor"]
+            )
 
             enc["old_position"] = enc["encoder"].position
 

--- a/kmk/modules/rotaryio_encoder.py
+++ b/kmk/modules/rotaryio_encoder.py
@@ -1,5 +1,6 @@
-from kmk.modules import Module
 import rotaryio
+
+from kmk.modules import Module
 
 
 class RotaryIOEncoder(Module):
@@ -10,7 +11,7 @@ class RotaryIOEncoder(Module):
     """
 
     def __init__(self, pin_a, pin_b, divisor=4):
-        self.encoder = rotaryio.IncrementalEncoder(pin_a,pin_b,divisor)
+        self.encoder = rotaryio.IncrementalEncoder(pin_a, pin_b, divisor)
         self.old_position = self.encoder.position
         self.change = None
         self.map = None

--- a/kmk/modules/rotaryio_encoder.py
+++ b/kmk/modules/rotaryio_encoder.py
@@ -4,33 +4,26 @@ from kmk.modules import Module
 
 
 class RotaryIOEncoder(Module):
-    """This class enables the use of rotary encoders.
+    '''This class enables the use of rotary encoders.
     It is a pretty thin wrapper around rotaryio.IncrementalEncoder.
     WARNING: The two pins used for the encoder must be adjacent (e.g.
              GP16 and GP17 on a Pi pico)
 
     Does not support buttons, they should be part of the keyboard matrix
-    """
+    '''
 
     def __init__(self, encoders):
-        """self.encoders is a list of dictionaries, with keys
-        "encoder": rotaryio.IncrementalEncoder objext
-        "keymap": tuple of pairs (one per layer) with the keymap
-        "pin_a":
-        "pin_b":
-        "divisor":
-        """
 
         self.encoders = encoders
 
         for enc in self.encoders:
             # if you didn't give it explicitly you probably want divisor = 4
-            enc["divisor"] = enc.get("divisor", 4)
-            enc["encoder"] = rotaryio.IncrementalEncoder(
-                enc["pin_a"], enc["pin_b"], enc["divisor"]
+            enc['divisor'] = enc.get('divisor', 4)
+            enc['encoder'] = rotaryio.IncrementalEncoder(
+                enc['pin_a'], enc['pin_b'], enc['divisor']
             )
 
-            enc["old_position"] = enc["encoder"].position
+            enc['old_position'] = enc['encoder'].position
 
     def during_bootup(self, keyboard):
         return
@@ -42,14 +35,14 @@ class RotaryIOEncoder(Module):
 
         for enc in self.encoders:
 
-            change = enc["encoder"].position - enc["old_position"]
+            change = enc['encoder'].position - enc['old_position']
 
             if change != 0:
                 layer_id = keyboard.active_layers[0]
-                key = enc["keymap"][layer_id][1 if change > 0 else 0]
+                key = enc['keymap'][layer_id][1 if change > 0 else 0]
                 keyboard.tap_key(key)
 
-            enc["old_position"] = enc["encoder"].position
+            enc['old_position'] = enc['encoder'].position
 
         return keyboard
 

--- a/kmk/modules/rotaryio_encoder.py
+++ b/kmk/modules/rotaryio_encoder.py
@@ -1,0 +1,56 @@
+from kmk.modules import Module
+import rotaryio
+
+
+class RotaryIOEncoder(Module):
+    """This class enables the use of rotary encoders.
+    It is a pretty thin wrapper around rotaryio.IncrementalEncoder.
+    WARNING: The two pins used for the encoder must be adjacent (e.g.
+             GP16 and GP17 on a Pi pico)
+    """
+
+    def __init__(self, pin_a, pin_b, divisor=4):
+        self.encoder = rotaryio.IncrementalEncoder(pin_a,pin_b,divisor)
+        self.position = self.encoder.position
+        self.map = None
+
+    def on_move_do(self, keyboard, encoder_id, state):
+        if self.map:
+            layer_id = keyboard.active_layers[0]
+            # if Left, key index 0 else key index 1
+            if state['direction'] == -1:
+                key_index = 0
+            else:
+                key_index = 1
+            key = self.map[layer_id][encoder_id][key_index]
+            keyboard.tap_key(key)
+
+
+    def during_bootup(self, keyboard):
+        return
+
+    def before_matrix_scan(self, keyboard):
+        '''
+        Return value will be injected as an extra matrix update
+        '''
+        encoder.update_state()
+
+        return keyboard
+
+    def after_matrix_scan(self, keyboard):
+        '''
+        Return value will be replace matrix update if supplied
+        '''
+        return
+
+    def before_hid_send(self, keyboard):
+        return
+
+    def after_hid_send(self, keyboard):
+        return
+
+    def on_powersave_enable(self, keyboard):
+        return
+
+    def on_powersave_disable(self, keyboard):
+        return


### PR DESCRIPTION
I have created a module `RotaryIOEncoder` that wraps the functionality of [rotaryio](https://docs.circuitpython.org/en/latest/shared-bindings/rotaryio/index.html#module-rotaryio). 

The current KMK module does not use `rotaryio`, so it does not have support for `divisor` (essential when the number of retents is not the same as the number of cycles per revolution). It also has some other minor issues, like dropping some keypresses if they happen too fast, which is solved by using `rotaryio`.

The module in this pull request allows the user to add multiple rotary encoders to a project, with layers support. It does not support press buttons on the encoder because `rotaryio` does not, they should be added to the matrix or included using `keypad` in a future version of KMK.

I have tested this module with [this](https://www.adafruit.com/product/5001) scroll wheel.