### PR TITLE
[debug] improve debug readability

### DIFF
--- a/kmk/extensions/led.py
+++ b/kmk/extensions/led.py
@@ -90,7 +90,7 @@ class LED(Extension):
         )
 
     def __repr__(self):
-        return 'LED({})'.format(self._to_dict())
+        return f'LED({self._to_dict()})'
 
     def _to_dict(self):
         return {

--- a/kmk/extensions/lock_status.py
+++ b/kmk/extensions/lock_status.py
@@ -22,7 +22,7 @@ class LockStatus(Extension):
                 self.hid = device
 
     def __repr__(self):
-        return ('LockStatus(report={})').format(self.report)
+        return f'LockStatus(report={self.report})'
 
     def during_bootup(self, sandbox):
         return

--- a/kmk/extensions/peg_rgb_matrix.py
+++ b/kmk/extensions/peg_rgb_matrix.py
@@ -36,7 +36,7 @@ class Rgb_matrix_data:
     ):
         keys = [key_color] * number_of_keys
         underglow = [underglow_color] * number_of_underglow
-        print('Rgb_matrix_data(keys={},\nunderglow={})'.format(keys, underglow))
+        print(f'Rgb_matrix_data(keys={keys},\nunderglow={underglow})')
 
 
 class Rgb_matrix(Extension):

--- a/kmk/extensions/statusled.py
+++ b/kmk/extensions/statusled.py
@@ -57,7 +57,7 @@ class statusLED(Extension):
             self._layer_last = layer_active
 
     def __repr__(self):
-        return 'SLED({})'.format(self._to_dict())
+        return f'SLED({self._to_dict()})'
 
     def _to_dict(self):
         return {

--- a/kmk/hid.py
+++ b/kmk/hid.py
@@ -70,7 +70,7 @@ class AbstractHID:
         self.post_init()
 
     def __repr__(self):
-        return '{}(REPORT_BYTES={})'.format(self.__class__.__name__, self.REPORT_BYTES)
+        return f'{self.__class__.__name__}(REPORT_BYTES={self.REPORT_BYTES})'
 
     def post_init(self):
         pass

--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -433,7 +433,7 @@ class Key:
         )
 
     def __repr__(self):
-        return 'Key(code={}, has_modifiers={})'.format(self.code, self.has_modifiers)
+        return f'Key(code={self.code}, has_modifiers={self.has_modifiers})'
 
     def on_press(self, state, coord_int=None, coord_raw=None):
         if hasattr(self, '_pre_press_handlers'):
@@ -616,9 +616,7 @@ class ModifierKey(Key):
         )
 
     def __repr__(self):
-        return 'ModifierKey(code={}, has_modifiers={})'.format(
-            self.code, self.has_modifiers
-        )
+        return f'ModifierKey(code={self.code}, has_modifiers={self.has_modifiers})'
 
 
 class ConsumerKey(Key):

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -67,37 +67,27 @@ class KMKKeyboard:
     # real known fix yet other than turning off debug, but M4s have always been
     # tight on RAM so....
     def __repr__(self):
-        return (
-            'KMKKeyboard(\n'
-            '  debug_enabled={}, '
-            'diode_orientation={}, '
-            'matrix={},\n'
-            '  unicode_mode={}, '
-            '_hid_helper={},\n'
-            '  keys_pressed={},\n'
-            '  coordkeys_pressed={},\n'
-            '  hid_pending={}, '
-            'active_layers={}, '
-            'timeouts={}\n'
-            ')'
-        ).format(
-            self.debug_enabled,
-            self.diode_orientation,
-            self.matrix,
-            self.unicode_mode,
-            self._hid_helper,
-            # internal state
-            self.keys_pressed,
-            self._coordkeys_pressed,
-            self.hid_pending,
-            self.active_layers,
-            self._timeouts,
+        return ''.join(
+            [
+                'KMKKeyboard(\n',
+                f'  debug_enabled={self.debug_enabled}, ',
+                f'diode_orientation={self.diode_orientation}, ',
+                f'matrix={self.matrix},\n',
+                f'  unicode_mode={self.unicode_mode}, ',
+                f'_hid_helper={self._hid_helper},\n',
+                f'  keys_pressed={self.keys_pressed},\n',
+                f'  _coordkeys_pressed={self._coordkeys_pressed},\n',
+                f'  hid_pending={self.hid_pending}, ',
+                f'active_layers={self.active_layers}, ',
+                f'_timeouts={self._timeouts}\n',
+                ')',
+            ]
         )
 
     def _print_debug_cycle(self, init=False):
         if self.debug_enabled:
             if init:
-                print('KMKInit(release={})'.format(KMK_RELEASE))
+                print(f'KMKInit(release={KMK_RELEASE})')
             print(self)
 
     def _send_hid(self):
@@ -107,7 +97,7 @@ class KMKKeyboard:
                 hid_report.send()
             except KeyError as e:
                 if self.debug_enabled:
-                    print('HidNotFound(HIDReportType={})'.format(e))
+                    print(f'HidNotFound(HIDReportType={e})')
         self.hid_pending = False
 
     def _handle_matrix_report(self, update=None):
@@ -120,7 +110,7 @@ class KMKKeyboard:
             idx = self.coord_mapping.index(int_coord)
         except ValueError:
             if self.debug_enabled:
-                print('CoordMappingNotFound(ic={})'.format(int_coord))
+                print(f'CoordMappingNotFound(ic={int_coord})')
 
             return None
 
@@ -141,7 +131,7 @@ class KMKKeyboard:
         int_coord = kevent.key_number
         is_pressed = kevent.pressed
         if self.debug_enabled:
-            print('\nMatrixChange(ic={}, pressed={})'.format(int_coord, is_pressed))
+            print(f'\nMatrixChange(ic={int_coord}, pressed={is_pressed})')
 
         key = None
         if not is_pressed:
@@ -156,11 +146,11 @@ class KMKKeyboard:
 
             if key is None:
                 if self.debug_enabled:
-                    print('MatrixUndefinedCoordinate(ic={})'.format(int_coord))
+                    print(f'MatrixUndefinedCoordinate(ic={int_coord})')
                 return self
 
         if self.debug_enabled:
-            print('KeyResolution(key={})'.format(key))
+            print(f'KeyResolution(key={key})')
 
         self.pre_process_key(key, is_pressed, int_coord)
 

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -68,17 +68,17 @@ class KMKKeyboard:
     # tight on RAM so....
     def __repr__(self):
         return (
-            'KMKKeyboard('
-            'debug_enabled={} '
-            'diode_orientation={} '
-            'matrix={} '
-            'unicode_mode={} '
-            '_hid_helper={} '
-            'keys_pressed={} '
-            'coordkeys_pressed={} '
-            'hid_pending={} '
-            'active_layers={} '
-            'timeouts={} '
+            'KMKKeyboard(\n'
+            '  debug_enabled={}, '
+            'diode_orientation={}, '
+            'matrix={},\n'
+            '  unicode_mode={}, '
+            '_hid_helper={},\n'
+            '  keys_pressed={},\n'
+            '  coordkeys_pressed={},\n'
+            '  hid_pending={}, '
+            'active_layers={}, '
+            'timeouts={}\n'
             ')'
         ).format(
             self.debug_enabled,
@@ -141,7 +141,7 @@ class KMKKeyboard:
         int_coord = kevent.key_number
         is_pressed = kevent.pressed
         if self.debug_enabled:
-            print('MatrixChange(ic={} pressed={})'.format(int_coord, is_pressed))
+            print('\nMatrixChange(ic={}, pressed={})'.format(int_coord, is_pressed))
 
         key = None
         if not is_pressed:

--- a/kmk/modules/pimoroni_trackball.py
+++ b/kmk/modules/pimoroni_trackball.py
@@ -70,7 +70,7 @@ class Trackball(Module):
         chip_id = struct.unpack('<H', bytearray(self._i2c_rdwr([REG_CHIP_ID_L], 2)))[0]
         if chip_id != CHIP_ID:
             raise RuntimeError(
-                'Invalid chip ID: 0x{:04X}, expected 0x{:04X}'.format(chip_id, CHIP_ID)
+                f'Invalid chip ID: 0x{chip_id:04X}, expected 0x{CHIP_ID:04X}'
             )
 
         make_key(

--- a/kmk/scanners/digitalio.py
+++ b/kmk/scanners/digitalio.py
@@ -63,9 +63,7 @@ class MatrixScanner(Scanner):
             ]
             self.translate_coords = False
         else:
-            raise ValueError(
-                'Invalid DiodeOrientation: {}'.format(self.diode_orientation)
-            )
+            raise ValueError(f'Invalid DiodeOrientation: {self.diode_orienttaion}')
 
         for pin in self.outputs:
             pin.switch_to_output()


### PR DESCRIPTION
little tweak in the debug output to make things more readable:
- wrap KMKKeyboard report to 100 char (changeable), not splitting a key=value
- include a \n before MatrixChange as those are the begining of  a new logical 'block'

example result:
```
MatrixChange(ic=14, pressed=True)
KeyResolution(key=Key(code=1021, has_modifiers=None))
KMKKeyboard(
  debug_enabled=True, diode_orientation=1, matrix=(<MatrixScanner object at 0x2000eef0>,),
  unicode_mode=0, _hid_helper=USBHID(REPORT_BYTES=9), keys_pressed=set(),
  _coordkeys_pressed={14: Key(code=1021, has_modifiers=None)}, hid_pending=False,
  active_layers=[1, 0], _timeouts={},
)

MatrixChange(ic=52, pressed=True)
KeyResolution(key=Key(code=20, has_modifiers={1}))
KMKKeyboard(
  debug_enabled=True, diode_orientation=1, matrix=(<MatrixScanner object at 0x2000eef0>,),
  unicode_mode=0, _hid_helper=USBHID(REPORT_BYTES=9),
  keys_pressed={Key(code=20, has_modifiers={1})},
  _coordkeys_pressed={52: Key(code=20, has_modifiers={1}), 14: Key(code=1021, has_modifiers=None)},
  hid_pending=False, active_layers=[1, 0], _timeouts={},
)

MatrixChange(ic=52, pressed=False)
KeyResolution(key=Key(code=20, has_modifiers={1}))
KMKKeyboard(
  debug_enabled=True, diode_orientation=1, matrix=(<MatrixScanner object at 0x2000eef0>,),
  unicode_mode=0, _hid_helper=USBHID(REPORT_BYTES=9), keys_pressed=set(),
  _coordkeys_pressed={14: Key(code=1021, has_modifiers=None)}, hid_pending=False,
  active_layers=[1, 0], _timeouts={},
)

MatrixChange(ic=14, pressed=False)
KeyResolution(key=Key(code=1021, has_modifiers=None))
KMKKeyboard(
  debug_enabled=True, diode_orientation=1, matrix=(<MatrixScanner object at 0x2000eef0>,),
  unicode_mode=0, _hid_helper=USBHID(REPORT_BYTES=9), keys_pressed=set(), _coordkeys_pressed={},
  hid_pending=False, active_layers=[0], _timeouts={},
)
```