### PR TITLE
Fix crash when typing quickly on a split board

### DIFF
--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -1,5 +1,7 @@
 from supervisor import ticks_ms
 
+from keypad import Event as KeyEvent
+
 from kmk.consts import KMK_RELEASE, UnicodeMode
 from kmk.hid import BLEHID, USBHID, AbstractHID, HIDModes
 from kmk.keys import KC
@@ -458,7 +460,9 @@ class KMKKeyboard:
         for matrix in self.matrix:
             update = matrix.scan_for_changes()
             if update:
-                self.matrix_update = update
+                self.matrix_update = KeyEvent(
+                    key_number=update.key_number, pressed=update.pressed
+                )
                 break
         self.sandbox.secondary_matrix_update = self.secondary_matrix_update
 


### PR DESCRIPTION
This fixes #424 by creating a new `KeyEvent` instance for each `matrix_update` like we already do for `secondary_matrix_update`.  Previously, we were always adding the same `KeyEvent` instance to the `matrix_update_queue` which works fine until you try to add a second one to the queue, changing the first one.   Now you can add as many `KeyEvent`s to the queue as you want without them interfering with each other.  