### PR TITLE
 Added on to the docs for splits using encoders

### DIFF
--- a/docs/encoder.md
+++ b/docs/encoder.md
@@ -3,6 +3,8 @@ Add twist control to your keyboard! Volume, zoom, anything you want
 
 I2C encoder type has been tested with the Adafruit I2C QT Rotary Encoder with NeoPixel
 
+**Note:** If using a split keyboard best to use the [encoder-scanner](scanners.md) encoder explained at the bottom of scanners docs.
+
 ## Enabling the extension
 The constructor(`EncoderHandler` class) takes a list of encoder, each one defined as either:
 

--- a/docs/encoder.md
+++ b/docs/encoder.md
@@ -3,7 +3,7 @@ Add twist control to your keyboard! Volume, zoom, anything you want
 
 I2C encoder type has been tested with the Adafruit I2C QT Rotary Encoder with NeoPixel
 
-**Note:** If using a split keyboard best to use the [encoder-scanner](scanners.md) encoder explained at the bottom of scanners docs.
+**Note:** If split with encoders and both sides should work, it's currently necessary to use the encoder-scanner explained at the bottom of [scanners docs](scanners.md).
 
 ## Enabling the extension
 The constructor(`EncoderHandler` class) takes a list of encoder, each one defined as either:

--- a/docs/scanners.md
+++ b/docs/scanners.md
@@ -143,7 +143,6 @@ class MyKeyboard(KMKKeyboard):
 ```
 
 
-
 ## `Scanner` base class
 
 If you require a different type of scanner, you can create your own by
@@ -161,7 +160,7 @@ example: The bulk of the keyboard may be scanned with a matrix scanner, but a
 couple of additional keys are directly connected to GPIOs.
 In that case KMK allows you to define multiple scanners. The `KMKKeyboard.matrix` attribute can either be assigned a single scanner, or a list of scanners.
 KMK assumes that successive scanner keys are consecutive, and populates
-`KMKKeyboard.coord_mapping` accordingly; for convenience you may have to supply a `coord_mapping` that resembles your physical layout more closely.
+`KMKKeyboard.coord_mapping` accordingly; for convenience you may have to supply a `coord_mapping` that resembles your physical layout more closely (expanded below).
 
 Example:
 ```python
@@ -173,9 +172,9 @@ class MyKeyboard(KMKKeyboard):
     ]
 ```
 #### Multiple Scanners coord_mapping and keymap changes
-To add more scanners you need to add onto your your " coord_mapping " Example below.
+To add more scanners you need to add onto your "coord_mapping" Example below.
 
-Before:
+Coord_mapping before with just "MatrixScanner" on a 58 key split keyboard:
 ```python
 coord_mapping = [
      0,  1,  2,  3,  4,  5,         35, 34, 33, 32, 31, 30,
@@ -186,7 +185,7 @@ coord_mapping = [
     ]
 ```
 
-After:
+Coord_mapping after using "RotaryioEncoder" and "MatrixScanner" on the same 58 key split keyboard with an encoder on each half:
 ```python
 coord_mapping = [
      0,  1,  2,  3,  4,  5,         37, 36, 35, 34, 33, 32,
@@ -197,6 +196,5 @@ coord_mapping = [
             30, 31,                         62, 63 
     ]
 ```
-This is as complicated as it can be. Split with "RotaryioEncoder" and "MatrixScanner". You will see that the top left side used to count up to 29 and the right side started at 30. With the encoder module added on the left side has 2 more keys so it now counts up to 31 and the right side starts its count at 32 and continues to 63. 30,31,62 and 63 are all for encoders. You will see that all of the encoders are at the end of the array, this means that we need to add 4 more key codes to the end of our `keymap` in `main.py`  
 
-
+On the top left side of a standard split keyboard "coord_mapping", right below that you see a split keyboard where "RotaryioEncoder" and "MatrixScanner"(the default scanner) are used. In the before example, we used to count from 0 to 29 while the top right side starts at 30. With the addition of the encoder scanner, the left side has 2 additional keys making it count up to 31 and the right side would then start at 32 and count to 63. This means that keys 30, 31, 62, and 63 are for encoders. Notice that all of the encoders are at the end of the array. Therefore, we need to add 4 more key codes to the end of our `keyboard.keymap`, They will be used for the encoders.

--- a/docs/scanners.md
+++ b/docs/scanners.md
@@ -26,8 +26,8 @@ class MyKeyboard(KMKKeyboard):
         # create and register the scanner
         self.matrix = MatrixScanner(
             # required arguments:
-            cols=self.col_pins,
-            rows=self.row_pins,
+            column_pins=self.col_pins,
+            row_pins=self.row_pins,
             # optional arguments with defaults:
             columns_to_anodes=DiodeOrientation.COL2ROW,
             interval=0.02,
@@ -143,6 +143,7 @@ class MyKeyboard(KMKKeyboard):
 ```
 
 
+
 ## `Scanner` base class
 
 If you require a different type of scanner, you can create your own by
@@ -171,3 +172,31 @@ class MyKeyboard(KMKKeyboard):
         # etc...
     ]
 ```
+#### Multiple Scanners coord_mapping and keymap changes
+To add more scanners you need to add onto your your " coord_mapping " Example below.
+
+Before:
+```python
+coord_mapping = [
+     0,  1,  2,  3,  4,  5,         35, 34, 33, 32, 31, 30,
+     6,  7,  8,  9, 10, 11,         41, 40, 39, 38, 37, 36,
+    12, 13, 14, 15, 16, 17,         47, 46, 45, 44, 43, 42,
+    18, 19, 20, 21, 22, 23, 29, 59, 53, 52, 51, 50, 49, 48,
+            25, 26, 27, 28,         58, 57, 56, 55, 
+    ]
+```
+
+After:
+```python
+coord_mapping = [
+     0,  1,  2,  3,  4,  5,         37, 36, 35, 34, 33, 32,
+     6,  7,  8,  9, 10, 11,         43, 42, 41, 40, 39, 38,
+    12, 13, 14, 15, 16, 17,         49, 48, 47, 46, 45, 44,
+    18, 19, 20, 21, 22, 23, 29, 61, 55, 54, 53, 52, 51, 50,
+            25, 26, 27, 28,         60, 59, 58, 57,
+            30, 31,                         62, 63 
+    ]
+```
+This is as complicated as it can be. Split with "RotaryioEncoder" and "MatrixScanner". You will see that the top left side used to count up to 29 and the right side started at 30. With the encoder module added on the left side has 2 more keys so it now counts up to 31 and the right side starts its count at 32 and continues to 63. 30,31,62 and 63 are all for encoders. You will see that all of the encoders are at the end of the array, this means that we need to add 4 more key codes to the end of our `keymap` in `main.py`  
+
+

--- a/docs/scanners.md
+++ b/docs/scanners.md
@@ -172,9 +172,11 @@ class MyKeyboard(KMKKeyboard):
     ]
 ```
 #### Multiple Scanners coord_mapping and keymap changes
-To add more scanners you need to add onto your "coord_mapping" Example below.
+To add more scanners you need to add onto your `coord_mapping`.
 
-Coord_mapping before with just "MatrixScanner" on a 58 key split keyboard:
+Example:
+
+`coord_mapping` with just one `MatrixScanner` on a 58 key split keyboard:
 ```python
 coord_mapping = [
      0,  1,  2,  3,  4,  5,         35, 34, 33, 32, 31, 30,
@@ -185,7 +187,7 @@ coord_mapping = [
     ]
 ```
 
-Coord_mapping after using "RotaryioEncoder" and "MatrixScanner" on the same 58 key split keyboard with an encoder on each half:
+`coord_mapping` using `MatrixScanner` and `RotaryioEncoder` on the same 58 key split keyboard with an encoder on each half:
 ```python
 coord_mapping = [
      0,  1,  2,  3,  4,  5,         37, 36, 35, 34, 33, 32,
@@ -197,4 +199,9 @@ coord_mapping = [
     ]
 ```
 
-On the top left side of a standard split keyboard "coord_mapping", right below that you see a split keyboard where "RotaryioEncoder" and "MatrixScanner"(the default scanner) are used. In the before example, we used to count from 0 to 29 while the top right side starts at 30. With the addition of the encoder scanner, the left side has 2 additional keys making it count up to 31 and the right side would then start at 32 and count to 63. This means that keys 30, 31, 62, and 63 are for encoders. Notice that all of the encoders are at the end of the array. Therefore, we need to add 4 more key codes to the end of our `keyboard.keymap`, They will be used for the encoders.
+On the top left side of a standard split keyboard `coord_mapping`, right below that you see a split keyboard where `RotaryioEncoder` and `MatrixScanner` (the default scanner) are used.
+In the single scanner example, we used to count from 0 to 29 while the top right side starts at 30.
+With the addition of the encoder scanner, the left side has 2 additional keys making it count up to 31 and the right side would then start at 32 and count to 63.
+This means that keys 30, 31, 62, and 63 are for encoders.
+Notice that all of the encoders are at the end of the array, because we put the encoder scanner after the matrix scanner in `keyboard.matrix`.
+Therefore, we need to add 4 more key codes in the corresponding places of our `keyboard.keymap`, they will be used for the encoders.


### PR DESCRIPTION
As you may have seen I have closed my last split/encoder pr. After talking with xs and being made aware that the encoder scanner does what I wanted (splits with encoders). So I figured out what I needed to do to get it working and now have updated the docs to be what would have been nice to have and would have made it effortless for me. 

Also made changes to lines 29 and 30 because they are just wrong and would not work.