### PR TITLE
[rgb] fix set_rgb_fill method

### DIFF
--- a/kmk/extensions/rgb.py
+++ b/kmk/extensions/rgb.py
@@ -287,10 +287,9 @@ class RGB(Extension):
         Takes an RGB or RGBW and displays it on all LEDs/Neopixels
         :param rgb: RGB or RGBW
         '''
-        for pixels in self.pixels:
-            pixels.fill(rgb)
-            if not self.disable_auto_write:
-                pixels.show()
+        self.pixels.fill(rgb)
+        if not self.disable_auto_write:
+            self.pixels.show()
 
     def increase_hue(self, step=None):
         '''


### PR DESCRIPTION
The code was wrongly iterating the neopixel, running `fill()` on every
individual pixels.

I suggested the change that was sucessfully tested by @ziptyze on discord.