### PR TITLE
add info to InvalidKey exception

### DIFF
--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -387,7 +387,7 @@ class KeyAttrDict:
                 print(f'{key}: {maybe_key}')
 
             if not maybe_key:
-                raise ValueError('Invalid key')
+                raise ValueError(f'Invalid key: {key}')
 
         return self.__cache[key]
 


### PR DESCRIPTION
When making a typo in a key in the keymap, this allow to know where to look precisely.