### PR TITLE
anavi/knobs3: Add ANAVI Knob 1

### DIFF
--- a/boards/anavi/knobs1/README.md
+++ b/boards/anavi/knobs1/README.md
@@ -1,0 +1,8 @@
+# ANAVI Knob 1
+
+ANAVI Knob 1 is an open source, programmable mechanical keyboard with a single rotary encoder and [Seeed XIAO RP2040](https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html).
+
+ANAVI Knob 1 is open source hardware designed with KiCad. All KiCad [files and schematics are available at GitHub](https://github.com/AnaviTechnology/anavi-knob-1) under [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/).
+
+Extensions enabled by default:
+- [Encoder](https://github.com/KMKfw/kmk_firmware/tree/master/docs/encoder.md) Twist control for all the things

--- a/boards/anavi/knobs1/anaviknob.py
+++ b/boards/anavi/knobs1/anaviknob.py
@@ -1,0 +1,23 @@
+'''
+KMK keyboard for ANAVI Knob 1
+'''
+
+import board
+
+from kmk.kmk_keyboard import KMKKeyboard
+from kmk.scanners.keypad import KeysScanner
+
+# fmt: off
+_KEY_CFG = [
+    board.D0
+]
+# fmt: on
+
+
+class AnaviKnob(KMKKeyboard):
+    '''
+    Default keyboard config for the ANAVI Knob 1
+    '''
+
+    def __init__(self):
+        self.matrix = KeysScanner(_KEY_CFG)

--- a/boards/anavi/knobs1/code.py
+++ b/boards/anavi/knobs1/code.py
@@ -1,0 +1,28 @@
+import board
+
+from anaviknob import AnaviKnob
+
+from kmk.extensions.RGB import RGB, AnimationModes
+from kmk.keys import KC
+from kmk.modules.encoder import EncoderHandler
+
+encoder_handler = EncoderHandler()
+encoder_handler.pins = ((board.D1, board.D2, None, False),)
+encoder_handler.map = (((KC.VOLD, KC.VOLU),),)  # base layer
+
+knob = AnaviKnob()
+knob.modules.append(encoder_handler)
+
+rgb_ext = RGB(
+    pixel_pin=board.NEOPIXEL,
+    num_pixels=1,
+    val_limit=100,
+    val_default=25,
+    animation_mode=AnimationModes.RAINBOW,
+)
+knob.extensions.append(rgb_ext)
+
+knob.keymap = [[KC.MUTE]]
+
+if __name__ == '__main__':
+    knob.go()


### PR DESCRIPTION
Add support for ANAVI Knob 1: an open source programmable mini
mechanical keyboard with a rotary encoders and Seeed XIAO RP2040.
This is open source hardware designed with KiCad, the smaller
version of ANAVI Knobs 3.

Signed-off-by: Leon Anavi <leon@anavi.org>