### PR TITLE
Enhancement scanner options

### DIFF
--- a/boards/pimoroni/keybow/keybow.py
+++ b/boards/pimoroni/keybow/keybow.py
@@ -45,19 +45,19 @@ from kmk.scanners.keypad import KeysScanner
 # fmt: off
 def raspi_pins():
     return [
-        [board.D20, board.D16, board.D26],
-        [board.D6,  board.D12, board.D13],
-        [board.D22, board.D24, board.D5],
-        [board.D17, board.D27, board.D23],
+        board.D20, board.D16, board.D26,
+        board.D6,  board.D12, board.D13,
+        board.D22, board.D24, board.D5,
+        board.D17, board.D27, board.D23,
     ]
 
 
 def itsybitsy_pins():
     return [
-        [board.D11, board.D12, board.D2],
-        [board.D10, board.D9,  board.D7],
-        [board.A5,  board.A4,  board.A3],
-        [board.A2,  board.A1,  board.A0],
+        board.D11, board.D12, board.D2,
+        board.D10, board.D9,  board.D7,
+        board.A5,  board.A4,  board.A3,
+        board.A2,  board.A1,  board.A0,
     ]
 # fmt: on
 

--- a/boards/pimoroni/keybow_2040/keybow_2040.py
+++ b/boards/pimoroni/keybow_2040/keybow_2040.py
@@ -28,11 +28,11 @@ from kmk.scanners.keypad import KeysScanner
 
 # fmt: off
 _KEY_CFG = [
-    [board.SW3,  board.SW7,  board.SW11, board.SW15],
-    [board.SW2,  board.SW6,  board.SW10, board.SW14],
-    [board.SW1,  board.SW5,  board.SW9,  board.SW13],
-    [board.SW0,  board.SW4,  board.SW8,  board.SW12],
-    [board.USER_SW],
+    board.SW3,  board.SW7,  board.SW11, board.SW15,
+    board.SW2,  board.SW6,  board.SW10, board.SW14,
+    board.SW1,  board.SW5,  board.SW9,  board.SW13,
+    board.SW0,  board.SW4,  board.SW8,  board.SW12,
+    board.USER_SW,
 ]
 # fmt: on
 

--- a/docs/scanners.md
+++ b/docs/scanners.md
@@ -9,6 +9,10 @@ need to swap it out with an alternative scanner.
 
 
 ## Keypad Scanners
+The scanners in `kmk.scanners.keypad` wrap the `keypad` module that ships with
+CircuitPython and support the some configuration and tuning options as their
+upstream. You can find out more in the (CircuitPython
+documentation)[https://docs.circuitpython.org/en/latest/shared-bindings/keypad/index.html].
 
 ### keypad MatrixScanner
 This is the default scanner used by KMK.
@@ -21,9 +25,13 @@ class MyKeyboard(KMKKeyboard):
     def __init__(self):
         # create and register the scanner
         self.matrix = MatrixScanner(
+            # required arguments:
             cols=self.col_pins,
             rows=self.row_pins,
-            diode_orientation=self.diode_orientation,
+            # optional arguments with defaults:
+            columns_to_anodes=DiodeOrientation.COL2ROW,
+            interval=0.02,
+            max_events=64
         )
 
 ```
@@ -43,10 +51,10 @@ from kmk.scanners.keypad import KeysScanner
 
 # GPIO to key mapping - each line is a new row.
 _KEY_CFG = [
-    [board.SW3,  board.SW7,  board.SW11, board.SW15],
-    [board.SW2,  board.SW6,  board.SW10, board.SW14],
-    [board.SW1,  board.SW5,  board.SW9,  board.SW13],
-    [board.SW0,  board.SW4,  board.SW8,  board.SW12],
+    board.SW3,  board.SW7,  board.SW11, board.SW15,
+    board.SW2,  board.SW6,  board.SW10, board.SW14,
+    board.SW1,  board.SW5,  board.SW9,  board.SW13,
+    board.SW0,  board.SW4,  board.SW8,  board.SW12,
 ]
 
 
@@ -54,7 +62,15 @@ _KEY_CFG = [
 class MyKeyboard(KMKKeyboard):
     def __init__(self):
         # create and register the scanner
-        self.matrix = MatrixScanner(pins=_KEY_CFG)
+        self.matrix = MatrixScanner(
+            # require argument:
+            pins=_KEY_CFG,
+            # optional arguments with defaults:
+            value_when_pressed=False,
+            pull=True,
+            interval=0.02,
+            max_events=64
+        )
 ```
 
 

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -305,9 +305,9 @@ class KMKKeyboard:
             if self.debug_enabled:
                 print('Initialising default matrix scanner.')
             self.matrix = MatrixScanner(
-                col_pins=self.col_pins,
+                column_pins=self.col_pins,
                 row_pins=self.row_pins,
-                direction=self.diode_orientation,
+                columns_to_anodes=self.diode_orientation,
             )
         else:
             if self.debug_enabled:

--- a/kmk/scanners/keypad.py
+++ b/kmk/scanners/keypad.py
@@ -11,13 +11,10 @@ class KeypadScanner(Scanner):
     :param kp: An instance of the keypad class.
     '''
 
-    def __init__(self, pin_map, kp):
-        self.pin_map = pin_map
-        self.keypad = kp
+    def __init__(self):
         # for split keyboards, the offset value will be assigned in Split module
         self.offset = 0
         self.coord_mapping = tuple(range(self.key_count))
-
         self.curr_event = keypad.Event()
 
     @property
@@ -39,7 +36,7 @@ class KeypadScanner(Scanner):
                 return ev
 
 
-def MatrixScanner(row_pins, col_pins, direction=DiodeOrientation.COLUMNS):
+class MatrixScanner(KeypadScanner):
     '''
     Row/Column matrix using the CircuitPython 7 keypad scanner.
 
@@ -47,23 +44,47 @@ def MatrixScanner(row_pins, col_pins, direction=DiodeOrientation.COLUMNS):
     :param col_pins: A sequence of pins used for columns.
     :param direction: The diode orientation of the matrix.
     '''
-    pin_map = [
-        (row, col) for row in range(len(row_pins)) for col in range(len(col_pins))
-    ]
-    kp = keypad.KeyMatrix(
-        row_pins, col_pins, columns_to_anodes=(direction == DiodeOrientation.COLUMNS)
-    )
-    return KeypadScanner(pin_map, kp)
+
+    def __init__(
+        self,
+        row_pins,
+        column_pins,
+        *,
+        columns_to_anodes=DiodeOrientation.COL2ROW,
+        interval=0.02,
+        max_events=64,
+    ):
+        self.keypad = keypad.KeyMatrix(
+            row_pins,
+            column_pins,
+            columns_to_anodes=(columns_to_anodes == DiodeOrientation.COL2ROW),
+            interval=interval,
+            max_events=max_events,
+        )
+        super().__init__()
 
 
-def KeysScanner(pins):
+class KeysScanner(KeypadScanner):
     '''
     GPIO-per-key 'matrix' using the native CircuitPython 7 keypad scanner.
 
     :param pins: An array of arrays of CircuitPython Pin objects, such that pins[r][c] is the pin for row r, column c.
     '''
-    pin_map = [(row, col) for row in range(len(pins)) for col in range(len(pins[row]))]
-    kp = keypad.Keys(
-        [pins[r][c] for (r, c) in pin_map], value_when_pressed=False, pull=True
-    )
-    return KeypadScanner(pin_map, kp)
+
+    def __init__(
+        self,
+        pins,
+        *,
+        value_when_pressed=False,
+        pull=True,
+        interval=0.02,
+        max_events=64,
+    ):
+        self.keypad = keypad.Keys(
+            pins,
+            value_when_pressed=value_when_pressed,
+            pull=pull,
+            interval=interval,
+            max_events=max_events,
+        )
+        super().__init__()


### PR DESCRIPTION
Exposes all options of the CP `keypad` modules through our scanner wrapper.
Depends on #388; ready for review once dependency is merged.