### PR TITLE
Support for tap behavior autorepeat for modtap and layertap keys.

### DIFF
--- a/docs/modtap.md
+++ b/docs/modtap.md
@@ -31,7 +31,7 @@ keyboard.modules.append(modtap)
 ## Custom HoldTap Behavior
 The full ModTap signature is as follows:
 ```python
-KC.MT(KC.TAP, KC.HOLD, prefer_hold=True, tap_interrupted=False, tap_time=None)
+KC.MT(KC.TAP, KC.HOLD, prefer_hold=True, tap_interrupted=False, tap_time=None, repeat=True)
 ```
 * `prefer_hold`: decides which keycode the ModTap key resolves to when another
   key is pressed before the timeout finishes. When `True` the hold keycode is
@@ -40,5 +40,10 @@ KC.MT(KC.TAP, KC.HOLD, prefer_hold=True, tap_interrupted=False, tap_time=None)
   key press/down, or after the first other key up/release. Set to `True` for
   interrupt on release.
 * `tap_time`: length of the tap timeout in milliseconds.
+* `repeat`: decides how to interpret a second press after a tap within the
+  timeout. When `True` the second press sends the tap keycode, no matter
+  how long the key remains pressed the second time. This allows the operating
+  system to trigger the autorepeat feature. Set it to `False` for handling
+  the second press as if no tap happened just before.
 
 Each of these parameters can be set for every ModTap key individually.

--- a/kmk/key_validators.py
+++ b/kmk/key_validators.py
@@ -28,7 +28,7 @@ def mod_tap_validator(
         prefer_hold=prefer_hold,
         tap_interrupted=tap_interrupted,
         tap_time=tap_time,
-        repeat=repeat
+        repeat=repeat,
     )
 
 

--- a/kmk/key_validators.py
+++ b/kmk/key_validators.py
@@ -17,7 +17,7 @@ def layer_key_validator(layer, kc=None):
 
 
 def mod_tap_validator(
-    kc, mods=None, prefer_hold=True, tap_interrupted=False, tap_time=None
+    kc, mods=None, prefer_hold=True, tap_interrupted=False, tap_time=None, repeat=True
 ):
     '''
     Validates that mod tap keys are correctly used
@@ -28,6 +28,7 @@ def mod_tap_validator(
         prefer_hold=prefer_hold,
         tap_interrupted=tap_interrupted,
         tap_time=tap_time,
+        repeat=repeat
     )
 
 

--- a/kmk/modules/holdtap.py
+++ b/kmk/modules/holdtap.py
@@ -105,7 +105,7 @@ class HoldTap(Module):
     def ht_pressed(self, key, keyboard, *args, **kwargs):
         '''Unless in repeat mode, do nothing yet, action resolves when key is released, timer expires or other key is pressed.'''
         state = self.key_states.get(key)
-        if not state == None and state.activated == ActivationType.RELEASED:
+        if not state is None and state.activated == ActivationType.RELEASED:
             state.activated = ActivationType.REPEAT
             self.ht_activate_tap(key, keyboard, *args, **kwargs)
         else:

--- a/kmk/modules/holdtap.py
+++ b/kmk/modules/holdtap.py
@@ -138,13 +138,13 @@ class HoldTap(Module):
             # press and release tap because key released within tap time
             self.ht_activate_tap(key, keyboard, *args, **kwargs)
             keyboard.set_timeout(
-                False,
-                lambda: self.ht_deactivate_tap(key, keyboard, *args, **kwargs),
+                False, lambda: self.ht_deactivate_tap(key, keyboard, *args, **kwargs)
             )
             state.activated = ActivationType.RELEASED
             self.send_key_buffer(keyboard)
             # don't delete the key state right now in this case
-            if key.meta.repeat: return keyboard 
+            if key.meta.repeat:
+                return keyboard
         elif state.activated == ActivationType.REPEAT:
             self.ht_deactivate_tap(key, keyboard, *args, **kwargs)
         del self.key_states[key]

--- a/kmk/modules/holdtap.py
+++ b/kmk/modules/holdtap.py
@@ -104,11 +104,10 @@ class HoldTap(Module):
 
     def ht_pressed(self, key, keyboard, *args, **kwargs):
         '''Unless in repeat mode, do nothing yet, action resolves when key is released, timer expires or other key is pressed.'''
-        if key in self.key_states:
-            state = self.key_states[key]
-            if state.activated == ActivationType.RELEASED:
-                state.activated = ActivationType.REPEAT
-                self.ht_activate_tap(key, keyboard, *args, **kwargs)
+        state = self.key_states.get(key)
+        if not state == None and state.activated == ActivationType.RELEASED:
+            state.activated = ActivationType.REPEAT
+            self.ht_activate_tap(key, keyboard, *args, **kwargs)
         else:
             if key.meta.tap_time is None:
                 tap_time = self.tap_time

--- a/kmk/modules/holdtap.py
+++ b/kmk/modules/holdtap.py
@@ -105,7 +105,7 @@ class HoldTap(Module):
     def ht_pressed(self, key, keyboard, *args, **kwargs):
         '''Unless in repeat mode, do nothing yet, action resolves when key is released, timer expires or other key is pressed.'''
         state = self.key_states.get(key)
-        if not state is None and state.activated == ActivationType.RELEASED:
+        if state is not None and state.activated == ActivationType.RELEASED:
             state.activated = ActivationType.REPEAT
             self.ht_activate_tap(key, keyboard, *args, **kwargs)
         else:

--- a/kmk/modules/layers.py
+++ b/kmk/modules/layers.py
@@ -6,7 +6,9 @@ from kmk.types import HoldTapKeyMeta
 
 
 def layer_key_validator_lt(layer, kc, prefer_hold=False, repeat=True, **kwargs):
-    return HoldTapKeyMeta(tap=kc, hold=KC.MO(layer), prefer_hold=prefer_hold, repeat=repeat, **kwargs)
+    return HoldTapKeyMeta(
+        tap=kc, hold=KC.MO(layer), prefer_hold=prefer_hold, repeat=repeat, **kwargs
+    )
 
 
 def layer_key_validator_tt(layer, prefer_hold=True, **kwargs):

--- a/kmk/modules/layers.py
+++ b/kmk/modules/layers.py
@@ -5,8 +5,8 @@ from kmk.modules.holdtap import ActivationType, HoldTap
 from kmk.types import HoldTapKeyMeta
 
 
-def layer_key_validator_lt(layer, kc, prefer_hold=False, **kwargs):
-    return HoldTapKeyMeta(tap=kc, hold=KC.MO(layer), prefer_hold=prefer_hold, **kwargs)
+def layer_key_validator_lt(layer, kc, prefer_hold=False, repeat=True, **kwargs):
+    return HoldTapKeyMeta(tap=kc, hold=KC.MO(layer), prefer_hold=prefer_hold, repeat=repeat, **kwargs)
 
 
 def layer_key_validator_tt(layer, prefer_hold=True, **kwargs):

--- a/kmk/types.py
+++ b/kmk/types.py
@@ -19,12 +19,14 @@ class HoldTapKeyMeta:
         prefer_hold=True,
         tap_interrupted=False,
         tap_time=None,
+        repeat=False,
     ):
         self.tap = tap
         self.hold = hold
         self.prefer_hold = prefer_hold
         self.tap_interrupted = tap_interrupted
         self.tap_time = tap_time
+        self.repeat = repeat
 
 
 class LayerKeyMeta:


### PR DESCRIPTION
This is an implementation of QMK-like autorepeat for tap-hold keys.

Assuming you have a tap hold key, you can simulate a long press of the tap behavior (which should trigger the autorepeat feature if set in the OS). To this purpose: within the hold delay, tap the key once, then press it again and keep it pressed as long as you want the autorepeat to last.
The behavior can be disabled by passing the optional argument `repeat = False`.

I did not write the doc yet (what are the concerned files? only `modtap.md` and  `layers.md`?)