### PR TITLE
Enhancement combos

### DIFF
--- a/docs/combos.md
+++ b/docs/combos.md
@@ -14,15 +14,19 @@ corresponding handlers.
 
 Combos may overlap, i.e. share match keys amongst each other.
 
-The optional arguments `timeout` and `per_key_timeout` define the time window
-within which the match has to happen and whether the timeout is renewed after
-each key press, respectively. These can be customized for every combo
-individually.
-
 ## Keycodes
 |New Keycode |Description                                         |
 |------------|----------------------------------------------------|
 |`KC.LEADER` | a dummy / convenience key for leader key sequences |
+
+## Custom Combo Behavior
+Optional arguments that customize individual combos:
+* `fast_reset`: If True, allows tapping every key (default for sequences);
+   if False, allows holding at least one key and tapping the rest to repeatedly
+   activate the combo (default for chords).
+* `per_key_timeout`: If True, reset timeout on every key press (default for
+  sequences).
+* `timeout`: Set the time window within which the match has to happen in ms.
 
 ## Example Code
 ```python
@@ -40,6 +44,6 @@ combos.combos = [
     Chord((KC.A, KC.B), KC.LSFT)
     Chord((KC.A, KC.B, KC.C), KC.LALT)
     Sequence((KC.LEADER, KC.A, KC.B), KC.C)
-    Sequence((KC.E, KC.F) KC.MYKEY, timeout=500, per_key_timeout=False)
+    Sequence((KC.E, KC.F) KC.MYKEY, timeout=500, per_key_timeout=False, fast_reset=False)
 ]
 ```

--- a/kmk/modules/combos.py
+++ b/kmk/modules/combos.py
@@ -111,6 +111,19 @@ class Combos(Module):
             self._key_buffer.append((int_coord, key, True))
             key = None
 
+            # Single match left: don't wait on timeout to activate
+            if len(self._matching) == 1 and not self._matching[0]._remaining:
+                combo = self._matching.pop(0)
+                self.activate(keyboard, combo)
+                if combo._timeout:
+                    keyboard.cancel_timeout(combo._timeout)
+                    combo._timeout = None
+                for _combo in self._matching:
+                    self.reset_combo(keyboard, _combo)
+                self._matching = []
+                self._key_buffer = []
+                self.reset(keyboard)
+
             # Start or reset individual combo timeouts.
             for combo in self._matching:
                 if combo._timeout:

--- a/kmk/modules/combos.py
+++ b/kmk/modules/combos.py
@@ -4,22 +4,35 @@ from kmk.modules import Module
 
 
 class Combo:
-    timeout = 50
+    fast_reset = False
     per_key_timeout = False
-    _timeout = None
+    timeout = 50
     _remaining = []
+    _timeout = None
 
-    def __init__(self, match, result, timeout=None, per_key_timeout=None):
+    def __init__(
+        self,
+        match,
+        result,
+        fast_reset=None,
+        per_key_timeout=None,
+        timeout=None,
+    ):
         '''
         match: tuple of keys (KC.A, KC.B)
         result: key KC.C
         '''
         self.match = match
         self.result = result
-        if timeout:
-            self.timeout = timeout
-        if per_key_timeout:
+        if fast_reset is not None:
+            self.fast_reset = fast_reset
+        if per_key_timeout is not None:
             self.per_key_timeout = per_key_timeout
+        if timeout is not None:
+            self.timeout = timeout
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}({[k.code for k in self.match]})'
 
     def matches(self, key):
         raise NotImplementedError
@@ -38,8 +51,9 @@ class Chord(Combo):
 
 
 class Sequence(Combo):
-    timeout = 1000
+    fast_reset = True
     per_key_timeout = True
+    timeout = 1000
 
     def matches(self, key):
         try:
@@ -147,13 +161,57 @@ class Combos(Module):
             if key in combo.match:
                 # Deactivate combo if it matches current key.
                 self.deactivate(keyboard, combo)
-                self.reset_combo(keyboard, combo)
+
+                if combo.fast_reset:
+                    self.reset_combo(keyboard, combo)
+                    self._key_buffer = []
+                else:
+                    combo._remaining.insert(0, key)
+                    self._matching.append(combo)
+
                 key = combo.result
                 break
 
-        # Don't propagate key-release events for keys that have been buffered.
-        # Append release events only if corresponding press is in buffer.
         else:
+            # Non-active but matching combos can either activate on key release
+            # if they're the only match, or "un-match" the released key but stay
+            # matching if they're a repeatable combo.
+            for combo in self._matching.copy():
+                if key not in combo.match:
+                    continue
+
+                # Combo matches, but first key released before timeout.
+                elif not combo._remaining:
+                    keyboard.cancel_timeout(combo._timeout)
+                    self._matching.remove(combo)
+                    self.activate(keyboard, combo)
+                    self._key_buffer = []
+                    keyboard._send_hid()
+                    self.deactivate(keyboard, combo)
+                    if combo.fast_reset:
+                        self.reset_combo(keyboard, combo)
+                    else:
+                        combo._remaining.insert(0, key)
+                        self._matching.append(combo)
+
+                # Skip combos that allow tapping.
+                elif combo.fast_reset:
+                    continue
+
+                # This was the last key released of a repeatable combo.
+                elif len(combo._remaining) == len(combo.match) - 1:
+                    self._matching.remove(combo)
+                    self.reset_combo(keyboard, combo)
+                    self.send_key_buffer(keyboard)
+                    self._key_buffer = []
+
+                # Anything between first and last key released.
+                else:
+                    combo._remaining.insert(0, key)
+
+            # Don't propagate key-release events for keys that have been
+            # buffered. Append release events only if corresponding press is in
+            # buffer.
             pressed = self._key_buffer.count((int_coord, key, True))
             released = self._key_buffer.count((int_coord, key, False))
             if (pressed - released) > 0:
@@ -170,13 +228,8 @@ class Combos(Module):
 
         if not combo._remaining:
             self.activate(keyboard, combo)
-            if any([not pressed for (int_coord, key, pressed) in self._key_buffer]):
-                # At least one of the combo keys has already been released:
-                # "tap" the combo result.
-                keyboard._send_hid()
-                self.deactivate(keyboard, combo)
-            self.reset(keyboard)
             self._key_buffer = []
+            self.reset(keyboard)
         else:
             if not self._matching:
                 # This was the last pending combo: flush key buffer.
@@ -216,4 +269,5 @@ class Combos(Module):
     def reset(self, keyboard):
         self._matching = []
         for combo in self.combos:
-            self.reset_combo(keyboard, combo)
+            if combo not in self._active:
+                self.reset_combo(keyboard, combo)

--- a/tests/test_combos.py
+++ b/tests/test_combos.py
@@ -7,7 +7,7 @@ from tests.keyboard_test import KeyboardTest
 
 
 class TestCombo(unittest.TestCase):
-    def test_basic_kmk_keyboard(self):
+    def setUp(self):
         combos = Combos()
         layers = Layers()
         KCMO = KC.MO(1)
@@ -20,9 +20,10 @@ class TestCombo(unittest.TestCase):
             Sequence((KC.N1, KC.N2), KC.X, timeout=50),
             Sequence((KC.N3, KC.N4), KC.Z, timeout=100),
             Sequence((KC.N1, KC.N1, KC.N1), KC.W, timeout=50),
+            Sequence((KC.N3, KC.N2, KC.N1), KC.Y, timeout=50, fast_reset=False),
             Sequence((KC.LEADER, KC.N1), KC.V, timeout=50),
         ]
-        keyboard = KeyboardTest(
+        self.keyboard = KeyboardTest(
             [combos, layers],
             [
                 [KC.A, KC.B, KC.C, KC.D, KC.E, KCMO],
@@ -31,10 +32,14 @@ class TestCombo(unittest.TestCase):
             debug_enabled=False,
         )
 
-        t_within = 40
-        t_after = 60
+        self.t_within = 40
+        self.t_after = 60
 
-        # test combos
+    def test_chord(self):
+        keyboard = self.keyboard
+        t_within = self.t_within
+        t_after = self.t_after
+
         keyboard.test(
             'match: 2 combo, within timeout',
             [(0, True), t_within, (1, True), (0, False), (1, False), t_after],
@@ -42,12 +47,11 @@ class TestCombo(unittest.TestCase):
         )
 
         keyboard.test(
-            'match: 3 combo, within timout, shuffled',
+            'match: 3 combo, within timeout, shuffled',
             [
                 (0, True),
                 (2, True),
                 (1, True),
-                t_within,
                 (1, False),
                 (0, False),
                 (2, False),
@@ -66,7 +70,7 @@ class TestCombo(unittest.TestCase):
                 t_after,
                 (2, True),
                 (2, False),
-                2 * t_after,
+                t_after,
             ],
             [{KC.X}, {}, {KC.C}, {}],
         )
@@ -149,7 +153,42 @@ class TestCombo(unittest.TestCase):
             [{KC.X}, {KC.E, KC.X}, {KC.E}, {}],
         )
 
-        #
+        keyboard.test(
+            'match: 2 combo, partial release and repeat',
+            [
+                (0, True),
+                (1, True),
+                t_after,
+                (1, False),
+                t_after,
+                (1, True),
+                (1, False),
+                (0, False),
+                t_after,
+            ],
+            [{KC.X}, {}, {KC.X}, {}],
+        )
+
+        keyboard.test(
+            'match: 2 combo, partial release and repeat',
+            [
+                (0, True),
+                (2, True),
+                (1, True),
+                t_after,
+                (1, False),
+                (0, False),
+                t_after,
+                (1, True),
+                (0, True),
+                (1, False),
+                (0, False),
+                (2, False),
+                t_after,
+            ],
+            [{KC.Y}, {}, {KC.Y}, {}],
+        )
+
         keyboard.test(
             'match: 2 combo + 2 combo, after timeout',
             [
@@ -158,7 +197,6 @@ class TestCombo(unittest.TestCase):
                 t_after,
                 (2, True),
                 (3, True),
-                2 * t_after,
                 (0, False),
                 (1, False),
                 (2, False),
@@ -176,7 +214,6 @@ class TestCombo(unittest.TestCase):
                 t_after,
                 (2, True),
                 (3, True),
-                2 * t_after,
                 (2, False),
                 (3, False),
                 t_after,
@@ -188,7 +225,7 @@ class TestCombo(unittest.TestCase):
         )
 
         keyboard.test(
-            'no match: partial combor, after timeout',
+            'no match: partial combo, after timeout',
             [(0, True), (0, False), t_after],
             [{KC.A}, {}],
         )
@@ -212,7 +249,6 @@ class TestCombo(unittest.TestCase):
         keyboard.test(
             'no match: partial combo, repeated',
             [
-                t_after,
                 (0, True),
                 (0, False),
                 (1, True),
@@ -258,7 +294,7 @@ class TestCombo(unittest.TestCase):
         )
 
         keyboard.test(
-            'no match: 2 + other combo within timeout',
+            'no match: 2 combo + other within timeout',
             [
                 (0, True),
                 t_within,
@@ -274,7 +310,7 @@ class TestCombo(unittest.TestCase):
         )
 
         keyboard.test(
-            'no match: 2 Combo after timeout',
+            'no match: 2 combo after timeout',
             [(0, True), (0, False), t_after, (1, True), (1, False), t_after],
             [{KC.A}, {}, {KC.B}, {}],
         )
@@ -313,7 +349,6 @@ class TestCombo(unittest.TestCase):
             [
                 (5, True),
                 (2, True),
-                t_within,
                 (2, False),
                 (5, False),
                 t_after,
@@ -333,8 +368,13 @@ class TestCombo(unittest.TestCase):
             [{KC.N1}, {}],
         )
 
-        # test sequences
+    def test_sequence(self):
+        keyboard = self.keyboard
+        t_within = self.t_within
+        t_after = self.t_after
+
         keyboard.keyboard.active_layers = [1]
+
         keyboard.test(
             'match: leader sequence, within timeout',
             [(5, True), (5, False), t_within, (0, True), (0, False), t_after],
@@ -380,10 +420,44 @@ class TestCombo(unittest.TestCase):
                 t_within,
                 (0, True),
                 (0, False),
-                t_within,
                 t_after,
             ],
             [{KC.W}, {}],
+        )
+
+        keyboard.test(
+            'match: 3 sequence hold + other, within timeout',
+            [
+                (0, True),
+                (0, False),
+                (0, True),
+                (0, False),
+                (0, True),
+                t_after,
+                (4, True),
+                (0, False),
+                (4, False),
+                t_after,
+            ],
+            [{KC.W}, {KC.W, KC.N5}, {KC.N5}, {}],
+        )
+
+        keyboard.test(
+            'match: 3 sequence, partial release and repeat',
+            [
+                (2, True),
+                (1, True),
+                (0, True),
+                (0, False),
+                (1, False),
+                (1, True),
+                (0, True),
+                (1, False),
+                (2, False),
+                (0, False),
+                t_after,
+            ],
+            [{KC.Y}, {}, {KC.Y}, {}],
         )
 
         keyboard.test(


### PR DESCRIPTION
Implements enhancements mentioned in #409 and #427:
- more flexible combo reset handling: enables modmorph / key override functionality. Hold down a chord -> activate combo -> release and tap one of the chord keys -> repeat combo without having to tap the entire chord.
- faster combo activation: if there's only one combo left and matching, activate it without waiting for a timeout.

This took a lot longer to get right than it should. Turns out my initial design with dynamically changing match/reset lists is getting unmaintainable. Thought the matching could be faster with a map-reduce like approach, but let's be realistic: few people will have so many combos that reallocating them constantly into different lists is a better solution than iterating over all and checking a flag.
Will port this to tag / state machine like logic at some point.