### PR TITLE
add `None` to account for no encoder button in encoder docs

### DIFF
--- a/docs/encoder.md
+++ b/docs/encoder.md
@@ -24,7 +24,7 @@ encoder_handler = EncoderHandler()
 keyboard.modules = [layers, modtap, encoder_handler]
 ```
 
-2. Define the pins for each encoder (pin_a, pin_b, pin_button, True for an inversed encoder)
+2. Define the pins for each encoder (pin_a, pin_b, pin_button [or `None` if the encoder's button is handled differently or not at all], True for an inversed encoder)
 ```python
 #GPIO Encoder
 encoder_handler.pins = ((board.GP17, board.GP15, board.GP14, False), (encoder 2 definition), etc. )


### PR DESCRIPTION
I had to dig through the code to find out what to do... adding it to the docs...