### PR TITLE
Updated KC.MACRO_SLEEP_MS(ms) documentation

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -203,7 +203,7 @@
 |`KC.UC_MODE_LINUX`     |Sets UnicodeMode to Linux                                            |
 |`KC.UC_MODE_MACOS`     |Sets UnicodeMode to macOS                                            |
 |`KC.UC_MODE_WINC`      |Sets UnicodeMode to WinCompose                                       |
-|`KC.MACRO_SLEEP_MS(ms)`|Sleeps in a macro. Check MACROS for more information.                |
+|`KC.MACRO_SLEEP_MS(ms)`|Sleeps in a macro. See [SEQUENCES](/docs/sequences.md) for more information.               |
 
 
 ## [Modifiers]

--- a/docs/sequences.md
+++ b/docs/sequences.md
@@ -54,6 +54,42 @@ keyboard.keymap = [...PASTE_WITH_COMMENTARY,...]
 The above example will type out "look at this: " and then paste the contents of your
 clipboard.
 
+
+### Sleeping within a sequence
+
+If you need to wait during a sequence, you can use `KC.MACRO_SLEEP_MS(ms)` to wait a 
+length of time, in milliseconds.
+
+```python
+from kmk.handlers.sequences import simple_key_sequence
+
+COUNTDOWN_TO_PASTE = simple_key_sequence(
+	(
+		KC.N3,
+		KC.ENTER,
+		KC.MACRO_SLEEP_MS(1000),
+		KC.N2,
+		KC.ENTER,
+		KC.MACRO_SLEEP_MS(1000),
+		KC.N1,
+		KC.ENTER,
+		KC.MACRO_SLEEP(1000),
+		KC.LCTL(KC.V),
+	)
+)
+
+keyboard.keymap = [...COUNTDOWN_TO_PASTE,...]
+```
+
+This example will type out the following, waiting one second (1000 ms) between numbers:
+
+    3
+    2
+    1
+
+and then paste the contents of your clipboard.
+
+
 ## Unicode
 Before trying to send Unicode sequences, make sure you set your `UnicodeMode`.
 You can set an initial value in your keymap by setting `keyboard.unicode_mode`.


### PR DESCRIPTION
* updated [keycodes.md](docs/keycodes.md) to reflect KC.MACRO_SLEEP_MS documentation within [sequences.md](docs/sequences.md) rather than "macros"
* provided an example of usage within the sequences documentation