### PR TITLE
Fix WinCompose usage

### DIFF
--- a/kmk/handlers/sequences.py
+++ b/kmk/handlers/sequences.py
@@ -152,3 +152,4 @@ def _winc_unicode_sequence(kc_macros, keyboard):
         yield RALT_KEY
         yield U_KEY
         yield kc_macro
+        yield ENTER_KEY


### PR DESCRIPTION
WinCompose requires the `enter` key to be typed at the end of a special unicode character. In order to help print emojis and emoticons in a windows environment, I have added the enter key to the Windows compose unicode sequence method. I have tested this with my local keyboard.