### PR TITLE
Update peg_oled_display.py

### DIFF
--- a/kmk/extensions/peg_oled_display.py
+++ b/kmk/extensions/peg_oled_display.py
@@ -1,3 +1,4 @@
+import board
 import busio
 import gc
 
@@ -123,9 +124,9 @@ class Oled(Extension):
     def on_runtime_disable(self, sandbox):
         return
 
-    def during_bootup(self, board):
+    def during_bootup(self, board, SCL=board.SCL, SDA=board.SDA):
         displayio.release_displays()
-        i2c = busio.I2C(board.SCL, board.SDA)
+        i2c = busio.I2C(SCL, SDA)
         self._display = adafruit_displayio_ssd1306.SSD1306(
             displayio.I2CDisplay(i2c, device_address=0x3C),
             width=self._width,


### PR DESCRIPTION
This makes is so that the SCL and SDA are taken from `kb.py` if they are explicitly declared. I don't know if this is a good way to fix it or not but this pr does fix this issue.