### PR TITLE
Refactor tapdance

### DIFF
--- a/docs/tapdance.md
+++ b/docs/tapdance.md
@@ -16,27 +16,18 @@ letter "b" will be held down until the tap dance key is released.
 
 To use this, you may want to define a `tap_time` value in your keyboard
 configuration. This is an integer in milliseconds, and defaults to `300`.
+The timeout is reset after each tap and every tapdance sequence can also define
+an individual `tap_time`.
 
 You'll then want to create a sequence of keys using `KC.TD(KC.SOMETHING,
 KC.SOMETHING_ELSE, MAYBE_THIS_IS_A_MACRO, WHATEVER_YO)`, and place it in your
 keymap somewhere. The only limits on how many keys can go in the sequence are,
-theoretically, the amount of RAM your MCU/board has, and how fast you can mash
-the physical key. Here's your chance to use all that button-mash video game
-experience you've built up over the years.
-[//]: # (The button mashing part has been 'fixed' by a timeout refresh per)
-[//]: # (button press. The comedic sentiment is worth keeping though.)
+theoretically, the amount of RAM your MCU/board has.
 
-**NOTE**: Currently our basic tap dance implementation has some limitations that
-are planned to be worked around "eventually", but for now are noteworthy:
-
-- The behavior of momentary layer switching within a tap dance sequence is
-  currently "undefined" at best, and will probably crash your keyboard. For now,
-  we strongly recommend avoiding `KC.MO` (or any other layer switch keys that
-  use momentary switch behavior - `KC.LM`, `KC.LT`, and `KC.TT`)
-[//]: # (This also doesn't seem to be the case anymore; as long as the layer)
-[//]: # (is transparent to the tap dance key.)
-[//]: # (At least KC.MO is working as intended, other momentary actions haven't)
-[//]: # (been tested.)
+Tap dance supports all `HoldTap` based keys, like mod tap, layer tap, oneshot...
+it will even honor every option set for those keys.
+Individual timeouts and prefer hold behavior for every tap in the sequence?
+Not a problem.
 
 Here's an example of all this in action:
 
@@ -52,13 +43,20 @@ tapdance.tap_time = 750
 keyboard.modules.append(tapdance)
 
 EXAMPLE_TD = KC.TD(
-    KC.A,  # Tap once for "a"
-    KC.B,  # Tap twice for "b"
+    # Tap once for "a"
+    KC.A,
+    # Tap twice for "b", or tap and hold for "left control"
+    KC.MT(KC.B, KC.LCTL, prefer_hold=False),
     # Tap three times to send a raw string via macro
     send_string('macros in a tap dance? I think yes'),
-    # Tap four times to toggle layer index 1
-    KC.TG(1),
+    # Tap four times to toggle layer index 1, tap 3 times and hold for 3s to
+    # momentary toggle layer index 1.
+    KC.TT(1, tap_time=3000),
 )
+
+# make the default tap time really short for this tap dance:
+EXAMPLE_TD2 = KC.TD(KC.A, KC.B, tap_time=80)
+
 
 keyboard.keymap = [[ ...., EXAMPLE_TD, ....], ....]
 ```

--- a/kmk/key_validators.py
+++ b/kmk/key_validators.py
@@ -11,9 +11,7 @@ def key_seq_sleep_validator(ms):
     return KeySeqSleepMeta(ms)
 
 
-def layer_key_validator(
-    layer, kc=None, prefer_hold=False, tap_interrupted=False, tap_time=None
-):
+def layer_key_validator(layer):
     '''
     Validates the syntax (but not semantics) of a layer key call.  We won't
     have access to the keymap here, so we can't verify much of anything useful
@@ -21,13 +19,7 @@ def layer_key_validator(
     existing is mostly that Python will catch extraneous args/kwargs and error
     out.
     '''
-    return LayerKeyMeta(
-        layer=layer,
-        kc=kc,
-        prefer_hold=prefer_hold,
-        tap_interrupted=tap_interrupted,
-        tap_time=tap_time,
-    )
+    return LayerKeyMeta(layer)
 
 
 def mod_tap_validator(

--- a/kmk/key_validators.py
+++ b/kmk/key_validators.py
@@ -1,10 +1,4 @@
-from kmk.types import (
-    KeySeqSleepMeta,
-    LayerKeyMeta,
-    ModTapKeyMeta,
-    TapDanceKeyMeta,
-    UnicodeModeKeyMeta,
-)
+from kmk.types import KeySeqSleepMeta, LayerKeyMeta, ModTapKeyMeta, UnicodeModeKeyMeta
 
 
 def key_seq_sleep_validator(ms):
@@ -35,10 +29,6 @@ def mod_tap_validator(
         tap_interrupted=tap_interrupted,
         tap_time=tap_time,
     )
-
-
-def tap_dance_key_validator(*codes):
-    return TapDanceKeyMeta(codes)
 
 
 def unicode_mode_key_validator(mode):

--- a/kmk/modules/holdtap.py
+++ b/kmk/modules/holdtap.py
@@ -1,6 +1,8 @@
 from micropython import const
 
+from kmk.keys import make_argumented_key
 from kmk.modules import Module
+from kmk.types import HoldTapKeyMeta
 
 
 class ActivationType:
@@ -24,6 +26,12 @@ class HoldTap(Module):
     def __init__(self):
         self.key_buffer = []
         self.key_states = {}
+        make_argumented_key(
+            validator=HoldTapKeyMeta,
+            names=('HT',),
+            on_press=self.ht_pressed,
+            on_release=self.ht_released,
+        )
 
     def during_bootup(self, keyboard):
         return
@@ -57,6 +65,9 @@ class HoldTap(Module):
                 keyboard._send_hid()
 
                 self.send_key_buffer(keyboard)
+
+            if state.activated == ActivationType.INTERRUPTED:
+                current_key = keyboard._find_key_in_map(int_coord)
 
             # if interrupt on release: store interrupting keys until one of them
             # is released.
@@ -140,16 +151,16 @@ class HoldTap(Module):
         self.key_buffer.clear()
 
     def ht_activate_hold(self, key, keyboard, *args, **kwargs):
-        pass
+        keyboard.process_key(key.meta.hold, True)
 
     def ht_deactivate_hold(self, key, keyboard, *args, **kwargs):
-        pass
+        keyboard.process_key(key.meta.hold, False)
 
     def ht_activate_tap(self, key, keyboard, *args, **kwargs):
-        pass
+        keyboard.process_key(key.meta.tap, True)
 
     def ht_deactivate_tap(self, key, keyboard, *args, **kwargs):
-        pass
+        keyboard.process_key(key.meta.tap, False)
 
     def ht_activate_on_interrupt(self, key, keyboard, *args, **kwargs):
         if key.meta.prefer_hold:

--- a/kmk/modules/modtap.py
+++ b/kmk/modules/modtap.py
@@ -15,13 +15,13 @@ class ModTap(HoldTap):
         )
 
     def ht_activate_hold(self, key, keyboard, *args, **kwargs):
-        handlers.default_pressed(key.meta.mods, keyboard, None)
+        handlers.default_pressed(key.meta.hold, keyboard, None)
 
     def ht_deactivate_hold(self, key, keyboard, *args, **kwargs):
-        handlers.default_released(key.meta.mods, keyboard, None)
+        handlers.default_released(key.meta.hold, keyboard, None)
 
     def ht_activate_tap(self, key, keyboard, *args, **kwargs):
-        handlers.default_pressed(key.meta.kc, keyboard, None)
+        handlers.default_pressed(key.meta.tap, keyboard, None)
 
     def ht_deactivate_tap(self, key, keyboard, *args, **kwargs):
-        handlers.default_released(key.meta.kc, keyboard, None)
+        handlers.default_released(key.meta.tap, keyboard, None)

--- a/kmk/modules/oneshot.py
+++ b/kmk/modules/oneshot.py
@@ -4,7 +4,7 @@ from kmk.types import HoldTapKeyMeta
 
 
 def oneshot_validator(kc, tap_time=None):
-    return HoldTapKeyMeta(kc=kc, prefer_hold=False, tap_time=tap_time)
+    return HoldTapKeyMeta(tap=kc, hold=kc, prefer_hold=False, tap_time=tap_time)
 
 
 class OneShot(HoldTap):
@@ -55,12 +55,3 @@ class OneShot(HoldTap):
             self.ht_released(key, keyboard, *args, **kwargs)
 
         return keyboard
-
-    def ht_activate_tap(self, key, keyboard, *args, **kwargs):
-        keyboard.process_key(key.meta.kc, True)
-
-    def ht_deactivate_tap(self, key, keyboard, *args, **kwargs):
-        keyboard.process_key(key.meta.kc, False)
-
-    def ht_deactivate_hold(self, key, keyboard, *args, **kwargs):
-        keyboard.process_key(key.meta.kc, False)

--- a/kmk/types.py
+++ b/kmk/types.py
@@ -35,8 +35,7 @@ class LayerKeyMeta(HoldTapKeyMeta):
 
 class ModTapKeyMeta(HoldTapKeyMeta):
     def __init__(self, kc=None, mods=None, **kwargs):
-        super().__init__(kc=kc, **kwargs)
-        self.mods = mods
+        super().__init__(tap=kc, hold=mods, **kwargs)
 
 
 class KeySequenceMeta:

--- a/kmk/types.py
+++ b/kmk/types.py
@@ -50,8 +50,3 @@ class KeySeqSleepMeta:
 class UnicodeModeKeyMeta:
     def __init__(self, mode):
         self.mode = mode
-
-
-class TapDanceKeyMeta:
-    def __init__(self, codes):
-        self.codes = codes

--- a/kmk/types.py
+++ b/kmk/types.py
@@ -27,9 +27,8 @@ class HoldTapKeyMeta:
         self.tap_time = tap_time
 
 
-class LayerKeyMeta(HoldTapKeyMeta):
-    def __init__(self, layer, **kwargs):
-        super().__init__(**kwargs)
+class LayerKeyMeta:
+    def __init__(self, layer):
         self.layer = layer
 
 

--- a/kmk/types.py
+++ b/kmk/types.py
@@ -12,8 +12,16 @@ class AttrDict(dict):
 
 
 class HoldTapKeyMeta:
-    def __init__(self, kc=None, prefer_hold=True, tap_interrupted=False, tap_time=None):
-        self.kc = kc
+    def __init__(
+        self,
+        tap,
+        hold,
+        prefer_hold=True,
+        tap_interrupted=False,
+        tap_time=None,
+    ):
+        self.tap = tap
+        self.hold = hold
         self.prefer_hold = prefer_hold
         self.tap_interrupted = tap_interrupted
         self.tap_time = tap_time


### PR DESCRIPTION
Refactors the `tapdance` module on top of `holdtap`.

This looks like a bigger "change" than it is. There's some plumbing rework in every module that builds on `holdtap` but no functionality has been changed.
Tap dances allow any kind of `holdtap` based key and propagates / adheres to the specific attributes of each key in the sequence -- for example:
```python
KC.TD = (KC.A, KC.MT(B, KC.LALT, prefer_hold=False), KC.TT(1, tap_time=3000), tap_time=200)
```
does what you'd expect it to do, without the need for `tapdance` to resolve an action, before the `holdtap` action starts.

For consistency any non-`holdtap` key gets replaced by `holdtap` with identical hold and tap. That is also the only major change to the layer module: `KC.LT` and `KC.TT` are composed of a tap and a hold key, instead of overloading the `ht_de/activate_*` methods.

I'll promote from draft when the docs are updated as well.