### PR TITLE
[doc:rgb] fix link to neopixel lib

### DIFF
--- a/docs/rgb.md
+++ b/docs/rgb.md
@@ -2,9 +2,7 @@
 Want your keyboard to shine? Add some lights!
 
 ## CircuitPython
-If not running KMKPython, this does require the NeoPixel library from Adafruit.
-This can be downloaded 
-[here](https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel/blob/6e35cd2b40575a20e2904b096508325cef4a71d3/neopixel.py).
+This does require the [NeoPixel library from Adafruit](https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel/blob/main/neopixel.py).
 It is part of the [Adafruit CircuitPython Bundle](https://github.com/adafruit/Adafruit_CircuitPython_Bundle).
 Simply put this in the "root" of your CircuitPython device. If unsure, it's the folder with main.py in it, and should be the first folder you see when you open the device.
 


### PR DESCRIPTION
The link is hardcoded to a commit from 2018-12-21 (version 3.3.5) while
we are currently at 6.3.3.

The rgb makes use of the fact that NeoPixel is a subclass of PixelBuf
but that was not true back then. Hence some people following the link in
the doc get a neopixel library incompatible with kmk.