### PR TITLE
anavi/knobs3: Add ANAVI Knobs 3

### DIFF
--- a/boards/anavi/knobs3/README.md
+++ b/boards/anavi/knobs3/README.md
@@ -1,0 +1,8 @@
+# ANAVI Knobs 3
+
+ANAVI Knobs 3 is an open source, programmable mechanical keyboard with 3 rotary encoders and [Seeed XIAO RP2040](https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html).
+
+ANAVI Knobs 3 is open source hardware designed with KiCad. All KiCad [files and schematics are available at GitHub](https://github.com/AnaviTechnology/anavi-knobs-3) under [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/).
+
+Extensions enabled by default:
+- [Encoder](https://github.com/KMKfw/kmk_firmware/tree/master/docs/encoder.md) Twist control for all the things

--- a/boards/anavi/knobs3/anaviknob.py
+++ b/boards/anavi/knobs3/anaviknob.py
@@ -1,0 +1,25 @@
+'''
+KMK keyboard for ANAVI Knobs 3
+'''
+
+import board
+
+from kmk.kmk_keyboard import KMKKeyboard
+from kmk.scanners.keypad import KeysScanner
+
+# fmt: off
+_KEY_CFG = [
+    board.D0,
+    board.D3,
+    board.D6
+]
+# fmt: on
+
+
+class AnaviKnob(KMKKeyboard):
+    '''
+    Default keyboard config for the Keybow2040.
+    '''
+
+    def __init__(self):
+        self.matrix = KeysScanner(_KEY_CFG)

--- a/boards/anavi/knobs3/code.py
+++ b/boards/anavi/knobs3/code.py
@@ -1,0 +1,24 @@
+import board
+
+from anaviknob import AnaviKnob
+
+from kmk.keys import KC
+from kmk.modules.encoder import EncoderHandler
+
+encoder_handler = EncoderHandler()
+encoder_handler.pins = (
+    (board.D1, board.D2, None, False),
+    (board.D9, board.D10, None, False),
+    (board.D7, board.D8, None, False),
+)
+encoder_handler.map = (
+    ((KC.VOLD, KC.VOLU), (KC.UP, KC.DOWN), (KC.RIGHT, KC.LEFT)),  # base layer
+)
+
+knob = AnaviKnob()
+knob.modules.append(encoder_handler)
+
+knob.keymap = [[KC.MUTE, KC.A, KC.B]]
+
+if __name__ == '__main__':
+    knob.go()


### PR DESCRIPTION
Add support for ANAVI Knobs 3: an open source programmable mini
mechanical keyboard with 3 rotary encoders and Seeed XIAO RP2040.
This is open source hardware designed with KiCad.

Signed-off-by: Leon Anavi <leon@anavi.org>