### PR TITLE
boards/anavi/knobs3/code.py: Enable RGB

### DIFF
--- a/boards/anavi/knobs3/code.py
+++ b/boards/anavi/knobs3/code.py
@@ -2,6 +2,7 @@ import board
 
 from anaviknob import AnaviKnob
 
+from kmk.extensions.RGB import RGB, AnimationModes
 from kmk.keys import KC
 from kmk.modules.encoder import EncoderHandler
 
@@ -17,6 +18,15 @@ encoder_handler.map = (
 
 knob = AnaviKnob()
 knob.modules.append(encoder_handler)
+
+rgb_ext = RGB(
+    pixel_pin=board.NEOPIXEL,
+    num_pixels=1,
+    val_limit=100,
+    val_default=25,
+    animation_mode=AnimationModes.RAINBOW,
+)
+knob.extensions.append(rgb_ext)
 
 knob.keymap = [[KC.MUTE, KC.A, KC.B]]
 


### PR DESCRIPTION
Enable RGB/Underglow/NeoPixel for the built-in NEOPIXEL LED on
Seeed XIAO RP2040. By default set it 25% brightness with rainbow
animation.

Signed-off-by: Leon Anavi <leon@anavi.org>