### PR TITLE
markdownlint

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,36 @@
+# starting point config to get linter passing. Almost all of this should be disabled, once existing files are remediated
+# see https://github.com/DavidAnson/markdownlint for full config
+
+# Default state for all rules
+default: true
+
+# MD001/heading-increment/header-increment Heading levels should only increment by one level at a time
+MD001: false
+
+# MD013/line-length Line length
+# Maybe consider only enforcing this on new docs?
+MD013: false
+
+# MD024/no-duplicate-heading/no-duplicate-header Multiple headings with the same content
+MD024: false
+
+# MD025/single-title/single-h1 Multiple top-level headings in the same document
+MD025: false
+
+# MD029/ol-prefix Ordered list item prefix
+MD029: false
+
+# MD033/no-inline-html Inline HTML
+MD033: false
+
+# MD040/fenced-code-language Fenced code blocks should have a language specified
+MD040: false
+
+# MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading
+MD041: false
+
+# MD046/code-block-style Code block style
+MD046: false
+
+# MD049/emphasis-style Emphasis style should be consistent
+MD049: false

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file -->
 Almost all of KMK is licensed under the GPLv3. The only exceptions are:
 
 - Hardware schematics are licensed under individual terms per schematic
@@ -5,7 +6,7 @@ Almost all of KMK is licensed under the GPLv3. The only exceptions are:
 Files/components not listed above or containing its own copyright header in the
 file itself are licensed under GPLv3 as follows:
 
-### GNU GENERAL PUBLIC LICENSE
+## GNU GENERAL PUBLIC LICENSE
 
 Version 3, 29 June 2007
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -42,18 +42,25 @@ Markdown can be found [here](https://docs.github.com/en/get-started/writing-on-g
 In particular, KMK's docs should include a title, demarcated with `#`, and subheadings 
 should be demarcated with `##`, `###`, and so on. Headings should be short and specific.
 
+**Draft: This is rough, and should be merged into a Makefile or similar, as well as GitHub Actions for CI**
+#### Please proof your docs before committing them by:
+* spell check
+* run `markdownlint docs/my_file.md` (`npm install markdownlint-cli --global`)
+
 ### Example Code
 Where possible, practical code examples should be included in documentation to help 
 new users understand how to implement features. In general, it's better to have a code-
 block with comments inside it rather than multiple blocks of code broken up with 
 explanation.
 
+<!-- markdownlint-disable MD040 -->
 Code blocks should be formatted as Python code as follows:
 ````
 ```python
 print('Hello, world!')
 ```
 ````
+<!-- markdownlint-enable MD040 -->
 
 Inline code, indicated with `` `backticks` ``, should be used when calling out specific 
 functions or Python keywords within the body of paragraphs or in lists.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,13 +1,17 @@
 # Contributing
-KMK is a community effort and welcomes contributions of code and documentation from people 
-of all backgrounds and levels of technical skill. As such, these guidelines should serve 
-to make contributing as easy as possible for everyone while maintaining a consistent style.
+
+KMK is a community effort and welcomes contributions of code and documentation
+from people of all backgrounds and levels of technical skill. As such, these
+guidelines should serve to make contributing as easy as possible for everyone
+while maintaining a consistent style.
 
 ## Contributing Code
-The following guidelines should ensure that any code contributed can be merged in as 
-painlessly as possible. If you're unsure how to set up your development environment, 
-feel free to join the chat, [#kmkfw:klar.sh on Matrix](https://matrix.to/#/#kmkfw:klar.sh). 
-This channel is bridged to Discord [here](https://discord.gg/QBHUUpeGUd) for convenience.
+
+The following guidelines should ensure that any code contributed can be merged
+in as painlessly as possible. If you're unsure how to set up your development
+environment, feel free to join the chat,
+[#kmkfw:klar.sh on Matrix](https://matrix.to/#/#kmkfw:klar.sh). This channel is
+bridged to Discord [here](https://discord.gg/QBHUUpeGUd) for convenience.
 
 ### Code Style
 
@@ -15,12 +19,12 @@ KMK uses [Black](https://github.com/psf/black) with a Python 3.6 target and,
 [(controversially?)](https://github.com/psf/black/issues/594) single quotes.
 Further code styling is enforced with isort and flake8 with several plugins.
 
-**NOTE:** before committing code, run `make fix-isort fix-formatting test` to 
-reduce workload for the project's maintainers and prevent the CI pipeline from 
+**NOTE:** before committing code, run `make fix-isort fix-formatting test` to
+reduce workload for the project's maintainers and prevent the CI pipeline from
 failing.
 
-There are some limited exceptions to the code formatting rules, which can be 
-found in `setup.cfg`, notably around `user_keymaps` (which are also not subject 
+There are some limited exceptions to the code formatting rules, which can be
+found in `setup.cfg`, notably around `user_keymaps` (which are also not subject
 to Black formatting as documented in `pyproject.toml`)
 
 ### Tests
@@ -31,30 +35,39 @@ them to be executed in a desktop development environment.
 Execute tests using the command `python -m unittest`.
 
 ## Contriburing Documentation
-While KMK welcomes documentation from anyone with and understanding of the issues 
-and a willingness to write them up, it's a good idea to familiarize yourself with 
-the docs. Documentation should be informative but concise.
+
+While KMK welcomes documentation from anyone with and understanding of the
+issues and a willingness to write them up, it's a good idea to familiarize
+yourself with the docs. Documentation should be informative but concise.
 
 ### Styling
-Docs are written and rendered in GitHub Markdown. A comprehensive guide to GitHub's 
-Markdown can be found [here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
 
-In particular, KMK's docs should include a title, demarcated with `#`, and subheadings 
-should be demarcated with `##`, `###`, and so on. Headings should be short and specific.
+Docs are written and rendered in GitHub Markdown. A comprehensive guide to
+GitHub's Markdown can be found
+[here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
 
-**Draft: This is rough, and should be merged into a Makefile or similar, as well as GitHub Actions for CI**
-#### Please proof your docs before committing them by:
-* spell check
+In particular, KMK's docs should include a title, demarcated with `#`, and
+subheadings should be demarcated with `##`, `###`, and so on. Headings should
+be short and specific.
+
+#### Please proof your docs before committing them
+
+Note: THIS IS A DRAFT: This is rough, and should be merged into a Makefile or
+similar, as well as GitHub Actions for CI
+
+* use a spell checker
 * run `markdownlint docs/my_file.md` (`npm install markdownlint-cli --global`)
 
 ### Example Code
-Where possible, practical code examples should be included in documentation to help 
-new users understand how to implement features. In general, it's better to have a code-
-block with comments inside it rather than multiple blocks of code broken up with 
-explanation.
+
+Where possible, practical code examples should be included in documentation to
+help new users understand how to implement features. In general, it's better to
+have a code-block with comments inside it rather than multiple blocks of code
+broken up with explanation.
 
 <!-- markdownlint-disable MD040 -->
 Code blocks should be formatted as Python code as follows:
+
 ````
 ```python
 print('Hello, world!')
@@ -62,7 +75,7 @@ print('Hello, world!')
 ````
 <!-- markdownlint-enable MD040 -->
 
-Inline code, indicated with `` `backticks` ``, should be used when calling out specific 
+Inline code, indicated with `` `backticks` ``, should be used when calling out specific
 functions or Python keywords within the body of paragraphs or in lists.
 
 ## License, Copyright, and Legal

--- a/hardware/LICENSE.md
+++ b/hardware/LICENSE.md
@@ -1,4 +1,5 @@
-Attribution-ShareAlike 4.0 International
+# Attribution-ShareAlike 4.0 International
+<!-- markdownlint-disable -->
 
 =======================================================================
 


### PR DESCRIPTION
Done so far:
* stub out relevant docs in contributing.md
* add config file: .markdownlint.yml
  * disabled every rule we're violating that `markdownlint` doesn't know how to autocorrect w/ `--fix` flag
* disable linter at a few key points in the docs
* make the needed changes to ONE MARKDOWN FILE to make it pass the linter (appropriately chose docs/contributing.md)

To do:
* Wait for #418 to merge, rebase to master (I'll do this even if I never get to the rest of this); this is important because the rest of this WILL create changes that won't merge cleanly with that commit (or any major doc changes)
* Run `markdownlint --fix '**/*.md'`, review the hundreds of changes
* commit
* Re-enable rules in `.markdownlint.yml` one at a time, run `markdownlint '**/*.md'`, and either remediate the effected docs or dicide to keep the rule
* commit
* Possibly look at git options that prevent lint changes from breaking `git blame`. 99% sure this is possible.

Notes:
The main markdown linters I found are:
* [markdownlint/markdownlint](https://github.com/markdownlint/markdownlint): ruby
* [DavidAnson/markdownlint](https://github.com/DavidAnson/markdownlint): Node.js

I'm using the latter because it appears to have more active maintenance including, critically, on the ruleset. I'm using markdownlint-cli rather than markdownlint-cli2 because there seems to be better support of the former in existing github actions.

I don't have any plans to work on this further anytime soon, so if someone finds this work valuable please feel free to pick it up and run with it.