### PR TITLE
fix crash on releasing dropped key presses

### DIFF
--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -178,7 +178,11 @@ class KMKKeyboard:
             if is_pressed:
                 self._coordkeys_pressed[int_coord] = key
             else:
-                del self._coordkeys_pressed[int_coord]
+                try:
+                    del self._coordkeys_pressed[int_coord]
+                except KeyError:
+                    if self.debug_enabled:
+                        print(f'ReleaseKeyError(ic={int_coord})')
 
         if key:
             self.process_key(key, is_pressed, int_coord)


### PR DESCRIPTION
We discovered a crash when keys are mashed (see #424). This crash is unrelated to the original issue, but should still be mitigated. It occurs when keys are pressed _very_ fast and some key press events are dropped, but matching key releases are propagated.
It would be nice to fix this at a lower level, but I assume this already happens in the scanner from CP and thus out of our immediate influence.