### PR TITLE
Fix encoder direction inversion being ignored

### DIFF
--- a/kmk/modules/encoder.py
+++ b/kmk/modules/encoder.py
@@ -227,8 +227,7 @@ class EncoderHandler(Module):
 
                     # Else fall back to GPIO
                     else:
-                        gpio_pins = pins[:3]
-                        new_encoder = GPIOEncoder(*gpio_pins)
+                        new_encoder = GPIOEncoder(*pins)
 
                     # In our case, we need to define keybord and encoder_id for callbacks
                     new_encoder.on_move_do = lambda x, bound_idx=idx: self.on_move_do(


### PR DESCRIPTION
`GPIOEncoder` needs 4 arguments, the last one being encoder direction. Unfortunately, seems like `EncoderHandler` limits the number of arguments to 3, so the inverted direction never gets passed and always defaults to `False`. 

I fixed this by removing the argument number limit entirely. This makes it in line with I2C encoder that doesn't have a limit. The limit also may cause confusion in the future as no additional arguments will be accepted either in case the encoder method will need to be extended (that happened to me, that's how I discovered this issue in the first place).

Test code from `main.py`:

```
encoder_handler.pins = ( (board.GP14, board.GP15, None, True), )
encoder_handler.map = ( ((KC.N1, KC.N2, KC.NO), ), )
```

Setting True to False and vice versa didn't have an effect when rotating the encoder. Now the direction is correctly inverted. 