### PR TITLE
Refactor: move matrix code

### DIFF
--- a/boards/atreus62/kb.py
+++ b/boards/atreus62/kb.py
@@ -1,9 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
-
-# from kmk.matrix import intify_coordinate as ic
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/boardsource/3x4/kb.py
+++ b/boards/boardsource/3x4/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/boardsource/4x12/kb.py
+++ b/boards/boardsource/4x12/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/boardsource/5x12/kb.py
+++ b/boards/boardsource/5x12/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/boardsource/microdox/kb.py
+++ b/boards/boardsource/microdox/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/crkbd/kb.py
+++ b/boards/crkbd/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/crkbd/kb_rp2040.py
+++ b/boards/crkbd/kb_rp2040.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/ergo_travel/kb.py
+++ b/boards/ergo_travel/kb.py
@@ -1,8 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
-from kmk.matrix import intify_coordinate as ic
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/fourtypercentclub/gherkin/kb.py
+++ b/boards/fourtypercentclub/gherkin/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/fourtypercentclub/luddite/converter_kb.py
+++ b/boards/fourtypercentclub/luddite/converter_kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/fourtypercentclub/luddite/kb.py
+++ b/boards/fourtypercentclub/luddite/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/jpconstantineau/Batreus44/kb_BlueMicro840.py
+++ b/boards/jpconstantineau/Batreus44/kb_BlueMicro840.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/jpconstantineau/PyKey60/kb.py
+++ b/boards/jpconstantineau/PyKey60/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/jpconstantineau/gridmx47/kb.py
+++ b/boards/jpconstantineau/gridmx47/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/jpconstantineau/offsetmx43/kb.py
+++ b/boards/jpconstantineau/offsetmx43/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/jpconstantineau/vcolchoc44/kb.py
+++ b/boards/jpconstantineau/vcolchoc44/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/jpconstantineau/vcolmx44/kb.py
+++ b/boards/jpconstantineau/vcolmx44/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/keebio/iris/kb.py
+++ b/boards/keebio/iris/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/keebio/iris/kb_converter.py
+++ b/boards/keebio/iris/kb_converter.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/keebio/levinson/kb.py
+++ b/boards/keebio/levinson/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/keebio/levinson/kb_converter.py
+++ b/boards/keebio/levinson/kb_converter.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/keebio/nyquist/kb.py
+++ b/boards/keebio/nyquist/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/keebio/nyquist/kb_converter.py
+++ b/boards/keebio/nyquist/kb_converter.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/klarank.py
+++ b/boards/klarank.py
@@ -1,9 +1,9 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
-from kmk.matrix import intify_coordinate as ic
 from kmk.modules.layers import Layers
+from kmk.scanners import DiodeOrientation
+from kmk.scanners import intify_coordinate as ic
 
 # Implements what used to be handled by KMKKeyboard.swap_indicies for this
 # board, by flipping various row3 (bottom physical row) keys so their

--- a/boards/kyria/kyria_v1_kb2040.py
+++ b/boards/kyria/kyria_v1_kb2040.py
@@ -1,8 +1,8 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
-from kmk.matrix import intify_coordinate as ic
+from kmk.scanners import DiodeOrientation
+from kmk.scanners import intify_coordinate as ic
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/kyria/kyria_v1_rp2040.py
+++ b/boards/kyria/kyria_v1_rp2040.py
@@ -1,8 +1,8 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
-from kmk.matrix import intify_coordinate as ic
+from kmk.scanners import DiodeOrientation
+from kmk.scanners import intify_coordinate as ic
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/lily58/kb.py
+++ b/boards/lily58/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/lunakey_pico/kb.py
+++ b/boards/lunakey_pico/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/may_pad/kb.py
+++ b/boards/may_pad/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/navi10/kb.py
+++ b/boards/navi10/kb.py
@@ -2,7 +2,7 @@ import board
 import digitalio
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/reviung39/kb.py
+++ b/boards/reviung39/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/reviung41/kb.py
+++ b/boards/reviung41/kb.py
@@ -1,8 +1,8 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
-from kmk.matrix import intify_coordinate as ic
+from kmk.scanners import DiodeOrientation
+from kmk.scanners import intify_coordinate as ic
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/rhymestone/kb.py
+++ b/boards/rhymestone/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/tg4x/kb.py
+++ b/boards/tg4x/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -22,7 +22,7 @@ import board
 
 from kmk.kmk_keyboard import KMKKeyboard
 from kmk.keys import KC
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 keyboard = KMKKeyboard()
 

--- a/docs/config_and_keymap.md
+++ b/docs/config_and_keymap.md
@@ -35,7 +35,7 @@ if __name__ == '__main__':
 ```python
 import board
 
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 col_pins = (board.SCK, board.MOSI, board.MISO, board.RX, board.TX, board.D4)
 row_pins = (board.D10, board.D11, board.D12, board.D13, board.D9, board.D6, board.D5, board.SCL)

--- a/docs/encoder.md
+++ b/docs/encoder.md
@@ -70,7 +70,7 @@ import board
 from kmk.kmk_keyboard import KMKKeyboard
 from kmk.consts import UnicodeMode
 from kmk.keys import KC
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 from kmk.modules.layers import Layers
 from kmk.modules.encoder import EncoderHandler
 

--- a/docs/ja/Getting_Started.md
+++ b/docs/ja/Getting_Started.md
@@ -35,7 +35,7 @@ import board
 
 from kmk.kmk_keyboard import KMKKeyboard
 from kmk.keys import KC
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 keyboard = KMKKeyboard()
 

--- a/docs/porting_to_kmk.md
+++ b/docs/porting_to_kmk.md
@@ -5,7 +5,7 @@ Porting a board to KMK is quite simple, and follows this base format.
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 {EXTENSIONS_IMPORT}
 
 class KMKKeyboard(_KMKKeyboard):
@@ -38,7 +38,7 @@ side, the right side being offset by the number of keys on the left side, as if
 the rows were stacked.
 That would look like this
 ```python
-from kmk.matrix import intify_coordinate as ic
+from kmk.scanners import intify_coordinate as ic
 
     coord_mapping = []
     coord_mapping.extend(ic(0, x, 6) for x in range(6))

--- a/docs/ptBR/Getting_Started.md
+++ b/docs/ptBR/Getting_Started.md
@@ -39,7 +39,7 @@ import board
 
 from kmk.kmk_keyboard import KMKKeyboard
 from kmk.keys import KC
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 keyboard = KMKKeyboard()
 

--- a/docs/ptBR/config_and_keymap.md
+++ b/docs/ptBR/config_and_keymap.md
@@ -36,7 +36,7 @@ if __name__ == '__main__':
 ```python
 import board
 
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 col_pins = (board.SCK, board.MOSI, board.MISO, board.RX, board.TX, board.D4)
 row_pins = (board.D10, board.D11, board.D12, board.D13, board.D9, board.D6, board.D5, board.SCL)

--- a/docs/ptBR/porting_to_kmk.md
+++ b/docs/ptBR/porting_to_kmk.md
@@ -6,7 +6,7 @@ Portar uma placa para o KMK é bastante simples, e segue o seguinte formato-base
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 {EXTENSIONS_IMPORT}
 
 class KMKKeyboard(_KMKKeyboard):
@@ -44,7 +44,7 @@ linhas, e 6 colunas para a linha inferior. Teclados repartidos são contados pel
 total, não por parte separada. Isto seria mais ou menos assim:
 
 ```python
-from kmk.matrix import intify_coordinate as ic
+from kmk.scanners import intify_coordinate as ic
 
     coord_mapping = []
     coord_mapping.extend(ic(0, x, 6) for x in range(6))

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -4,7 +4,8 @@ from kmk.consts import KMK_RELEASE, UnicodeMode
 from kmk.hid import BLEHID, USBHID, AbstractHID, HIDModes
 from kmk.keys import KC
 from kmk.kmktime import ticks_add, ticks_diff
-from kmk.matrix import MatrixScanner, intify_coordinate
+from kmk.scanners import intify_coordinate
+from kmk.scanners.digitalio_matrix import MatrixScanner
 
 
 class Sandbox:

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -3,12 +3,13 @@ import busio
 from micropython import const
 from supervisor import runtime, ticks_ms
 
+from keypad import Event as KeyEvent
 from storage import getmount
 
 from kmk.hid import HIDModes
 from kmk.kmktime import check_deadline
-from kmk.matrix import KeyEvent, intify_coordinate
 from kmk.modules import Module
+from kmk.scanners import intify_coordinate
 
 
 class SplitSide:

--- a/kmk/scanners/__init__.py
+++ b/kmk/scanners/__init__.py
@@ -1,3 +1,22 @@
+def intify_coordinate(row, col, len_cols):
+    return len_cols * row + col
+
+
+class DiodeOrientation:
+    '''
+    Orientation of diodes on handwired boards. You can think of:
+    COLUMNS = vertical
+    ROWS = horizontal
+
+    COL2ROW and ROW2COL are equivalent to their meanings in QMK.
+    '''
+
+    COLUMNS = 0
+    ROWS = 1
+    COL2ROW = COLUMNS
+    ROW2COL = ROWS
+
+
 class Scanner:
     '''
     Base class for scanners.

--- a/kmk/scanners/digitalio_matrix.py
+++ b/kmk/scanners/digitalio_matrix.py
@@ -1,31 +1,8 @@
 import digitalio
 
-from kmk.scanners import Scanner
+from keypad import Event as KeyEvent
 
-
-def intify_coordinate(row, col, len_cols):
-    return len_cols * row + col
-
-
-class DiodeOrientation:
-    '''
-    Orientation of diodes on handwired boards. You can think of:
-    COLUMNS = vertical
-    ROWS = horizontal
-
-    COL2ROW and ROW2COL are equivalent to their meanings in QMK.
-    '''
-
-    COLUMNS = 0
-    ROWS = 1
-    COL2ROW = COLUMNS
-    ROW2COL = ROWS
-
-
-class KeyEvent:
-    def __init__(self, key_number, pressed):
-        self.key_number = key_number
-        self.pressed = pressed
+from kmk.scanners import DiodeOrientation, Scanner
 
 
 class MatrixScanner(Scanner):

--- a/kmk/scanners/native_keypad_scanner.py
+++ b/kmk/scanners/native_keypad_scanner.py
@@ -1,7 +1,6 @@
 import keypad
 
-from kmk.matrix import DiodeOrientation
-from kmk.scanners import Scanner
+from kmk.scanners import DiodeOrientation, Scanner
 
 
 class NativeKeypadScanner(Scanner):

--- a/tests/keyboard_test.py
+++ b/tests/keyboard_test.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 from kmk.hid import HIDModes
 from kmk.keys import ModifierKey
 from kmk.kmk_keyboard import KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class DigitalInOut(Mock):

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -3,6 +3,12 @@ import time
 from unittest.mock import Mock
 
 
+class KeyEvent:
+    def __init__(self, key_number, pressed):
+        self.key_number = key_number
+        self.pressed = pressed
+
+
 def init_circuit_python_modules_mocks():
     sys.modules['usb_hid'] = Mock()
     sys.modules['digitalio'] = Mock()
@@ -12,6 +18,9 @@ def init_circuit_python_modules_mocks():
     sys.modules['microcontroller'] = Mock()
     sys.modules['board'] = Mock()
     sys.modules['storage'] = Mock()
+
+    sys.modules['keypad'] = Mock()
+    sys.modules['keypad'].Event = KeyEvent
 
     sys.modules['micropython'] = Mock()
     sys.modules['micropython'].const = lambda x: x

--- a/user_keymaps/dgriswo/pyKey60.py
+++ b/user_keymaps/dgriswo/pyKey60.py
@@ -7,8 +7,8 @@ import board
 from kmk.extensions.RGB import RGB, AnimationModes
 from kmk.keys import KC
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
 from kmk.modules.layers import Layers
+from kmk.scanners import DiodeOrientation
 
 keyboard = _KMKKeyboard()
 keyboard.modules.append(Layers())

--- a/user_keymaps/dzervas/lab68.py
+++ b/user_keymaps/dzervas/lab68.py
@@ -7,8 +7,8 @@ from adafruit_mcp230xx.mcp23017 import MCP23017
 from kmk.hid import HIDModes
 from kmk.keys import KC
 from kmk.kmk_keyboard import KMKKeyboard
-from kmk.matrix import DiodeOrientation
 from kmk.modules.layers import Layers
+from kmk.scanners import DiodeOrientation
 
 # DEBUG_ENABLE = True
 


### PR DESCRIPTION
Move the old KMK matrix scanning code into the scanner module collection and give it a nice name.