### PR TITLE
Minimum necessary to add index and get capability and tests

### DIFF
--- a/docs/keys.md
+++ b/docs/keys.md
@@ -23,27 +23,27 @@ The next few steps are the interesting part, but to understand them, we need to
 understand a bit about what a `Key` object is (found in `kmk/keys.py`). `Key`
 objects have a few core pieces of information:
 
-* Their `code`, which can be any integer. Integers below
+- Their `code`, which can be any integer. Integers below
   `FIRST_KMK_INTERNAL_KEY` are sent through to the HID stack (and thus the
   computer, which will translate that integer to something meaningful - for
   example, `code=4` becomes `a` on a US QWERTY/Dvorak keyboard).
 
-* Their attached modifiers (to implement things like shifted keys or `KC.HYPR`,
+- Their attached modifiers (to implement things like shifted keys or `KC.HYPR`,
   which are single key presses sending along more than one key in a single HID
   report. This is a distinct concept from Sequences, which are a KMK feature
   documented in `sequences.md`). For almost all purposes outside of KMK core,
   this field should be ignored - it can be safely populated through far more
   sane means than futzing with it by hand.
 
-* Some data on whether the key should actually be pressed or released - this is
+- Some data on whether the key should actually be pressed or released - this is
   mostly an implementation detail of how Sequences work, where, for example,
   `KC.RALT` may need to be held down for the entirety of a sequence, rather than
-  being released immediately before moving to the next character.  Usually end
+  being released immediately before moving to the next character. Usually end
   users shouldn't need to mess with this, but the fields are called `no_press`
   and `no_release` and are referenced in a few places in the codebase if you
   need examples.
 
-* Handlers for "press" (sometimes known as "keydown") and "release" (sometimes
+- Handlers for "press" (sometimes known as "keydown") and "release" (sometimes
   known as "keyup") events. KMK provides handlers for standard keyboard
   functions and some special override keys (like `KC.GESC`, which is an enhanced
   form of existing ANSI keys) in `kmk/handlers/stock.py`, for layer switching in
@@ -51,10 +51,10 @@ objects have a few core pieces of information:
   `sequences.md` again) in `kmk/handlers/sequences.py`. We'll discuss these more
   shortly.
 
-* Optional callbacks to be run before and/or after the above handlers. More on
+- Optional callbacks to be run before and/or after the above handlers. More on
   that soon.
 
-* A generic `meta` field, which is most commonly used for "argumented" keys -
+- A generic `meta` field, which is most commonly used for "argumented" keys -
   objects in the `KC` object which are actually functions that return `Key`
   instances, which often need to access the arguments passed into the "outer"
   function. Many of these examples are related to layer switching - for example,
@@ -121,6 +121,7 @@ whatever the stock handler is, you're covered. This also means you can add
 completely new functionality to KMK by writing your own handler.
 
 Here's an example of an after_press_handler to change the RGB lights with a layer change:
+
 ```python
 LOWER = KC.DF(LYR_LOWER) #Set layer to LOWER
 
@@ -130,10 +131,11 @@ def low_lights(key, keyboard, *args):
 
 LOWER.after_press_handler(low_lights) #call the key with the after_press_handler
 ```
+
 Here's an example of a lifecycle hook to print a giant Shrek ASCII art. It
 doesn't care about any of the arguments passed into it, because it has no
 intentions of modifying the internal state. It is purely a [side
-effect](https://en.wikipedia.org/wiki/Side_effect_(computer_science)) run every
+effect](<https://en.wikipedia.org/wiki/Side_effect_(computer_science)>) run every
 time Left Alt is pressed:
 
 ```python
@@ -168,16 +170,18 @@ SHREKLESS_ALT = KC.LALT.clone()
 ```
 
 You can also refer to a key by index:
-* KC['A']
-* KC['NO']
-* KC['LALT']
 
-or the get function which has an optional argument of `default`. `default` is
-be returned if the key is not found (`None` unless otherwise specified):
-* KC.get('A')
-* KC.get('NO', None)
-* KC.get('NOT DEFINED', KC.RALT)
+- `KC['A']`
+- `KC['NO']`
+- `KC['LALT']`
 
-Keys names are case-sensitive.  KC['NO'] being different from KC['no']. It is recommended
-that names are capitalised typically. The exception to this is alphabetical; KC['A'] and
-KC['a'] will both return the same, unshifted, key.
+Or the `KC.get` function which has an optional default argument, which will
+be returned if the key is not found (`default=None` unless otherwise specified):
+
+- `KC.get('A')`
+- `KC.get('NO', None)`
+- `KC.get('NOT DEFINED', KC.RALT)`
+
+Key names are case-sensitive. `KC['NO']` is different from `KC['no']`. It is recommended
+that names are normally UPPER_CASE. The exception to this are alpha keys; `KC['A']` and
+`KC['a']` will both return the same, unshifted, key.

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -88,7 +88,7 @@ These same steps are run for when a key is released.
 
 _So now... what's a handler, and what's a pre/post callback?!_
 
-All of these serve rougly the same purpose: to _do something_ with the key's
+All of these serve roughly the same purpose: to _do something_ with the key's
 data, or to fire off side effects. Most handlers are provided by KMK internally
 and modify the `InternalState` in some way - adding the key to the HID queue,
 changing layers, etc. The pre/post handlers are designed to allow functionality
@@ -99,7 +99,7 @@ All of these methods take the same arguments, and for this, I'll lift a
 docstring straight out of the source:
 
 > Receives the following:
-> 
+>
 > - self (this Key instance)
 > - state (the current InternalState)
 > - KC (the global KC lookup table, for convenience)
@@ -107,10 +107,10 @@ docstring straight out of the source:
 >   for the pressed key - this is likely not useful to end users, but is
 >   provided for consistency with the internal handlers)
 > - `coord_raw` (an X,Y tuple of the matrix coordinate - also likely not useful)
-> 
+>
 > The return value of the provided callback is discarded. Exceptions are _not_
 > caught, and will likely crash KMK if not handled within your function.
-> 
+>
 > These handlers are run in attachment order: handlers provided by earlier
 > calls of this method will be executed before those provided by later calls.
 
@@ -153,7 +153,7 @@ def shrek(*args, **kwargs):
     print('⠀⠀⠀⠀⠀⠀⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠃⠀⠀⠀⠀⠀⠀⠀⠀')
     print('⠀⠀⠀⠀⠀⠀⠀⠹⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠟⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀')
     print('⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⠻⠿⠿⠿⠿⠛⠉')
-    
+
     return False #Returning True will follow thru the normal handlers sending the ALT key to the OS
 KC.LALT.before_press_handler(shrek)
 ```
@@ -166,3 +166,18 @@ have my handlers attached:
 ```python
 SHREKLESS_ALT = KC.LALT.clone()
 ```
+
+You can also refer to a key by index:
+* KC['A']
+* KC['NO']
+* KC['LALT']
+
+or the get function which has an optional argument of `default`. `default` is
+be returned if the key is not found (`None` unless otherwise specified):
+* KC.get('A')
+* KC.get('NO', None)
+* KC.get('NOT DEFINED', KC.RALT)
+
+Keys names are case-sensitive.  KC['NO'] being different from KC['no']. It is recommended
+that names are capitalised typically. The exception to this is alphabetical; KC['A'] and
+KC['a'] will both return the same, unshifted, key.

--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -4,7 +4,7 @@ from micropython import const
 import kmk.handlers.stock as handlers
 from kmk.consts import UnicodeMode
 from kmk.key_validators import key_seq_sleep_validator, unicode_mode_key_validator
-from kmk.types import AttrDict, UnicodeModeKeyMeta
+from kmk.types import UnicodeModeKeyMeta
 
 DEBUG_OUTPUT = False
 

--- a/tests/test_kmk_keys.py
+++ b/tests/test_kmk_keys.py
@@ -1,6 +1,6 @@
 import unittest
 
-from kmk.keys import KC, Key, ModifierKey
+from kmk.keys import KC, Key, ModifierKey, KeyAttrDict, make_key
 from tests.keyboard_test import KeyboardTest
 
 
@@ -95,6 +95,199 @@ class TestKmkKeys(unittest.TestCase):
         assert not isinstance(KC.Q(no_press=True), ModifierKey)
         assert isinstance(KC.RALT(KC.Q), Key)
         assert not isinstance(KC.RALT(KC.Q), ModifierKey)
+
+
+import unittest
+
+from kmk.keys import KC, KeyAttrDict, make_key
+
+
+class TestKeys_dot(unittest.TestCase):
+    def setUp(self):
+        global KC
+        KC = KeyAttrDict()
+
+    def test_expected_code_uppercase(self):
+        assert 4 == KC.A.code
+
+    def test_expected_code_lowercase(self):
+        assert 4 == KC.a.code
+
+    def test_case_ignored_alpha(self):
+        upper_key = KC.A
+        lower_key = KC.a
+        assert upper_key is lower_key
+
+    def test_case_requested_order_irrelevant(self):
+        lower_key = KC.a
+        upper_key = KC.A
+        assert upper_key is lower_key
+
+    def test_secondary_name(self):
+        primary_key = KC.NO
+        secondary_key = KC.XXXXXXX
+        assert primary_key is secondary_key
+
+    def test_invalid_key_upper(self):
+        with self.assertRaises(ValueError):
+            KC.INVALID_KEY
+
+    def test_invalid_key_lower(self):
+        with self.assertRaises(ValueError):
+            KC.invalid_key
+
+    def test_custom_key(self):
+        created = make_key(
+            KC.N2.code,
+            names=(
+                'EURO',
+                '€',
+            ),
+            has_modifiers={KC.LSFT.code, KC.ROPT.code},
+        )
+        assert created is KC.get('EURO')
+        assert created is KC.get('€')
+
+    def test_match_exactly_case(self):
+        created = make_key(names=('ThIs_Is_A_StRaNgE_kEy',))
+        assert created is KC.get('ThIs_Is_A_StRaNgE_kEy')
+
+
+class TestKeys_index(unittest.TestCase):
+    def setUp(self):
+        global KC
+        KC = KeyAttrDict()
+
+    def test_expected_code_uppercase(self):
+        assert 4 == KC['A'].code
+
+    def test_expected_code_lowercase(self):
+        assert 4 == KC['a'].code
+
+    def test_case_ignored_alpha(self):
+        upper_key = KC['A']
+        lower_key = KC['a']
+        assert upper_key is lower_key
+
+    def test_case_requested_order_irrelevant(self):
+        lower_key = KC['a']
+        upper_key = KC['A']
+        assert upper_key is lower_key
+
+    def test_invalid_key_upper(self):
+        with self.assertRaises(ValueError):
+            KC['NOT_A_VALID_KEY']
+
+    def test_invalid_key_lower(self):
+        with self.assertRaises(ValueError):
+            KC['not_a_valid_key']
+
+    def test_custom_key(self):
+        created = make_key(
+            KC['N2'].code,
+            names=(
+                'EURO',
+                '€',
+            ),
+            has_modifiers={KC['LSFT'].code, KC['ROPT'].code},
+        )
+        assert created is KC['EURO']
+        assert created is KC['€']
+
+    def test_match_exactly_case(self):
+        created = make_key(names=('ThIs_Is_A_StRaNgE_kEy',))
+        assert created is KC['ThIs_Is_A_StRaNgE_kEy']
+
+
+class TestKeys_get(unittest.TestCase):
+    def setUp(self):
+        global KC
+        KC = KeyAttrDict()
+
+    def test_expected_code_uppercase(self):
+        assert 4 == KC.get('A').code
+
+    def test_expected_code_lowercase(self):
+        assert 4 == KC.get('a').code
+
+    def test_case_ignored_alpha(self):
+        upper_key = KC.get('A')
+        lower_key = KC.get('a')
+        assert upper_key is lower_key
+
+    def test_case_requested_order_irrelevant(self):
+        lower_key = KC.get('a')
+        upper_key = KC.get('A')
+        assert upper_key is lower_key
+
+    def test_secondary_name(self):
+        primary_key = KC.NO
+        secondary_key = KC.XXXXXXX
+        assert primary_key is secondary_key
+
+    def test_invalid_key_upper(self):
+        assert KC.get('INVALID_KEY') is None
+
+    def test_invalid_key_lower(self):
+        assert KC.get('not_a_valid_key') is None
+
+    def test_custom_key(self):
+        created = make_key(
+            KC.get('N2').code,
+            names=(
+                'EURO',
+                '€',
+            ),
+            has_modifiers={KC.get('LSFT').code, KC.get('ROPT').code},
+        )
+        assert created is KC.get('EURO')
+        assert created is KC.get('€')
+
+    def test_match_exactly_case(self):
+        created = make_key(names=('ThIs_Is_A_StRaNgE_kEy',))
+        assert created is KC.get('ThIs_Is_A_StRaNgE_kEy')
+
+
+# Some of these test appear silly, but they're testing we get the
+# same, single, instance back when requested through KC and that
+# order of request doesn't matter
+class TestKeys_instances(unittest.TestCase):
+    def setUp(self):
+        global KC
+        KC = KeyAttrDict()
+
+    def test_make_key_new_instance(self):
+        key1 = make_key(code=1)
+        key2 = make_key(code=1)
+        assert key1 is not key2
+        assert key1.code == key2.code
+
+    def test_index_is_index(self):
+        assert KC['A'] is KC['A']
+
+    def test_index_is_dot(self):
+        assert KC['A'] is KC.A
+
+    def test_index_is_get(self):
+        assert KC['A'] is KC.get('A')
+
+    def test_dot_is_dot(self):
+        assert KC.A is KC.A
+
+    def test_dot_is_index(self):
+        assert KC.A is KC['A']
+
+    def test_dot_is_get(self):
+        assert KC.A is KC.get('A')
+
+    def test_get_is_get(self):
+        assert KC.get('A') is KC.get('A')
+
+    def test_get_is_index(self):
+        assert KC.get('A') is KC['A']
+
+    def test_get_is_dot(self):
+        assert KC.get('A') is KC.A
 
 
 if __name__ == '__main__':

--- a/tests/test_kmk_keys.py
+++ b/tests/test_kmk_keys.py
@@ -1,6 +1,6 @@
 import unittest
 
-from kmk.keys import KC, Key, ModifierKey, KeyAttrDict, make_key
+from kmk.keys import KC, Key, KeyAttrDict, ModifierKey, make_key
 from tests.keyboard_test import KeyboardTest
 
 
@@ -95,11 +95,6 @@ class TestKmkKeys(unittest.TestCase):
         assert not isinstance(KC.Q(no_press=True), ModifierKey)
         assert isinstance(KC.RALT(KC.Q), Key)
         assert not isinstance(KC.RALT(KC.Q), ModifierKey)
-
-
-import unittest
-
-from kmk.keys import KC, KeyAttrDict, make_key
 
 
 class TestKeys_dot(unittest.TestCase):

--- a/tests/test_kmk_keys.py
+++ b/tests/test_kmk_keys.py
@@ -1,6 +1,6 @@
 import unittest
 
-from kmk.keys import KC, Key, KeyAttrDict, ModifierKey, make_key
+from kmk.keys import KC, Key, ModifierKey, make_key
 from tests.keyboard_test import KeyboardTest
 
 

--- a/tests/test_kmk_keys.py
+++ b/tests/test_kmk_keys.py
@@ -99,8 +99,7 @@ class TestKmkKeys(unittest.TestCase):
 
 class TestKeys_dot(unittest.TestCase):
     def setUp(self):
-        global KC
-        KC = KeyAttrDict()
+        KC.clear()
 
     def test_expected_code_uppercase(self):
         assert 4 == KC.A.code
@@ -150,8 +149,7 @@ class TestKeys_dot(unittest.TestCase):
 
 class TestKeys_index(unittest.TestCase):
     def setUp(self):
-        global KC
-        KC = KeyAttrDict()
+        KC.clear()
 
     def test_expected_code_uppercase(self):
         assert 4 == KC['A'].code
@@ -196,8 +194,7 @@ class TestKeys_index(unittest.TestCase):
 
 class TestKeys_get(unittest.TestCase):
     def setUp(self):
-        global KC
-        KC = KeyAttrDict()
+        KC.clear()
 
     def test_expected_code_uppercase(self):
         assert 4 == KC.get('A').code
@@ -248,8 +245,7 @@ class TestKeys_get(unittest.TestCase):
 # order of request doesn't matter
 class TestKeys_instances(unittest.TestCase):
     def setUp(self):
-        global KC
-        KC = KeyAttrDict()
+        KC.clear()
 
     def test_make_key_new_instance(self):
         key1 = make_key(code=1)


### PR DESCRIPTION
Rework of #405.

This is the minimum that gives KC.keyname, KC['keyname'] and KC.get('keyname') with tests.