### PR TITLE
markdown spelling and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ channel below.
 - [Chainable
   keys](https://github.com/KMKfw/kmk_firmware/blob/master/docs/keys.md) such as
   `KC.LWIN(KC.L)` to lock the screen on a Windows PC
-- [Built-in unicode macros, including
+- [Built-in Unicode macros, including
   emojis](https://github.com/KMKfw/kmk_firmware/blob/master/docs/sequences.md)
 - [RGB underglow](https://github.com/KMKfw/kmk_firmware/blob/master/docs/rgb.md)
   and [LED

--- a/boards/kyria/README.md
+++ b/boards/kyria/README.md
@@ -10,9 +10,9 @@ Keyboard works with controllers having Pro Micro layout. Existing configurations
 
 | PCB version | Board                                                                | Config file               |
 |:-----------:|----------------------------------------------------------------------|---------------------------|
-|     1.*     | [Sparkfun Pro Micro RP2040](https://www.sparkfun.com/products/18288) | kyria_v1_rp2040           |
+|     1.*     | [SparkFun Pro Micro RP2040](https://www.sparkfun.com/products/18288) | kyria_v1_rp2040           |
 |     1.*     | [Adafruit KB2040](https://www.adafruit.com/product/5302)             | kyria_v1_kb2040           |
-|     2.*     | [Sparkfun Pro Micro RP2040](https://www.sparkfun.com/products/18288) | _waiting for pinout docs_ |
+|     2.*     | [SparkFun Pro Micro RP2040](https://www.sparkfun.com/products/18288) | _waiting for pinout docs_ |
 |     2.*     | [Adafruit KB2040](https://www.adafruit.com/product/5302)             | _waiting for pinout docs_ |
 
 ## Compatibility issues

--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -54,7 +54,7 @@ if __name__ == '__main__':
 ### You're extremely lucky and you have a fully supported keyboard
 If your keyboard and microcontroller are officially supported, simply visit the page for your files, and dropping them on the root of the "flash drive". Those pages can be found [here](https://github.com/KMKfw/kmk_firmware/tree/master/boards). You will need the `kb.py` and `main.py`. More advanced instructions can be found [here](config_and_keymap.md).
 
-### You've got another, maybe DIY, board and want to customise KMK for it  
+### You've got another, maybe DIY, board and want to customize KMK for it  
 First, be sure to understand how your device work, and particularly its specific matrix configuration. You can have a look [here](http://pcbheaven.com/wikipages/How_Key_Matrices_Works/) or read the [guide](https://docs.qmk.fm/#/hand_wire) provided by the QMK team for handwired keyboards
 <br>Once you've got the gist of it:
 - You can have a look [here](config_and_keymap.md) and [here](keys.md) to start customizing your code.py / main.py file
@@ -64,7 +64,7 @@ First, be sure to understand how your device work, and particularly its specific
 And to go even further:
 - [Sequences](sequences.md) are used for sending multiple keystrokes in a single action
 - [Layers](layers.md) can transform the whole way your keyboard is behaving with a single touch
-- [ModTap](modtap.md) allow you to customize the way a key behaves wether it is tapped or hold, and [TapDance](tapdance.md) depending on the number of times it is pressed
+- [ModTap](modtap.md) allow you to customize the way a key behaves whether it is tapped or hold, and [TapDance](tapdance.md) depending on the number of times it is pressed
 
 Want to have fun features such as RGB, split keyboards and more? Check out what builtin [modules](modules.md) and [extensions](extensions.md) can do!
 You can also get ideas from the various [user examples](https://github.com/KMKfw/kmk_firmware/tree/master/user_keymaps) that we provide and dig into our [documentation](README.md).

--- a/docs/Officially_Supported_Microcontrollers.md
+++ b/docs/Officially_Supported_Microcontrollers.md
@@ -3,7 +3,7 @@ While most CircuitPython devices are great for hand wired keyboards, most
 keyboards are designed to accept a Pro Micro. The boards listed below either 
 are, or can be adapted to that pinout to use common keyboards already on the market.
 
-## Nice!Nano
+## nice!nano
 Features include
 - Pro Micro pinout
 - Both USB HID and Bluetooth support
@@ -13,13 +13,13 @@ Features include
 Downsides
 - $25 USD per microcontroller at most retailers
 
-### Pre-compiling KMK for Nice!Nano
-Nice!Nano has limited flash memory which does not fit CircuitPython, adafruit-ble, and KMK by default. You will need to use pre-compiled KMK to get it to fit. Grab [compatible mpy-cross](https://adafruit-circuit-python.s3.amazonaws.com/index.html?prefix=bin/mpy-cross/) and run `make compile` to generate `.mpy` version of KMK files before copying them over. 
+### Pre-compiling KMK for nice!nano
+nice!nano has limited flash memory which does not fit CircuitPython, adafruit-ble, and KMK by default. You will need to use pre-compiled KMK to get it to fit. Grab [compatible mpy-cross](https://adafruit-circuit-python.s3.amazonaws.com/index.html?prefix=bin/mpy-cross/) and run `make compile` to generate `.mpy` version of KMK files before copying them over.
 
 
 Common Retailers
-[Boardsource](https://boardsource.xyz/store/5f4a1733bbaa5c635b83ed67)
-[NiceKeyboards](https://nicekeyboards.com/collections/group-buy/products/nice-nano-v1-0).
+- [Boardsource](https://boardsource.xyz/store/5f4a1733bbaa5c635b83ed67)
+- [Nice Keyboards](https://nicekeyboards.com/nice-nano/)
 
 ## ItsyBitsy M4 Express
 Features include
@@ -31,7 +31,7 @@ Downsides
 [HERE](https://github.com/KMKfw/kmk_firmware/tree/master/hardware)
 
 Common Retailers
-[Adafruit](https://www.adafruit.com/product/3800)
+- [Adafruit](https://www.adafruit.com/product/3800)
 
 ## RP2040
 Features include
@@ -42,13 +42,13 @@ Downsides
 - Little support for keyboard kits
 
 Common Retailers
-[Adafruit](https://www.adafruit.com/pico?src=raspberrypi)
-[SparkFun](https://www.sparkfun.com/products/17829?src=raspberrypi)
+- [Adafruit](https://www.adafruit.com/pico?src=raspberrypi)
+- [SparkFun](https://www.sparkfun.com/products/17829?src=raspberrypi)
 
 ## Adafruit ItsyBitsy nRF52840 Express
 Features include
 - Both USB HID and Bluetooth support
-- More affordable than the Nice!Nano at only $18
+- More affordable than the nice!nano at only $18
 
 Downsides
 - Needs adapted to work with Pro Micro pinout keyboards. Adapter can be found
@@ -57,7 +57,7 @@ Downsides
 [HERE](https://www.adafruit.com/product/2124) 
 
 Common Retailers
-[Adafruit](https://www.adafruit.com/product/4481)
+- [Adafruit](https://www.adafruit.com/product/4481)
 
 ## Other microcontrollers
 What you'll need to have at minimum

--- a/docs/Officially_Supported_Microcontrollers.md
+++ b/docs/Officially_Supported_Microcontrollers.md
@@ -1,5 +1,5 @@
 # Officially supported microcontrollers
-While most Circuitpython devices are great for hand wired keyboards, most 
+While most CircuitPython devices are great for hand wired keyboards, most
 keyboards are designed to accept a Pro Micro. The boards listed below either 
 are, or can be adapted to that pinout to use common keyboards already on the market.
 
@@ -7,7 +7,7 @@ are, or can be adapted to that pinout to use common keyboards already on the mar
 Features include
 - Pro Micro pinout
 - Both USB HID and Bluetooth support
-- Can do bluetooth split keyboards with no wires at all
+- Can do Bluetooth split keyboards with no wires at all
 - Has battery support including charging
 
 Downsides
@@ -43,7 +43,7 @@ Downsides
 
 Common Retailers
 [Adafruit](https://www.adafruit.com/pico?src=raspberrypi)
-[Sparkfun](https://www.sparkfun.com/products/17829?src=raspberrypi)
+[SparkFun](https://www.sparkfun.com/products/17829?src=raspberrypi)
 
 ## Adafruit ItsyBitsy nRF52840 Express
 Features include

--- a/docs/adns9800.md
+++ b/docs/adns9800.md
@@ -5,7 +5,7 @@ from kmk.modules.adns9800 import ADNS9800
 keyboard.modules.append(ADNS9800(cs=board.GP0, sclk=board.GP2, miso=board.GP4, mosi=board.GP3, invert_y=True))
 ```
 
-Firmware for this sensor has to be obtained separately and placed in kmk\modules\adns9800_firmware.py
+Firmware for this sensor has to be obtained separately and placed in `kmk\modules\adns9800_firmware.py`
 ```python
 firmware = (
     b'\x03'
@@ -15,4 +15,5 @@ firmware = (
 ```
 
 ## Constructor parameters
+
 ADNS9800(cs=*cs_pin*, sclk=*clock_pin*, miso=*miso_pin*, mosi=*mosi_pin*, invert_x=*False*, invert_y=*False*)

--- a/docs/ble_hid.md
+++ b/docs/ble_hid.md
@@ -1,12 +1,12 @@
 # BLE HID
 Bluetooth connections help clean up the wire mess!
 
-## Circuitpython
-If not running KMKpython, this does require the adafruit_ble library from Adafruit.
+## CircuitPython
+If not running KMKPython, this does require the adafruit_ble library from Adafruit.
 This can be downloaded
 [here](https://github.com/adafruit/Adafruit_CircuitPython_BLE/tree/master/adafruit_ble).
 It is part of the [Adafruit CircuitPython Bundle](https://github.com/adafruit/Adafruit_CircuitPython_Bundle).
-Simply put this in the "root" of your circuitpython device. If unsure, it's the folder with main.py in it, and should be the first folder you see when you open the device.
+Simply put this in the "root" of your CircuitPython device. If unsure, it's the folder with main.py in it, and should be the first folder you see when you open the device.
 
 ## Enabling BLE
 

--- a/docs/boot.md
+++ b/docs/boot.md
@@ -4,7 +4,7 @@ There is a more detailed explanation in the [circuit python docs](https://docs.c
 however there are some common use cases for your keyboard listed here.
 
 ## Hiding device storage
-You can hide your device from showing up as a usb storage by default (this can be overridden 
+You can hide your device from showing up as a USB storage by default (this can be overridden 
 at startup if desired, per the example code further down this page).
 
 ```python
@@ -28,7 +28,7 @@ usb_cdc.disable()
 ```
 
 ## Example code
-Below is a fully working example, which disables usb storage, cdc and enables BIOS mode.
+Below is a fully working example, which disables USB storage, CDC and enables BIOS mode.
 
 ```python
 import supervisor

--- a/docs/capsword.md
+++ b/docs/capsword.md
@@ -1,6 +1,6 @@
 # CapsWord
-The capsword module functions similar to caps lock but will deactivate automatically when its encounters a key that breaks the word or after inactivity timeout.  
-By default it will not deactivate capsword on numbers, alphabets, underscore, modifiers, minus, backspace and other keys like modtap, layers, etc.
+The CapsWord module functions similar to caps lock but will deactivate automatically when its encounters a key that breaks the word or after inactivity timeout.
+By default it will not deactivate CapsWord on numbers, alphabets, underscore, modifiers, minus, backspace and other keys like ModTap, Layers, etc.
 Add it to your keyboard's modules list with:
 
 ```python
@@ -24,4 +24,4 @@ keyboard.keymap = [
 
 |Key                    |Aliases             |Description                                    |
 |-----------------------|--------------------|-----------------------------------------------|
-|`KC.CW`                |`KC.CAPSWORD`       |Enables/disables capsword                      |
+|`KC.CW`                |`KC.CAPSWORD`       |Enables/disables CapsWord                      |

--- a/docs/capsword.md
+++ b/docs/capsword.md
@@ -1,6 +1,6 @@
 # CapsWord
-The capsword module functions similar to caps lock but will deactive automatically when its encounters a key that breaks the word or after inactivity timeout.  
-By default it will not deactive capsword on numbers, alphabets, underscore, modifiers, minus, backspace and other keys like modtap, layers, etc.
+The capsword module functions similar to caps lock but will deactivate automatically when its encounters a key that breaks the word or after inactivity timeout.  
+By default it will not deactivate capsword on numbers, alphabets, underscore, modifiers, minus, backspace and other keys like modtap, layers, etc.
 Add it to your keyboard's modules list with:
 
 ```python

--- a/docs/cg_swap.md
+++ b/docs/cg_swap.md
@@ -1,5 +1,5 @@
-# Ctrl Gui Swap
-This module allows to swap Ctrl with Gui and vice versa. This will reset on restart to the default implementation
+# Ctrl GUI Swap
+This module allows to swap Ctrl with GUI and vice versa. This will reset on restart to the default implementation
 
 ## Enabling the module
 ```python

--- a/docs/combos.md
+++ b/docs/combos.md
@@ -15,7 +15,7 @@ corresponding handlers.
 Combos may overlap, i.e. share match keys amongst each other.
 
 The optional arguments `timeout` and `per_key_timeout` define the time window
-within which the match has to happen and wether the timeout is renewed after
+within which the match has to happen and whether the timeout is renewed after
 each key press, respectively. These can be customized for every combo
 individually.
 

--- a/docs/config_and_keymap.md
+++ b/docs/config_and_keymap.md
@@ -3,7 +3,7 @@
 KMK is configured through a rather large plain-old-Python class called
 `KMKKeyboard`. Subclasses of this configuration exist which pre-fill defaults
 for various known keyboards (for example, many QMK, TMK, or ZMK keyboards 
-are supported with a nice!nano, or through our ItsyBitsy to ProMicro pinout adapter. 
+are supported with a nice!nano, or through our ItsyBitsy to Pro Micro pinout adapter. 
 This class is the main interface between end users and the inner workings of KMK. 
 Let's dive in!
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -30,7 +30,7 @@ them to be executed in a desktop development environment.
 
 Execute tests using the command `python -m unittest`.
 
-## Contriburing Documentation
+## Contributing Documentation
 While KMK welcomes documentation from anyone with and understanding of the issues 
 and a willingness to write them up, it's a good idea to familiarize yourself with 
 the docs. Documentation should be informative but concise.
@@ -61,7 +61,7 @@ functions or Python keywords within the body of paragraphs or in lists.
 ## License, Copyright, and Legal
 
 All software in this repository is licensed under the [GNU Public License,
-verison 3](https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)).
+version 3](https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)).
 All documentation and hardware designs are licensed under the [Creative Commons
 Attribution-ShareAlike 4.0](https://creativecommons.org/licenses/by-sa/4.0/)
 license. Contributions to this repository must use these licenses unless

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,7 +25,7 @@ to Black formatting as documented in `pyproject.toml`)
 
 ### Tests
 
-Unit tests within the `tests` folder mock various CicuitPython modules to allow
+Unit tests within the `tests` folder mock various CircuitPython modules to allow
 them to be executed in a desktop development environment.
 
 Execute tests using the command `python -m unittest`.

--- a/docs/easypoint.md
+++ b/docs/easypoint.md
@@ -1,4 +1,4 @@
-# AS5013 (aka. 'EasyPoint')
+# AS5013 (aka 'EasyPoint')
 
 Module handles the AM5013 Two-dimensional magnetic position sensor with digital coordinates output
 

--- a/docs/encoder.md
+++ b/docs/encoder.md
@@ -6,7 +6,7 @@ I2C encoder type has been tested with the Adafruit I2C QT Rotary Encoder with Ne
 ## Enabling the extension
 The constructor(`EncoderHandler` class) takes a list of encoder, each one defined as either:
 
-* a list of pad_a pin, pad_b pin, button_pin and optionnally a flag set to True is you want it to be reversed
+* a list of pad_a pin, pad_b pin, button_pin and optionally a flag set to True is you want it to be reversed
 * a `busio.I2C`, address and optionally a flag set to True if you want it to be reversed
 
 The encoder_map is modeled after the keymap and works the same way. It should have as many layers (key pressed on "turned left", key pressed on "turned right", key pressed on "knob pressed") as your keymap, and use KC.NO keys for layers that you don't require any action.

--- a/docs/extension_statusled.md
+++ b/docs/extension_statusled.md
@@ -1,8 +1,8 @@
 # Status LEDs
 
-Indicate which layer you are on with ah array of single leds.
+Indicate which layer you are on with an array of single leds.
 
-During startup the leds light up to indicte that the bootup is finished.
+During startup the leds light up to indicate that the bootup is finished.
 
 For the time being just a simple consecutive single led
 indicator. And when there are more layers than leds it

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -2,7 +2,7 @@
 
 In general, we recommend using the instructions in `README.md`, however, mostly
 as a development artifact, another method of flashing KMK exists (tested and
-supported only on Linux, though it should also work on MacOS, the BSDs, and
+supported only on Linux, though it should also work on macOS, the BSDs, and
 other Unix-likes. It may also work on Cygwin and the Windows Subsystem for
 Linux).
 

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -201,7 +201,7 @@
 |`KC.BKDL`              |Backspace when tapped, Delete when pressed with GUI                  |
 |`KC.UC_MODE_NOOP`      |Sets UnicodeMode to NOOP                                             |
 |`KC.UC_MODE_LINUX`     |Sets UnicodeMode to Linux                                            |
-|`KC.UC_MODE_MACOS`     |Sets UnicodeMode to MocOS                                            |
+|`KC.UC_MODE_MACOS`     |Sets UnicodeMode to macOS                                            |
 |`KC.UC_MODE_WINC`      |Sets UnicodeMode to WinCompose                                       |
 |`KC.MACRO_SLEEP_MS(ms)`|Sleeps in a macro. Check MACROS for more information.                |
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -88,7 +88,7 @@ These same steps are run for when a key is released.
 
 _So now... what's a handler, and what's a pre/post callback?!_
 
-All of these serve rougly the same purpose: to _do something_ with the key's
+All of these serve roughly the same purpose: to _do something_ with the key's
 data, or to fire off side effects. Most handlers are provided by KMK internally
 and modify the `InternalState` in some way - adding the key to the HID queue,
 changing layers, etc. The pre/post handlers are designed to allow functionality

--- a/docs/kmkpython_vs_circuitpython.md
+++ b/docs/kmkpython_vs_circuitpython.md
@@ -2,25 +2,25 @@
 
 ## Firmware of choice
 ### KMKPython
-KMKPython is a fork of Circuitpython, but with libraries for most extensions 
+KMKPython is a fork of CircuitPython, but with libraries for most extensions
 built in. This saves you from having to get them all and keep them updated 
 yourself. There may be other features added in the future that are exclusive to 
 KMKPython. For the nice!nano, this is highly recommended, and used in place of 
-Circuitpython.  
+CircuitPython.
 Notable differences include
-- Built in libraries for bluetooth, RGB, and more
+- Built in libraries for Bluetooth, RGB, and more
 - Saves space as builds are optimized for keyboards
 - Microcontrollers like the nice!nano will be able to access all features out of
 the box.
 
-### Circuitpython
-Circuitpython can be installed by following this guide using the guide 
+### CircuitPython
+CircuitPython can be installed by following this guide using the guide
 [here](https://learn.adafruit.com/welcome-to-circuitpython/installing-circuitpython). 
 It's recommended to run the latest stable version that is at least 5.0 or higher.
 Beta versions may work, but expect limited support.
 #### Notable differences include
  - Supports more devices
- - Less built in libraries. If using RGB, bluetooth, and more, you will have to 
+ - Less built in libraries. If using RGB, Bluetooth, and more, you will have to
  add these libraries yourself
  - Some devices such as the nice!nano don't have much free space, so not all 
  features can be installed at the same time

--- a/docs/modtap.md
+++ b/docs/modtap.md
@@ -12,21 +12,21 @@ keyboard.modules.append(modtap)
 
 ## Keycodes
 
-|New Keycode                                            | Description                                                     |
-|-------------------------------------------------------|-----------------------------------------------------------------|
-|LCTL = KC.MT(KC.SOMETHING, KC.LCTRL)                   |`LCTRL` if held `kc` if tapped                                   |
-|LSFT = KC.MT(KC.SOMETHING, KC.LSFT)                    |`LSHIFT` if held `kc` if tapped                                  |
-|LALT = KC.MT(KC.SOMETHING, KC.LALT)                    |`LALT` if held `kc` if tapped                                    |
-|LGUI = KC.MT(KC.SOMETHING, KC.LGUI)                    |`LGUI` if held `kc` if tapped                                    |
-|RCTL = KC.MT(KC.SOMETHING, KC.RCTRL)                   |`RCTRL` if held `kc` if tapped                                   |
-|RSFT = KC.MT(KC.SOMETHING, KC.RSFT)                    |`RSHIFT` if held `kc` if tapped                                  |
-|RALT = KC.MT(KC.SOMETHING, KC.RALT)                    |`RALT` if held `kc` if tapped                                    |
-|RGUI = KC.MT(KC.SOMETHING, KC.RGUI)                    |`RGUI` if held `kc` if tapped                                    |
-|SGUI = KC.MT(KC.SOMETHING, KC.LSHFT(KC.LGUI))          |`LSHIFT` and `LGUI` if held `kc` if tapped                       |
-|LCA = KC.MT(KC.SOMETHING, KC.LCTRL(KC.LALT))           |`LCTRL` and `LALT` if held `kc` if tapped                        |
-|LCAG = KC.MT(KC.SOMETHING, KC.LCTRL(KC.LALT(KC.LGUI))) |`LCTRL` and `LALT` and `LGUI` if held `kc` if tapped             |
-|MEH = KC.MT(KC.SOMETHING, KC.LCTRL(KC.LSFT(KC.LALT)))  |`CTRL` and `LSHIFT` and `LALT` if held `kc` if tapped            |
-|HYPR = KC.MT(KC.SOMETHING, KC.HYPR)                    |`LCTRL` and `LSHIFT` and `LALT` and `LGUI` if held `kc` if tapped|
+|New Keycode                                              | Description                                                     |
+|---------------------------------------------------------|-----------------------------------------------------------------|
+|`LCTL = KC.MT(KC.SOMETHING, KC.LCTRL)`                   |`LCTRL` if held `kc` if tapped                                   |
+|`LSFT = KC.MT(KC.SOMETHING, KC.LSFT)`                    |`LSHIFT` if held `kc` if tapped                                  |
+|`LALT = KC.MT(KC.SOMETHING, KC.LALT)`                    |`LALT` if held `kc` if tapped                                    |
+|`LGUI = KC.MT(KC.SOMETHING, KC.LGUI)`                    |`LGUI` if held `kc` if tapped                                    |
+|`RCTL = KC.MT(KC.SOMETHING, KC.RCTRL)`                   |`RCTRL` if held `kc` if tapped                                   |
+|`RSFT = KC.MT(KC.SOMETHING, KC.RSFT)`                    |`RSHIFT` if held `kc` if tapped                                  |
+|`RALT = KC.MT(KC.SOMETHING, KC.RALT)`                    |`RALT` if held `kc` if tapped                                    |
+|`RGUI = KC.MT(KC.SOMETHING, KC.RGUI)`                    |`RGUI` if held `kc` if tapped                                    |
+|`SGUI = KC.MT(KC.SOMETHING, KC.LSHFT(KC.LGUI))`          |`LSHIFT` and `LGUI` if held `kc` if tapped                       |
+|`LCA = KC.MT(KC.SOMETHING, KC.LCTRL(KC.LALT))`           |`LCTRL` and `LALT` if held `kc` if tapped                        |
+|`LCAG = KC.MT(KC.SOMETHING, KC.LCTRL(KC.LALT(KC.LGUI)))` |`LCTRL` and `LALT` and `LGUI` if held `kc` if tapped             |
+|`MEH = KC.MT(KC.SOMETHING, KC.LCTRL(KC.LSFT(KC.LALT)))`  |`CTRL` and `LSHIFT` and `LALT` if held `kc` if tapped            |
+|`HYPR = KC.MT(KC.SOMETHING, KC.HYPR)`                    |`LCTRL` and `LSHIFT` and `LALT` and `LGUI` if held `kc` if tapped|
 
 ## Custom HoldTap Behavior
 The full ModTap signature is as follows:

--- a/docs/modtap.md
+++ b/docs/modtap.md
@@ -35,7 +35,7 @@ KC.MT(KC.TAP, KC.HOLD, prefer_hold=True, tap_interrupted=False, tap_time=None)
 ```
 * `prefer_hold`: decides which keycode the ModTap key resolves to when another
   key is pressed before the timeout finishes. When `True` the hold keycode is
-  choosen, the tap keycode when `False`.
+  chosen, the tap keycode when `False`.
 * `tap_interrupted`: decides if the timeout will interrupt at the first other
   key press/down, or after the first other key up/release. Set to `True` for
   interrupt on release.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -29,4 +29,4 @@ These modules are for specific hardware and may require additional libraries to 
 - [ADNS9800](adns9800.md): Controlling ADNS9800 optical sensor.
 - [Encoder](encoder.md): Handling rotary encoders.
 - [Pimoroni trackball](pimoroni_trackball.md): Handling a small I2C trackball made by Pimoroni.
-- [AS5013 aka. easypoint](easypoint.md): Handling a small I2C magnetic position sensor made by AMS.
+- [AS5013 aka EasyPoint](easypoint.md): Handling a small I2C magnetic position sensor made by AMS.

--- a/docs/mouse_keys.md
+++ b/docs/mouse_keys.md
@@ -1,5 +1,8 @@
 # Mouse keys
-To enable mouse cursor and/or mouse buttons control from the keyboard add this module to list:
+
+To enable mouse cursor and/or mouse buttons control from the keyboard add this
+module to list:
+
 ```python
 from kmk.modules.mouse_keys import MouseKeys
 keyboard.modules.append(MouseKeys())
@@ -7,14 +10,14 @@ keyboard.modules.append(MouseKeys())
 
 # Keycodes
 
-|Keycode        | Description               |
-|---------------|---------------------------|
-|MB_LMB         |Left mouse button          |
-|MB_RMB         |Right mouse button         |
-|MB_MMB         |Middle mouse button        |
-|MW_UP          |Mouse wheel up             |
-|MW_DOWN, MW_DN |Mouse wheel down           |
-|MS_UP          |Move mouse cursor up       |
-|MS_DOWN, MS_DN |Move mouse cursor down     |
-|MS_LEFT, MS_LT |Move mouse cursor left     |
-|MS_RIGHT, MS_RT|Move mouse cursor right    |
+| Keycode             | Description                          |
+|---------------------|--------------------------------------|
+| `MB_LMB`            | Left mouse button                    |
+| `MB_RMB`            | Right mouse button                   |
+| `MB_MMB`            | Middle mouse button                  |
+| `MW_UP`             | Mouse wheel up                       |
+| `MW_DOWN`, `MW_DN`  | Mouse wheel down                     |
+| `MS_UP`             | Move mouse cursor up                 |
+| `MS_DOWN`, `MS_DN`  | Move mouse cursor down               |
+| `MS_LEFT`, `MS_LT`  | Move mouse cursor left               |
+| `MS_RIGHT`, `MS_RT` | Move mouse cursor right              |

--- a/docs/porting_to_kmk.md
+++ b/docs/porting_to_kmk.md
@@ -16,7 +16,7 @@ class KMKKeyboard(_KMKKeyboard):
 
 ## REQUIRED
 This is designed to be replaced with the defining pins of your keyboard. Rows, 
-colums and the diode direction (if any), should be defined like this
+columns and the diode direction (if any), should be defined like this
 ```python
     row_pins = [board.p0_31, board.p0_29, board.p0_02, board.p1_15]
     col_pins = [board.p0_22, board.p0_24, board.p1_00, board.p0_11, board.p1_04]
@@ -25,15 +25,15 @@ colums and the diode direction (if any), should be defined like this
 
 ## Additional pins for extensions
 KMK includes built in extensions for RGB and split keyboards, and powersave. If
-these are applicible on your keyboard/microcontroller, the pins should be added
+these are applicable on your keyboard/microcontroller, the pins should be added
 here. Refer to the instructions on the respective extensions page on how to add 
 them. If not adding any extensions, leave this as an empty list as shown.
 
 # Coord mapping
 If your keyboard is not built electrically as a square (though most are), you can
 provide a mapping directly. An example of this is the 
-[Corne](https://github.com/foostan/crkbd). That has 12 colums for 3 rows, and 6 
-colums for the bottom row. Split keyboards count as the total keyboard, not per 
+[Corne](https://github.com/foostan/crkbd). That has 12 columns for 3 rows, and 6 
+columns for the bottom row. Split keyboards count as the total keyboard, not per 
 side, the right side being offset by the number of keys on the left side, as if
 the rows were stacked.
 That would look like this
@@ -66,7 +66,7 @@ coord_mapping = [
 ## Keymaps
 Keymaps are organized as a list of lists. Keycodes are added for every key on 
 each layer. See [keycodes](keycodes.md) for more details on what keycodes are 
-avaliable. If using layers or other extensions, also refer to the extensions 
+available. If using layers or other extensions, also refer to the extensions 
 page for additional keycodes.
 ```python
 from kb import KMKKeyboard

--- a/docs/power.md
+++ b/docs/power.md
@@ -1,5 +1,5 @@
 # Power(save)
-This module allows you to save power and is targeted to bluetooth/battery 
+This module allows you to save power and is targeted to Bluetooth/battery
 based keyboards.
 
 ## Keycodes

--- a/docs/ptBR/Officially_Supported_Microcontrollers.md
+++ b/docs/ptBR/Officially_Supported_Microcontrollers.md
@@ -45,7 +45,7 @@ Desvantagens:
 
 Varejistas comuns:
 - [Adafruit](https://www.adafruit.com/pico?src=raspberrypi)
-- [Sparkfun](https://www.sparkfun.com/products/17829?src=raspberrypi)
+- [SparkFun](https://www.sparkfun.com/products/17829?src=raspberrypi)
 
 ## Adafruit ItsyBitsy nRF52840 Express
 

--- a/docs/ptBR/Officially_Supported_Microcontrollers.md
+++ b/docs/ptBR/Officially_Supported_Microcontrollers.md
@@ -5,7 +5,7 @@ teclados artesanais, amaioria dos teclados é projetada para aceitar um Pro
 Micro. As placas listadas abaixo ou são, ou podem ser adaptadas para essa
 pinagem a fim de usar teclados comuns já presentes no mercado.
 
-## Nice!Nano
+## nice!nano
 
 Características:
 - Pinagem Pro Micro
@@ -18,7 +18,7 @@ Desvantagens:
 
 Varejistas comund:
 - [Boardsource](https://boardsource.xyz/store/5f4a1733bbaa5c635b83ed67)
-- [NiceKeyboards](https://nicekeyboards.com/collections/group-buy/products/nice-nano-v1-0).
+- [Nice Keyboards](https://nicekeyboards.com/nice-nano/)
 
 ## ItsyBitsy M4 Express
 
@@ -51,7 +51,7 @@ Varejistas comuns:
 
 Características:
 - Suporte a USB HID e Bluetooth
-- Mais acessível que o Nice!Nano, apenas 18 dólares
+- Mais acessível que o nice!nano, apenas 18 dólares
 
 Desvantagens:
 - Precisa de adaptador para funcionar com teclados de pinagem Pro Micro pinout

--- a/docs/ptBR/mouse_keys.md
+++ b/docs/ptBR/mouse_keys.md
@@ -10,17 +10,14 @@ keyboard.modules.append(MouseKeys())
 
 # Keycodes
 
-|-----------------|------------------------------------------|
-| Keycode         | Descrição                                |
-|-----------------|------------------------------------------|
-| MB_LMB          | Botão esquerdo do mouse                  |
-| MB_RMB          | Botão direito do mouse                   |
-| MB_MMB          | Botão do meio do mouse                   |
-| MW_UP           | Rolar o scroll para cima                 |
-| MW_DOWN, MW_DN  | Rolar o scroll para baixo                |
-| MS_UP           | Mover o cursor do mouse para cima        |
-| MS_DOWN, MS_DN  | Mover o cursor do mouse para baixo       |
-| MS_LEFT, MS_LT  | Mover o cursor do mouse para a esquerdax |
-| MS_RIGHT, MS_RT | Mover o cursor do mouse para a direita   |
-|-----------------|------------------------------------------|
-
+| Keycode             | Descrição                                |
+|---------------------|------------------------------------------|
+| `MB_LMB`            | Botão esquerdo do mouse                  |
+| `MB_RMB`            | Botão direito do mouse                   |
+| `MB_MMB`            | Botão do meio do mouse                   |
+| `MW_UP`             | Rolar o scroll para cima                 |
+| `MW_DOWN`, `MW_DN`  | Rolar o scroll para baixo                |
+| `MS_UP`             | Mover o cursor do mouse para cima        |
+| `MS_DOWN`, `MS_DN`  | Mover o cursor do mouse para baixo       |
+| `MS_LEFT`, `MS_LT`  | Mover o cursor do mouse para a esquerdax |
+| `MS_RIGHT`, `MS_RT` | Mover o cursor do mouse para a direita   |

--- a/docs/rgb.md
+++ b/docs/rgb.md
@@ -1,12 +1,12 @@
-# RGB/Underglow/Neopixel
+# RGB/Underglow/NeoPixel
 Want your keyboard to shine? Add some lights!
 
-## Circuitpython
-If not running KMKpython, this does require the neopixel library from Adafruit. 
+## CircuitPython
+If not running KMKPython, this does require the NeoPixel library from Adafruit.
 This can be downloaded 
 [here](https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel/blob/6e35cd2b40575a20e2904b096508325cef4a71d3/neopixel.py).
 It is part of the [Adafruit CircuitPython Bundle](https://github.com/adafruit/Adafruit_CircuitPython_Bundle).
-Simply put this in the "root" of your circuitpython device. If unsure, it's the folder with main.py in it, and should be the first folder you see when you open the device.
+Simply put this in the "root" of your CircuitPython device. If unsure, it's the folder with main.py in it, and should be the first folder you see when you open the device.
 
 Currently we support the following addressable LEDs:
 
@@ -48,7 +48,7 @@ keyboard.extensions.append(rgb_ext)
 |`KC.RGB_MODE_BREATHE`        |`RGB_M_B`          |Breathing animation         |
 |`KC.RGB_MODE_RAINBOW`        |`RGB_M_R`          |Rainbow animation           |
 |`KC.RGB_MODE_BREATHE_RAINBOW`|`RGB_M_BR`         |Breathing rainbow animation |
-|`KC.RGB_MODE_KNIGHT`         |`RGB_M_K`          |Knightrider animation       |
+|`KC.RGB_MODE_KNIGHT`         |`RGB_M_K`          |Knight Rider animation      |
 |`KC.RGB_MODE_SWIRL`          |`RGB_M_S`          |Swirl animation             |
 
 ## Configuration
@@ -133,14 +133,14 @@ add a 3 wires. The power wire will run on 3.3v or 5v (depending on the LED),
 ground, and data pins will need added to an unused pin on your microcontroller
 unless your keyboard has specific solder points for them. With those 3 wires
 connected, set the `pixel_pin` as described above, and you are ready to use your
-RGB LED's/Neopixels.
+RGB LED's/NeoPixel.
 
 ## Troubleshooting
 ### Incorrect colors
 If your colors are incorrect, check the pixel order of your specific LED's. Here are some common ones.
  * WS2811, WS2812, WS2812B, WS2812C are all GRB (1, 0, 2)
  * SK6812, SK6812MINI, SK6805 are all GRB (1, 0, 2)
- * Neopixels will vary depending on which one you buy. It will be listed on the product page.
+ * NeoPixels will vary depending on which one you buy. It will be listed on the product page.
 
 ### Lights don't turn on
 
@@ -152,10 +152,10 @@ installed LED's in total.
 
 ## Alternate LED chipsets
 
-Not all RGB LEDs are compatible with Neopixels. To support these, the RGB
+Not all RGB LEDs are compatible with NeoPixels. To support these, the RGB
 extension accepts an instance of a `Pixelbuf`-compatible object as an optional
 parameter. If supplied, `pixel_pin` is ignored and the supplied Pixelbuf is
-used instead of creating a Neopixel object.
+used instead of creating a NeoPixel object.
 The RGB extension will figure out LED count from the pixelbuffer length if not
 passed explicitly.
 

--- a/docs/rgb.md
+++ b/docs/rgb.md
@@ -176,7 +176,7 @@ keyboard.extensions.append(rgb_ext)
 ```
 
 ### Multiple PixelBuffer
-Simlar to alternate drivers tha RGB module supports passing multiple `Pixelbuf`
+Similar to alternate drivers, the RGB module supports passing multiple `Pixelbuf`
 objects as an iterable.
 ```python
 from kmk.extensions.RGB import RGB

--- a/docs/scanners.md
+++ b/docs/scanners.md
@@ -41,7 +41,7 @@ class MyKeyboard(KMKKeyboard):
 
 The `keypad.Keys` scanner treats individual GPIO pins as discrete keys. To use
 this scanner, provide a sequence of pins that describes the layout of your
-board then include it in the initialisation sequence of your keyboard class.
+board then include it in the initialization sequence of your keyboard class.
 
 ```python
 import board
@@ -105,7 +105,7 @@ class MyKeyboard(KMKKeyboard):
 ### digitalio MatrixScanner
 
 The digitalio Matrix can scan over, as the name implies, `digitalio.DigitalInOut`
-objects. That is especially usefull if a matrix is build with IO-expanders.
+objects. That is especially useful if a matrix is build with IO-expanders.
 
 ```python
 from kmk.scanners.digitalio import MatrixScanner

--- a/docs/sequences.md
+++ b/docs/sequences.md
@@ -1,7 +1,7 @@
 # Sequences
 
 Sequences are used for sending multiple keystrokes in a single action, and can
-be used for things like unicode characters (even emojis! 🇨🇦), lorei epsum
+be used for things like Unicode characters (even emojis! 🇨🇦), _Lorem ipsum_
 generators, triggering side effects (think lighting, speakers,
 microcontroller-optimized cryptocurrency miners, whatever). If you are still
 unsure of what this is, most other vendors call these "Macros", but can do much
@@ -76,7 +76,7 @@ On Windows, [WinCompose](https://github.com/samhocevar/wincompose) is required.
 
 ### Unicode Examples
 
-To send a simple unicode symbol
+To send a simple Unicode symbol
 ```python
 from kmk.handlers.sequences import unicode_string_sequence
 
@@ -104,7 +104,7 @@ keymap = [...emoticons.BEER, emoticons.HAND_WAVE...]
 > `kmk.types.AttrDict`, which you can think of as a read-only view over a
 > dictionary adding attribute-based (dot-notation) access.
 
-Finally, if you need to send arbitrary unicode codepoints in raw form, that's
+Finally, if you need to send arbitrary Unicode codepoints in raw form, that's
 supported too, through `unicode_codepoint_sequence`.
 
 ```python

--- a/docs/split_keyboards.md
+++ b/docs/split_keyboards.md
@@ -1,6 +1,6 @@
 # Split Keyboards
 Split keyboards are mostly the same as unsplit. Wired UART is fully supported,
-and testing of bluetooth splits, though we don't currently offer support for this.
+and testing of Bluetooth splits, though we don't currently offer support for this.
 
 Notice that this Split module must be added after the ModTap module to the keyboard.modules.
 
@@ -47,7 +47,7 @@ split = Split(
 ```
 
 ### EE HANDS
-If you want to plug USB in on either side, or are using bluetooth, this is for 
+If you want to plug USB in on either side, or are using Bluetooth, this is for
 you.
 
 Rename your CIRCUITPY drive to something different. The left side must 
@@ -57,7 +57,7 @@ longer than 11 characters. Instructions on how to do that are
 [here](https://learn.adafruit.com/welcome-to-circuitpython/the-circuitpy-drive).
 For example on NYQUISTL for left and NYQUISTR for the right. 
 
-For wired connections you don't need to pass anything. For bluetooth, remove the `split_side` like this
+For wired connections you don't need to pass anything. For Bluetooth, remove the `split_side` like this
 ```python
 # Wired
 split = Split()

--- a/docs/split_keyboards.md
+++ b/docs/split_keyboards.md
@@ -6,7 +6,7 @@ Notice that this Split module must be added after the ModTap module to the keybo
 
 ## Wired UART
 Wired connections can use UART over 1 or 2 wires. With 2 wires, you will be able
-to syncronize the halves allowing additional features in some extensions.
+to synchronize the halves allowing additional features in some extensions.
 ```python
 from kb import data_pin
 :from kmk.modules.split import Split, SplitType

--- a/hardware/README-ptBR.md
+++ b/hardware/README-ptBR.md
@@ -4,7 +4,7 @@
 
 Esta placa adapta a pinagem de uma [Adafruit Itsy Bitsy M4
 Express](https://www.adafruit.com/product/3800) compatível com o CircuitPython
-para aquela da [Sparkfun Pro Micro](https://www.sparkfun.com/products/12640) a
+para aquela da [SparkFun Pro Micro](https://www.sparkfun.com/products/12640) a
 fim de permitir que a Itsy Bitsy seja usável com os diversos teclados que
 suportam a planta do Pro Micro.
 

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -5,31 +5,31 @@
 This board adapts the pinout of a Circuit Python compatible [Adafruit ItsyBitsy M4 Express](https://www.adafruit.com/product/3800) to that of the [SparkFun Pro Micro](https://www.sparkfun.com/products/12640) to allow the ItsyBitsy to be used with the many keyboards that support the footprint of the Pro Micro.
 
 ## Pin mapping
-Pro Micro Pin | ItsyBitsy Pin
------------- | -------------
-TX0/PD3 | TX
-RX1/PD2 | RX
-GND | GND
-GND | GND
-2/PD1 | SDA
-3/PD0 | SCL
-4/PD4 | D13
-5/PC6 | D12
-6/PD7 | D11
-7/PE6 | D10
-8/PB4 | D9
-9/PB5 | D7
-Raw | 
-GND | GND
-RST | RST
-VCC | USB
-A3/PF4 | A0
-A2/PF5 | A1
-A1/PF6 | A2
-A0/PF7 | A3
-15/PB1 | A4
-14/PB3 | A5
-16/PB2 | SCK
+| Pro Micro Pin   | ItsyBitsy Pin   |
+|-----------------|-----------------|
+| `TX0/PD3`       | `TX`            |
+| `RX1/PD2`       | `RX`            |
+| `GND`           | `GND`           |
+| `GND`           | `GND`           |
+| `2/PD1`         | `SDA`           |
+| `3/PD0`         | `SCL`           |
+| `4/PD4`         | `D13`           |
+| `5/PC6`         | `D12`           |
+| `6/PD7`         | `D11`           |
+| `7/PE6`         | `D10`           |
+| `8/PB4`         | `D9`            |
+| `9/PB5`         | `D7`            |
+| `Raw`           |                 |
+| `GND`           | `GND`           |
+| `RST`           | `RST`           |
+| `VCC`           | `USB`           |
+| `A3/PF4`        | `A0`            |
+| `A2/PF5`        | `A1`            |
+| `A1/PF6`        | `A2`            |
+| `A0/PF7`        | `A3`            |
+| `15/PB1`        | `A4`            |
+| `14/PB3`        | `A5`            |
+| `16/PB2`        | `SCK`           |
 
 
 ## So how do I use it?

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -35,7 +35,7 @@ A0/PF7 | A3
 ## So how do I use it?
 1. The pads for the Pro Micro footprint are circled on the underside of the board. Solder male headers into these pads on the underside of the board (the same side as the markings) so that the pins extend "downward" so that they can be plugged into the keyboard.
 
-2. The remaining pads are for the Itsy Bitsy. Assuming height is a concern, rather than soldering male headers into the Itsy Bitsy and female headers into the adapter board, instead place the long side of male headers through the Itsy Bitsy pads from underneath the board so that they protrude through he pads on the top of the board and solder them in place. Make sure to keep the headers perpindicular to the surface of the board.
+2. The remaining pads are for the Itsy Bitsy. Assuming height is a concern, rather than soldering male headers into the Itsy Bitsy and female headers into the adapter board, instead place the long side of male headers through the Itsy Bitsy pads from underneath the board so that they protrude through he pads on the top of the board and solder them in place. Make sure to keep the headers perpendicular to the surface of the board.
 
 3. Once soldered, place the Itsy Bitsy board over the headers that are now protruding upwards so that the headers go through the pads of the ItsyBitsy and solder in place.
 

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -1,11 +1,11 @@
 # KMK Hardware: Devices for use with KMK
 
-## Itsy Bitsy to Pro Micro pinout adapter
+## ItsyBitsy to Pro Micro pinout adapter
 
-This board adapts the pinout of a Circuit Python compatible [Adafruit Itsy Bitsy M4 Express](https://www.adafruit.com/product/3800) to that of the [Sparkfun Pro Micro](https://www.sparkfun.com/products/12640) to allow the Itsy Bitsy to be used with the many keyboards that support the footprint of the Pro Micro. 
+This board adapts the pinout of a Circuit Python compatible [Adafruit ItsyBitsy M4 Express](https://www.adafruit.com/product/3800) to that of the [SparkFun Pro Micro](https://www.sparkfun.com/products/12640) to allow the ItsyBitsy to be used with the many keyboards that support the footprint of the Pro Micro.
 
 ## Pin mapping
-Pro Micro Pin | Itsy Bitsy Pin
+Pro Micro Pin | ItsyBitsy Pin
 ------------ | -------------
 TX0/PD3 | TX
 RX1/PD2 | RX
@@ -35,9 +35,9 @@ A0/PF7 | A3
 ## So how do I use it?
 1. The pads for the Pro Micro footprint are circled on the underside of the board. Solder male headers into these pads on the underside of the board (the same side as the markings) so that the pins extend "downward" so that they can be plugged into the keyboard.
 
-2. The remaining pads are for the Itsy Bitsy. Assuming height is a concern, rather than soldering male headers into the Itsy Bitsy and female headers into the adapter board, instead place the long side of male headers through the Itsy Bitsy pads from underneath the board so that they protrude through he pads on the top of the board and solder them in place. Make sure to keep the headers perpendicular to the surface of the board.
+2. The remaining pads are for the ItsyBitsy. Assuming height is a concern, rather than soldering male headers into the ItsyBitsy and female headers into the adapter board, instead place the long side of male headers through the ItsyBitsy pads from underneath the board so that they protrude through he pads on the top of the board and solder them in place. Make sure to keep the headers perpendicular to the surface of the board.
 
-3. Once soldered, place the Itsy Bitsy board over the headers that are now protruding upwards so that the headers go through the pads of the ItsyBitsy and solder in place.
+3. Once soldered, place the ItsyBitsy board over the headers that are now protruding upwards so that the headers go through the pads of the ItsyBitsy and solder in place.
 
 4. Trim the ItsyBitsy headers as needed with flush cutters.
 


### PR DESCRIPTION
Fixed many typographical errors. Most of these should be noncontroversial, explanation follows where there was more of a judgement call:

* Both customise and customize were used in the same article. Using both was sloppy. Chose customize, which is the preferred US and Oxford usage
* initialization is also the preferred US and Oxford usage, though it wasn't used both ways
* Several proper nouns in the documentation used two conflicting capitalizations, in each case switched to the "official" spelling for consistency:
  * "Bluetooth" vs "bluetooth"
  * "Unicode" vs "unicode"
  * "USB" vs "usb"

More straightforward choices where one spelling is clearly wrong:
* [SparkFun, not Sparkfun](https://www.sparkfun.com/)
* [Pro Micro, not ProMicro](https://www.sparkfun.com/products/15795)
* [CircuitPython spelling](https://learn.adafruit.com/welcome-to-circuitpython/what-is-circuitpython)
* [Adafruit ItsyBitsy has no space](https://www.adafruit.com/product/3800)

I'm happy to remove any changes that you don't agree with.