### PR TITLE
The variable pixels is initiated in wrong way

### DIFF
--- a/kmk/extensions/rgb.py
+++ b/kmk/extensions/rgb.py
@@ -110,12 +110,12 @@ class RGB(Extension):
         if pixels is None:
             import neopixel
 
-            pixels = neopixel.NeoPixel(
+            pixels = (neopixel.NeoPixel(
                 pixel_pin,
                 num_pixels,
                 pixel_order=rgb_order,
                 auto_write=not disable_auto_write,
-            )
+            ),)
         self.pixels = pixels
         self.num_pixels = num_pixels
 


### PR DESCRIPTION
Currently pixels shall be a list, but when pixels is not initiated then it is initiated as neopixel.NeoPixel object instead of list with neopixel.NeoPixel obeject element inside.