### PR TITLE
Enhancement: multiple scanners

### DIFF
--- a/docs/scanners.md
+++ b/docs/scanners.md
@@ -126,3 +126,25 @@ If you require a different type of scanner, you can create your own by
 providing a subclass of `Scanner`. This is a very simple interface, it only
 contains a single method, `scan_for_changes(self)` which returns a key report
 if one exists, or `None` otherwise.
+
+
+## Advanced Configuration
+
+### Multiple Scanners
+
+Sometimes a single scanner doesn't cover all hardware configurations. For
+example: The bulk of the keyboard may be scanned with a matrix scanner, but a
+couple of additional keys are directly connected to GPIOs.
+In that case KMK allows you to define multiple scanners. The `KMKKeyboard.matrix` attribute can either be assigned a single scanner, or a list of scanners.
+KMK assumes that successive scanner keys are consecutive, and populates
+`KMKKeyboard.coord_mapping` accordingly; for convenience you may have to supply a `coord_mapping` that resembles your physical layout more closely.
+
+Example:
+```python
+class MyKeyboard(KMKKeyboard):
+    self.matrix = [
+        MatrixScanner(...),
+        KeysScanner(...),
+        # etc...
+    ]
+```

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -286,7 +286,10 @@ class KMKKeyboard:
             return
 
         if not self.coord_mapping:
-            self.coord_mapping = self.matrix.coord_mapping
+            cm = []
+            for m in self.matrix:
+                cm.extend(m.coord_mapping)
+            self.coord_mapping = tuple(cm)
 
     def _init_hid(self):
         if self.hid_type == HIDModes.NOOP:
@@ -312,6 +315,15 @@ class KMKKeyboard:
         else:
             if self.debug_enabled:
                 print('Matrix scanner already set, not overwriting.')
+
+        try:
+            self.matrix = tuple(iter(self.matrix))
+            offset = 0
+            for matrix in self.matrix:
+                matrix.offset = offset
+                offset += matrix.key_count
+        except TypeError:
+            self.matrix = (self.matrix,)
 
         return self
 
@@ -442,7 +454,11 @@ class KMKKeyboard:
 
         self.before_matrix_scan()
 
-        self.matrix_update = self.sandbox.matrix_update = self.matrix.scan_for_changes()
+        for matrix in self.matrix:
+            update = matrix.scan_for_changes()
+            if update:
+                self.matrix_update = update
+                break
         self.sandbox.secondary_matrix_update = self.secondary_matrix_update
 
         self.after_matrix_scan()

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -9,7 +9,6 @@ from storage import getmount
 from kmk.hid import HIDModes
 from kmk.kmktime import check_deadline
 from kmk.modules import Module
-from kmk.scanners import intify_coordinate
 
 
 class SplitSide:
@@ -123,7 +122,7 @@ class Split(Module):
             keyboard._hid_send_enabled = False
 
         if self.split_offset is None:
-            self.split_offset = len(keyboard.col_pins) * len(keyboard.row_pins)
+            self.split_offset = keyboard.matrix[-1].coord_mapping[-1] + 1
 
         if self.split_type == SplitType.UART and self.data_pin is not None:
             if self._is_target or not self.uart_flip:
@@ -143,7 +142,7 @@ class Split(Module):
 
         # Attempt to sanely guess a coord_mapping if one is not provided.
         if not keyboard.coord_mapping:
-            keyboard.coord_mapping = []
+            cm = []
 
             rows_to_calc = len(keyboard.row_pins)
             cols_to_calc = len(keyboard.col_pins)
@@ -155,13 +154,11 @@ class Split(Module):
 
             for ridx in range(rows_to_calc):
                 for cidx in range(cols_to_calc):
-                    keyboard.coord_mapping.append(
-                        intify_coordinate(ridx, cidx, cols_to_calc)
-                    )
+                    cm.append(cols_to_calc * ridx + cidx)
                 for cidx in cols_rhs:
-                    keyboard.coord_mapping.append(
-                        intify_coordinate(rows_to_calc + ridx, cidx, cols_to_calc)
-                    )
+                    cm.append(cols_to_calc * (rows_to_calc + ridx) + cidx)
+
+            keyboard.coord_mapping = tuple(cm)
 
         if self.split_side == SplitSide.RIGHT:
             keyboard.matrix.offset = self.split_offset

--- a/kmk/scanners/__init__.py
+++ b/kmk/scanners/__init__.py
@@ -22,7 +22,12 @@ class Scanner:
     Base class for scanners.
     '''
 
-    coord_mapping = None
+    # for split keyboards, the offset value will be assigned in Split module
+    offset = 0
+
+    @property
+    def coord_mapping(self):
+        return tuple(range(self.offset, self.offset + self.key_count))
 
     @property
     def key_count(self):
@@ -34,4 +39,4 @@ class Scanner:
 
         The key report is a byte array with contents [row, col, True if pressed else False]
         '''
-        pass
+        raise NotImplementedError

--- a/kmk/scanners/digitalio.py
+++ b/kmk/scanners/digitalio.py
@@ -78,7 +78,6 @@ class MatrixScanner(Scanner):
             self.rollover_cols_every_rows = self.len_rows
 
         self._key_count = self.len_cols * self.len_rows
-        self.coord_mapping = tuple(range(self.key_count))
         self.state = bytearray(self.key_count)
 
     @property

--- a/kmk/scanners/keypad.py
+++ b/kmk/scanners/keypad.py
@@ -12,9 +12,6 @@ class KeypadScanner(Scanner):
     '''
 
     def __init__(self):
-        # for split keyboards, the offset value will be assigned in Split module
-        self.offset = 0
-        self.coord_mapping = tuple(range(self.key_count))
         self.curr_event = keypad.Event()
 
     @property


### PR DESCRIPTION
Support for multiple (i.e. a list of) scanners.
`KMKKeyboard.matrix` can either be a single scanner (support for current implementations), or a list of scanners.
`coord_mapping` for mirrored non-square matrices or multiple scanners has to be defined manually -- there's no general solution. Individual scanner "flips" may be added in the future.

Before merging, confirmation from a split user would be appreciated.