### PR TITLE
RGB matrix split side using drive name

### DIFF
--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -1,7 +1,7 @@
 # Getting Started
 > Life was like a box of chocolates. You never know what you're gonna get.
 
-KMK is a keyboard focused layer that sits on top of [CircuitPython](https://circuitpython.org/). As such, it should work with most [boards that support CircuitPython](https://circuitpython.org/downloads). It is best to use the last stable version (>5.0).
+KMK is a keyboard focused layer that sits on top of [CircuitPython](https://circuitpython.org/). As such, it should work with most [boards that support CircuitPython](https://circuitpython.org/downloads). It is best to use the last stable version (>7.0).
 Known working and recommended devices can be found [here](Officially_Supported_Microcontrollers.md)
 
 <br>

--- a/kmk/extensions/peg_rgb_matrix.py
+++ b/kmk/extensions/peg_rgb_matrix.py
@@ -3,6 +3,7 @@ import neopixel
 from kmk.extensions import Extension
 from kmk.handlers.stock import passthrough as handler_passthrough
 from kmk.keys import make_key
+from storage import getmount
 
 
 class Color:
@@ -46,10 +47,15 @@ class Rgb_matrix(Extension):
         split=False,
         rightSide=False,
     ):
+        name = str(getmount('/').label)
         self.rgb_order = rgb_order
         self.disable_auto_write = disable_auto_write
         self.split = split
         self.rightSide = rightSide
+        if name.endswith('L'):
+                self.rightSide = False
+        elif name.endswith('R'):
+                self.rightSide = True
         if type(ledDisplay) is Rgb_matrix_data:
             self.ledDisplay = ledDisplay.data
         else:

--- a/kmk/extensions/peg_rgb_matrix.py
+++ b/kmk/extensions/peg_rgb_matrix.py
@@ -1,9 +1,10 @@
 import neopixel
 
+from storage import getmount
+
 from kmk.extensions import Extension
 from kmk.handlers.stock import passthrough as handler_passthrough
 from kmk.keys import make_key
-from storage import getmount
 
 
 class Color:
@@ -53,9 +54,9 @@ class Rgb_matrix(Extension):
         self.split = split
         self.rightSide = rightSide
         if name.endswith('L'):
-                self.rightSide = False
+            self.rightSide = False
         elif name.endswith('R'):
-                self.rightSide = True
+            self.rightSide = True
         if type(ledDisplay) is Rgb_matrix_data:
             self.ledDisplay = ledDisplay.data
         else:


### PR DESCRIPTION
Rgb matrix code can now use the drive name to work out if it is on the right or left side of the keyboard.
You can still pass the bool if you want but it will use the drive name as default.

Also getting started was just a lie.