### PR TITLE
Encoder resolution setting

### DIFF
--- a/docs/encoder.md
+++ b/docs/encoder.md
@@ -1,32 +1,31 @@
 # Encoder module
-Add twist control to your keyboard! Volume, zoom, anything you want
+Add twist control to your keyboard! Volume, zoom, anything you want.
 
-I2C encoder type has been tested with the Adafruit I2C QT Rotary Encoder with NeoPixel
+I2C encoder type has been tested with the Adafruit I2C QT Rotary Encoder with NeoPixel.
 
-**Note:** If split with encoders and both sides should work, it's currently necessary to use the encoder-scanner explained at the bottom of [scanners docs](scanners.md).
+**Note:** If you have a **split** keyboard with encoders and **both sides** should work, it's currently necessary to use the encoder-scanner explained at the bottom of [scanners docs](scanners.md).
 
 ## Enabling the extension
-The constructor(`EncoderHandler` class) takes a list of encoder, each one defined as either:
+The constructor(`EncoderHandler` class) takes a list of encoders, each one defined as either:
 
-* a list of pad_a pin, pad_b pin, button_pin and optionally a flag set to True is you want it to be reversed
+* a list of `pad_a` pin, `pad_b` pin, `button_pin` and optionally a flag set to `True` is you want encoder direction to be reversed
 * a `busio.I2C`, address and optionally a flag set to True if you want it to be reversed
 
-The encoder_map is modeled after the keymap and works the same way. It should have as many layers (key pressed on "turned left", key pressed on "turned right", key pressed on "knob pressed") as your keymap, and use KC.NO keys for layers that you don't require any action.
-The encoder supports a velocity mode if you desire to make something for video or sound editing. 
+The `encoder_map` is modeled after the keymap and works the same way. It should have as many layers (key pressed on "turned left", key pressed on "turned right", key pressed on "knob pressed") as your keymap, and use `KC.NO` keys for layers that you don't require any action. The encoder supports a velocity mode if you desire to make something for video or sound editing. 
 
 
 
 ## How to use
-How to use this module in your main / code file
+How to use this module in your `main.py` / `code.py` file.
 
-1. load the module
+1. Load the module.
 ```python
 from kmk.modules.encoder import EncoderHandler
 encoder_handler = EncoderHandler()
 keyboard.modules = [layers, modtap, encoder_handler]
 ```
 
-2. Define the pins for each encoder (pin_a, pin_b, pin_button [or `None` if the encoder's button is handled differently or not at all], True for an inversed encoder)
+2. Define the pins for each encoder: `pin_a`, `pin_b` for rotations, `pin_button` for the switch in the encoder (set to `None` if the encoder's button is handled differently or not at all). If you want to invert the direction of the encoder, set the 4th (optional) parameter `is_inverted` to `True`.
 ```python
 #GPIO Encoder
 encoder_handler.pins = ((board.GP17, board.GP15, board.GP14, False), (encoder 2 definition), etc. )
@@ -42,27 +41,24 @@ SDA = board.GP0
 SCL = board.GP1
 i2c = busio.I2C(SCL, SDA)
 
-encoder_handler.pins = ((i2c, 0x36, False),)
+encoder_handler.pins = ((i2c, 0x36, False), (encoder 2 definition), etc. )
 ```
 
 
-3. Define the mapping of keys to be called (1 / layer)
+3. Define the mapping of keys to be called for each layer.
 ```python
 # You can optionally predefine combo keys as for your layout
 Zoom_in = KC.LCTRL(KC.EQUAL)
 Zoom_out = KC.LCTRL(KC.MINUS)
 
-
-encoder_handler.map = [(( KC.VOLD, KC.VOLU, KC.MUTE),(encoder 2 definition), etc. ), # Layer 1
-                      ((KC.Zoom_out, KC.Zoom_in, KC.NO),(encoder 2 definition), etc. ), # Layer 2
-                      ((KC.A, KC.Z, KC.N1),(encoder 2 definition), etc. ), # Layer 3
-                      ((KC.NO, KC.NO, KC.NO),(encoder 2 definition), etc. ), # Layer 4
+encoder_handler.map = [(( KC.VOLD, KC.VOLU, KC.MUTE), (encoder 2 definition), etc. ), # Layer 1
+                      ((Zoom_out, Zoom_in, KC.NO), (encoder 2 definition), etc. ), # Layer 2
+                      ((KC.A, KC.Z, KC.N1), (encoder 2 definition), etc. ), # Layer 3
+                      ((KC.NO, KC.NO, KC.NO), (encoder 2 definition), etc. ), # Layer 4
                       ]
 ```
 
-
-
-4. Encoder methods on_move_do and on_button_do can be overwritten for complex use cases
+4. Encoder methods `on_move_do` and `on_button_do` can be overwritten for complex use cases.
 
 ## Full example (with 1 encoder)
 
@@ -165,3 +161,4 @@ encoder_handler.map = ( ((KC.UP, KC.DOWN, KC.MUTE),), # Standard
 
 if __name__ == "__main__":
     keyboard.go()
+```

--- a/docs/encoder.md
+++ b/docs/encoder.md
@@ -16,22 +16,24 @@ The `encoder_map` is modeled after the keymap and works the same way. It should 
 
 
 ## How to use
-How to use this module in your `main.py` / `code.py` file.
+Here is all you need to use this module in your `main.py` / `code.py` file.
 
 1. Load the module.
+
 ```python
 from kmk.modules.encoder import EncoderHandler
 encoder_handler = EncoderHandler()
 keyboard.modules = [layers, modtap, encoder_handler]
 ```
 
-2. Define the pins for each encoder: `pin_a`, `pin_b` for rotations, `pin_button` for the switch in the encoder (set to `None` if the encoder's button is handled differently or not at all). If you want to invert the direction of the encoder, set the 4th (optional) parameter `is_inverted` to `True`.
+2. Define the pins for each encoder: `pin_a`, `pin_b` for rotations, `pin_button` for the switch in the encoder (set to `None` if the encoder's button is handled differently or not at all). If you want to invert the direction of the encoder, set the 4th (optional) parameter `is_inverted` to `True`. 5th parameter is [encoder resolution](#encoder-resolution), it can be either `2` or `4`.
+ 
 ```python
-#GPIO Encoder
+# Regular GPIO Encoder
 encoder_handler.pins = ((board.GP17, board.GP15, board.GP14, False), (encoder 2 definition), etc. )
 ```
 
-OR
+Or in case you have an I2C encoder on a special PCB (e.g. Adafruit I2C QT Rotary Encoder), define I2C encoder as following.
 
 ```python
 # I2C Encoder
@@ -44,8 +46,8 @@ i2c = busio.I2C(SCL, SDA)
 encoder_handler.pins = ((i2c, 0x36, False), (encoder 2 definition), etc. )
 ```
 
-
 3. Define the mapping of keys to be called for each layer.
+
 ```python
 # You can optionally predefine combo keys as for your layout
 Zoom_in = KC.LCTRL(KC.EQUAL)
@@ -58,7 +60,32 @@ encoder_handler.map = [(( KC.VOLD, KC.VOLU, KC.MUTE), (encoder 2 definition), et
                       ]
 ```
 
-4. Encoder methods `on_move_do` and `on_button_do` can be overwritten for complex use cases.
+## Encoder resolution
+
+Depending on your encoder precision, it may send 4 or 2 pulses on every detent. By default the encoder resolution is set to 4, but if your an encoder only activates on every second detent (skips pulses), set the resolution to 2. If the encoder activates twice on every detent, set the value to 4.
+
+You can change the default globally for all encoders **before** initializing the encoder pins (`main.py` file):
+```python
+encoder_handler.resolution = 2
+encoder_handler.pins = ( (board.GP14, board.GP15, None), (board.GP26, board.GP27, None), )
+```
+
+Or if you have different types of encoders, set resolution for each encoder individually:
+```python
+encoder_handler.pins = (
+    (board.GP14, board.GP15, None, False, 4), 
+    (board.GP26, board.GP27, None, False, 2),
+    (board.GP26, board.GP27, None ), # will be set to global default
+)
+```
+
+## Handler methods overrides
+
+Encoder methods `on_move_do` and `on_button_do` can be overridden for complex use cases.
+
+
+---
+
 
 ## Full example (with 1 encoder)
 
@@ -94,6 +121,7 @@ keyboard.diode_orientation = DiodeOrientation.COLUMNS
 #i2c = busio.I2C(SCL, SDA)
 #encoder_handler.i2c = ((i2c, 0x36, False),)
 
+# encoder_handler.resolution = 2 # for encoders with more precision
 encoder_handler.pins = ((board.GP17, board.GP15, board.GP14, False),)
 
 keyboard.tap_time = 250

--- a/docs/encoder.md
+++ b/docs/encoder.md
@@ -8,8 +8,8 @@ I2C encoder type has been tested with the Adafruit I2C QT Rotary Encoder with Ne
 ## Enabling the extension
 The constructor(`EncoderHandler` class) takes a list of encoders, each one defined as either:
 
-* a list of `pad_a` pin, `pad_b` pin, `button_pin` and optionally a flag set to `True` is you want encoder direction to be reversed
-* a `busio.I2C`, address and optionally a flag set to True if you want it to be reversed
+* a list of `pad_a` pin, `pad_b` pin, `button_pin` and optionally a flag set to `True` is you want encoder direction to be reversed;
+* a `busio.I2C`, address and optionally a flag set to `True` if you want it to be reversed.
 
 The `encoder_map` is modeled after the keymap and works the same way. It should have as many layers (key pressed on "turned left", key pressed on "turned right", key pressed on "knob pressed") as your keymap, and use `KC.NO` keys for layers that you don't require any action. The encoder supports a velocity mode if you desire to make something for video or sound editing. 
 

--- a/docs/encoder.md
+++ b/docs/encoder.md
@@ -3,7 +3,7 @@ Add twist control to your keyboard! Volume, zoom, anything you want.
 
 I2C encoder type has been tested with the Adafruit I2C QT Rotary Encoder with NeoPixel.
 
-**Note:** If you have a **split** keyboard with encoders and **both sides** should work, it's currently necessary to use the encoder-scanner explained at the bottom of [scanners docs](scanners.md).
+**Note:** If you have a **split** keyboard and encoders on **both sides** should work, it's currently necessary to use the encoder-scanner explained at the bottom of [scanners docs](scanners.md).
 
 ## Enabling the extension
 The constructor(`EncoderHandler` class) takes a list of encoders, each one defined as either:

--- a/kmk/modules/encoder.py
+++ b/kmk/modules/encoder.py
@@ -227,8 +227,7 @@ class EncoderHandler(Module):
 
                     # Else fall back to GPIO
                     else:
-                        gpio_pins = pins[:3]
-                        new_encoder = GPIOEncoder(*gpio_pins)
+                        new_encoder = GPIOEncoder(*pins)
 
                     # In our case, we need to define keybord and encoder_id for callbacks
                     new_encoder.on_move_do = lambda x, bound_idx=idx: self.on_move_do(

--- a/kmk/modules/encoder.py
+++ b/kmk/modules/encoder.py
@@ -58,19 +58,21 @@ class BaseEncoder:
                     self._direction = -1
 
             # when the encoder settles on a position (every 2 steps)
-            if new_state == (True, True):
-                if self._movement > 2:
-                    # 1 full step is 4 movements, however, when rotated quickly,
-                    # some steps may be missed. This makes it behaves more
-                    # naturally
-                    real_movement = round(self._movement / 4)
+            if new_state[0] == new_state[1]:
+                # when the encoder made a full loop according to its resolution
+                if self._movement >= self.resolution - 1:
+                    # 1 full step is 4 movements (2 for high-resolution encoder), 
+                    # however, when rotated quickly, some steps may be missed. 
+                    # This makes it behave more naturally
+                    real_movement = round(self._movement / self.resolution)
                     self._pos += self._direction * real_movement
                     if self.on_move_do is not None:
                         for i in range(real_movement):
                             self.on_move_do(self.get_state())
-                # Reinit to properly identify new movement
-                self._movement = 0
-                self._direction = 0
+
+                    # Rotation finished, reset to identify new movement
+                    self._movement = 0
+                    self._direction = 0
 
             self._state = new_state
 
@@ -97,8 +99,12 @@ class BaseEncoder:
 
 
 class GPIOEncoder(BaseEncoder):
-    def __init__(self, pin_a, pin_b, pin_button=None, is_inverted=False):
+    def __init__(self, pin_a, pin_b, pin_button=None, is_inverted=False, resolution=None):
         super().__init__(is_inverted)
+
+        # Resolution can be 4 or 2 depending on whether the detent 
+        # on the encoder is defined by 2 or 4 pulses
+        self.resolution = resolution
 
         self.pin_a = EncoderPin(pin_a)
         self.pin_b = EncoderPin(pin_b)
@@ -210,6 +216,7 @@ class EncoderHandler(Module):
         self.encoders = []
         self.pins = None
         self.map = None
+        self.resolution = 4
 
     def on_runtime_enable(self, keyboard):
         return
@@ -228,6 +235,9 @@ class EncoderHandler(Module):
                     # Else fall back to GPIO
                     else:
                         new_encoder = GPIOEncoder(*pins)
+                        # Set default resolution if unset
+                        if new_encoder.resolution is None:
+                            new_encoder.resolution = self.resolution
 
                     # In our case, we need to define keybord and encoder_id for callbacks
                     new_encoder.on_move_do = lambda x, bound_idx=idx: self.on_move_do(

--- a/kmk/modules/encoder.py
+++ b/kmk/modules/encoder.py
@@ -61,8 +61,8 @@ class BaseEncoder:
             if new_state[0] == new_state[1]:
                 # when the encoder made a full loop according to its resolution
                 if self._movement >= self.resolution - 1:
-                    # 1 full step is 4 movements (2 for high-resolution encoder), 
-                    # however, when rotated quickly, some steps may be missed. 
+                    # 1 full step is 4 movements (2 for high-resolution encoder),
+                    # however, when rotated quickly, some steps may be missed.
                     # This makes it behave more naturally
                     real_movement = round(self._movement / self.resolution)
                     self._pos += self._direction * real_movement
@@ -99,10 +99,12 @@ class BaseEncoder:
 
 
 class GPIOEncoder(BaseEncoder):
-    def __init__(self, pin_a, pin_b, pin_button=None, is_inverted=False, resolution=None):
+    def __init__(
+        self, pin_a, pin_b, pin_button=None, is_inverted=False, resolution=None
+    ):
         super().__init__(is_inverted)
 
-        # Resolution can be 4 or 2 depending on whether the detent 
+        # Resolution can be 4 or 2 depending on whether the detent
         # on the encoder is defined by 2 or 4 pulses
         self.resolution = resolution
 


### PR DESCRIPTION
Added support for GPIO encoders with different resolutions: previously only ones with 4 state changes per detent were supported, I added support for encoders with 2 state changes per detent. The resolution can be set globally (before initializing the pins) or individually for each encoder.

I called the setting “resolution” as it's not technically the same as “divisor” (e.g. in rotaryio). Also QMK uses the same name and I'm used to it, I find it quite intuitive. 

Could be a better (no rotaryio) alternative to #357. Or both could be used without conflicts. Also this solves #347.

Tested with 5 different encoders on separate pins (vertical 24 and 20 detents with resolution = 4, EVQWGD001 roller with resolution 4, two models of encoders with 30 detents per revolution with resolution = 2), everything works as expected, no issues whatsoever. No skipped pulses or double activations. 

Docs updated (and slightly improved overall), tests and formatting ran.

Haven't looked into adding this for I2C encoders: they seem quite rare, I don't have any.