### PR TITLE
Split tap key and encoders working on splits

### DIFF
--- a/docs/encoder.md
+++ b/docs/encoder.md
@@ -24,7 +24,7 @@ encoder_handler = EncoderHandler()
 keyboard.modules = [layers, modtap, encoder_handler]
 ```
 
-2. Define the pins for each encoder (pin_a, pin_b, pin_button, True for an inversed encoder)
+2. Define the pins for each encoder (pin_a, pin_b, pin_button [or `None` if the encoder's button is handled differently or not at all], True for an inversed encoder)
 ```python
 #GPIO Encoder
 encoder_handler.pins = ((board.GP17, board.GP15, board.GP14, False), (encoder 2 definition), etc. )
@@ -62,6 +62,8 @@ encoder_handler.map = [(( KC.VOLD, KC.VOLU, KC.MUTE),(encoder 2 definition), etc
 
 4. Encoder methods on_move_do and on_button_do can be overwritten for complex use cases
 
+
+
 ### Note on split keyboard usage
 If your second side has an encoder as well. Set it up the exact same but when you set up the module pass True in to tell the encoder module that this is a split side. Then when you turn the knob it will send it over to the main side. Example
 ```python
@@ -82,7 +84,7 @@ import board
 from kmk.kmk_keyboard import KMKKeyboard
 from kmk.consts import UnicodeMode
 from kmk.keys import KC
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 from kmk.modules.layers import Layers
 from kmk.modules.encoder import EncoderHandler
 
@@ -175,3 +177,5 @@ encoder_handler.map = ( ((KC.UP, KC.DOWN, KC.MUTE),), # Standard
 
 if __name__ == "__main__":
     keyboard.go()
+
+

--- a/docs/encoder.md
+++ b/docs/encoder.md
@@ -24,7 +24,7 @@ encoder_handler = EncoderHandler()
 keyboard.modules = [layers, modtap, encoder_handler]
 ```
 
-2. Define the pins for each encoder (pin_a, pin_b, pin_button [or `None` if the encoder's button is handled differently or not at all], True for an inversed encoder)
+2. Define the pins for each encoder (pin_a, pin_b, pin_button, True for an inversed encoder)
 ```python
 #GPIO Encoder
 encoder_handler.pins = ((board.GP17, board.GP15, board.GP14, False), (encoder 2 definition), etc. )
@@ -62,6 +62,18 @@ encoder_handler.map = [(( KC.VOLD, KC.VOLU, KC.MUTE),(encoder 2 definition), etc
 
 4. Encoder methods on_move_do and on_button_do can be overwritten for complex use cases
 
+### Note on split keyboard usage
+If your second side has an encoder as well. Set it up the exact same but when you set up the module pass True in to tell the encoder module that this is a split side. Then when you turn the knob it will send it over to the main side. Example
+```python
+from kmk.modules.encoder import EncoderHandler
+encoder_handler = EncoderHandler(True)
+keyboard.modules = [layers, modtap, encoder_handler]
+```
+Now there are a few limatations at this time.
+* only works with UART ATM (ble should be easy)
+* It will always be on the base layer.
+
+
 ## Full example (with 1 encoder)
 
 ```python
@@ -70,7 +82,7 @@ import board
 from kmk.kmk_keyboard import KMKKeyboard
 from kmk.consts import UnicodeMode
 from kmk.keys import KC
-from kmk.scanners import DiodeOrientation
+from kmk.matrix import DiodeOrientation
 from kmk.modules.layers import Layers
 from kmk.modules.encoder import EncoderHandler
 

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -7,7 +7,7 @@ from keypad import Event as KeyEvent
 from storage import getmount
 
 from kmk.hid import HIDModes
-from kmk.keys import KC, make_key
+from kmk.keys import make_key
 from kmk.kmktime import check_deadline
 from kmk.modules import Module
 from kmk.scanners import intify_coordinate

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -341,7 +341,7 @@ class Split(Module):
         return buffer
 
     def _serialize_keyCode(self, keyCode):
-        buffer = keyCode.to_bytes(2, "little")
+        buffer = keyCode.to_bytes(2, 'little')
         return buffer
 
     def _deserialize_update(self, update):
@@ -349,7 +349,7 @@ class Split(Module):
         return kevent
 
     def _deserialize_keyCode(self, keycode):
-        newkeycode = int.from_bytes(keycode, "little")
+        newkeycode = int.from_bytes(keycode, 'little')
         keyobj = make_key(code=newkeycode)
         return keyobj
 


### PR DESCRIPTION
I started working on this because I wanted encoders to work on splits. 

So after looking at how encoders worked I saw that they are not part of the matrix and just called "tap_key". I thought the most pragmatic way of doing this was be able to call tap_key from the offside. I think this not only fixes encoders but is a good thing to have in the code base in general. If we have a function to just send a key press we should also be able to use that on splits. 

Let's get into how I did this and what changes I made.

In the split module, I added a new uart header at the top of the file. This will be added to the messages sent to see if it should be handled like normal or as a " tap_key ". Next, I had to add the send_key_press function. This is the function you want to use outside of the split code. Right now it just calls the _send_uart_press function if uart is being used. But If this gets merged I will work on the BLE side.
Now we have a function we can call we need to send it to the other side. So I made "_serialize_keyCode" This takes in our keycode and gives us back bytes we can send over uart.

Ok offside done we need to handle it correctly.

Incomes "_deserialize_keyCode" takes those bytes and gives back a kmk keycode same as KC.ESC. Then in "_receive_uart" We had an if block that was checking the old uart header so already nothing was broken it was just not dealing with the new messages. So we simply add a new if block that checks to see if it is the "key press header" and handle it thereby calling"_deserialize_keyCode" to get our key and keyboard.tap_key(deserialize_keyCode)