### PR TITLE
implement stricter and more consistent timeouts.

### DIFF
--- a/kmk/kmktime.py
+++ b/kmk/kmktime.py
@@ -12,6 +12,10 @@ def ticks_diff(new, start):
     return diff
 
 
+def ticks_add(ticks, delta):
+    return (ticks + delta) % _TICKS_PERIOD
+
+
 def check_deadline(new, start, ms):
     return ticks_diff(new, start) < ms
 


### PR DESCRIPTION
- stricter timeouts: Instead of adding an entire millisecond, use a list
  of timeouts that are supposed to be handled on the same tick. This
  reduces the delay between target tick and actual tick, especially for
  many timeouts issued to the same tick, i.e. combos.
- consistent timeouts: Timeouts are now guaranteed to be handled in the
  order they were issued. Timer rollover is handled properly.

caveat / change to the interface: the returned `timeout_key` is a tuple
of the target timeout tick and the index of the timeout at that tick.