### PR TITLE
Add RapidFire module

### DIFF
--- a/docs/rapidfire.md
+++ b/docs/rapidfire.md
@@ -7,6 +7,7 @@ Some instances where this may be useful are:
 - MMOs and other games where you are encouraged to repeatedly spam a key
 - More responsive volume up and volume down
 - Faster cursor key navigation
+- Combine with the [Mouse Keys](https://github.com/KMKfw/kmk_firmware/blob/master/docs/mouse_keys.md) module to create rapid-fire mouse clicks
 - Anywhere else you may need an ergonomic alternative to repetitive key tapping
 
 ## Keycodes
@@ -21,12 +22,12 @@ Each repeat counts as one full cycle of pressing and releasing. RapidFire works 
 
 The RapidFire keycode has a few different options:
 
-|        Option         | Default Value | Description                                                                                                                                                  |
-| :-------------------: | :-----------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|       `repeat`        |     `100`     | The delay between repeats. Note: `2` appears to be the minimum effective value. If you run into issues, try increasing this value.           |
-|        `wait`         |     `200`     | The delay before starting to repeat. Useful if you want to be able to type with keys that have a low `repeat` value. |
-|  `randomize_repeat`   |    `False`    | Randomize the value of `repeat`. Useful for making the repetitive input look human in instances where you may be flagged as a bot otherwise.                 |
-| `randomize_magnitude` |     `15`      | The magnitude of the randomization. If randomization is enabled, the repeat delay will be `repeat` plus or minus a random value up to this amount.           |
+|        Option         | Default Value | Description                                                                                                                                        |
+| :-------------------: | :-----------: | :------------------------------------------------------------------------------------------------------------------------------------------------- |
+|       `repeat`        |     `100`     | The delay between repeats. Note: `2` appears to be the minimum effective value. If you run into issues, try increasing this value.                 |
+|        `wait`         |     `200`     | The delay before starting to repeat. Useful if you want to be able to type with keys that have a low `repeat` value.                               |
+|  `randomize_repeat`   |    `False`    | Randomize the value of `repeat`. Useful for making the repetitive input look human in instances where you may be flagged as a bot otherwise.       |
+| `randomize_magnitude` |     `15`      | The magnitude of the randomization. If randomization is enabled, the repeat delay will be `repeat` plus or minus a random value up to this amount. |
 
 ### Example Code
 

--- a/docs/rapidfire.md
+++ b/docs/rapidfire.md
@@ -1,6 +1,6 @@
 # RapidFire
 
-The RapidFire module lets a user send repeated key presses while a key is held.
+The RapidFire module lets a user send repeated key taps while a key is held.
 
 Some instances where this may be useful are:
 

--- a/docs/rapidfire.md
+++ b/docs/rapidfire.md
@@ -22,13 +22,13 @@ Each repeat counts as one full cycle of pressing and releasing. RapidFire works 
 
 The RapidFire keycode has a few different options:
 
-|          Option           | Default Value | Description                                                                                                                                                                                                                 |
-| :-----------------------: | :-----------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|        `interval`         |     `100`     | The time between key taps sent in milliseconds. Note: `10` appears to be the minimum effective value.                                                                                                                       |
-|         `timeout`         |     `200`     | The amount of time in milliseconds the key must be held down before RapidFire activates. Useful if you want to be able to type with keys that have a low `interval` value. A value of `0` will result in no waiting period. |
-|        `randomize`        |    `False`    | Add randomization to the value of `interval`. Useful for making the repetitive input look human in instances where you may be flagged as a bot otherwise.                                                                   |
-| `randomization_magnitude` |     `15`      | If `randomize` is `True`, the time between key taps sent will be `interval` plus or minus a random value up to this amount.                                                                                                 |
-|         `toggle`          |    `False`    | If set to `True`, activating RapidFire will toggle it on or off. Useful if you don't want to have to keep the button held. Set `timeout` to `0` if you would like to toggle on tap.                                         |
+|             Option              | Default Value | Description                                                                                                                                                                                                                 |
+| :-----------------------------: | :-----------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|           `interval`            |     `100`     | The time between key taps sent in milliseconds. Note: `10` appears to be the minimum effective value.                                                                                                                       |
+|            `timeout`            |     `200`     | The amount of time in milliseconds the key must be held down before RapidFire activates. Useful if you want to be able to type with keys that have a low `interval` value. A value of `0` will result in no waiting period. |
+| `enable_interval_randomization` |    `False`    | Enable randomizing the value of `interval`. Useful for making the repetitive input look human in instances where you may be flagged as a bot otherwise.                                                                     |
+|    `randomization_magnitude`    |     `15`      | If `enable_interval_randomization` is `True`, the time between key taps sent will be `interval` plus or minus a random value up to this amount.                                                                             |
+|            `toggle`             |    `False`    | If set to `True`, activating RapidFire will toggle it on or off. Useful if you don't want to have to keep the button held. Set `timeout` to `0` if you would like to toggle on tap.                                         |
 
 ### Example Code
 
@@ -38,7 +38,7 @@ from kmk.modules.rapidfire import RapidFire
 keyboard.modules.append(RapidFire())
 
 # After 200 milliseconds, repeatedly send Shift+A every 75-125 milliseconds while the button is held
-SPAM_A = KC.RF(KC.LSFT(KC.A), timeout=200, interval=100, randomize=True, randomization_magnitude=25)
+SPAM_A = KC.RF(KC.LSFT(KC.A), timeout=200, interval=100, enable_interval_randomization=True, randomization_magnitude=25)
 # Immediately toggle repeatedly sending Enter every 50 milliseconds on tap
 SPAM_ENTER = KC.RF(KC.ENT, toggle=True, timeout=0, interval=50)
 

--- a/docs/rapidfire.md
+++ b/docs/rapidfire.md
@@ -22,13 +22,13 @@ Each repeat counts as one full cycle of pressing and releasing. RapidFire works 
 
 The RapidFire keycode has a few different options:
 
-|        Option         | Default Value | Description                                                                                                                                                                           |
-| :-------------------: | :-----------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-|       `repeat`        |     `100`     | The delay between repeats in milliseconds. Note: `10` appears to be the minimum effective value. If you run into issues, try increasing this value.                                   |
-|        `wait`         |     `200`     | The delay before starting to repeat in milliseconds. Useful if you want to be able to type with keys that have a low `repeat` value. A value of `0` will result in no waiting period. |
-|  `randomize_repeat`   |    `False`    | Randomize the value of `repeat`. Useful for making the repetitive input look human in instances where you may be flagged as a bot otherwise.                                          |
-| `randomize_magnitude` |     `15`      | The magnitude of the randomization. If randomization is enabled, the repeat delay will be `repeat` plus or minus a random value up to this amount.                                    |
-|       `toggle`        |    `False`    | If set to `True`, activating RapidFire will toggle it on or off. Useful if you don't want to have to keep the button held. Set `wait` to `0` if you would like to toggle on tap.      |
+|          Option           | Default Value | Description                                                                                                                                                                                                                 |
+| :-----------------------: | :-----------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|        `interval`         |     `100`     | The time between key taps sent in milliseconds. Note: `10` appears to be the minimum effective value.                                                                                                                       |
+|         `timeout`         |     `200`     | The amount of time in milliseconds the key must be held down before RapidFire activates. Useful if you want to be able to type with keys that have a low `interval` value. A value of `0` will result in no waiting period. |
+|        `randomize`        |    `False`    | Add randomization to the value of `interval`. Useful for making the repetitive input look human in instances where you may be flagged as a bot otherwise.                                                                   |
+| `randomization_magnitude` |     `15`      | If `randomize` is `True`, the time between key taps sent will be `interval` plus or minus a random value up to this amount.                                                                                                 |
+|         `toggle`          |    `False`    | If set to `True`, activating RapidFire will toggle it on or off. Useful if you don't want to have to keep the button held. Set `timeout` to `0` if you would like to toggle on tap.                                         |
 
 ### Example Code
 
@@ -38,9 +38,9 @@ from kmk.modules.rapidfire import RapidFire
 keyboard.modules.append(RapidFire())
 
 # After 200 milliseconds, repeatedly send Shift+A every 75-125 milliseconds while the button is held
-SPAM_A = KC.RF(KC.LSFT(KC.A), wait=200, repeat=100, randomize_repeat=True, randomize_magnitude=25)
+SPAM_A = KC.RF(KC.LSFT(KC.A), timeout=200, interval=100, randomize=True, randomization_magnitude=25)
 # Immediately toggle repeatedly sending Enter every 50 milliseconds on tap
-SPAM_ENTER = KC.RF(KC.ENT, toggle=True, wait=0, repeat=50)
+SPAM_ENTER = KC.RF(KC.ENT, toggle=True, timeout=0, interval=50)
 
 
 keyboard.keymap = [[

--- a/docs/rapidfire.md
+++ b/docs/rapidfire.md
@@ -28,7 +28,7 @@ The RapidFire keycode has a few different options:
 |        `wait`         |     `200`     | The delay before starting to repeat. Useful if you want to be able to type with keys that have a low `repeat` value.                               |
 |  `randomize_repeat`   |    `False`    | Randomize the value of `repeat`. Useful for making the repetitive input look human in instances where you may be flagged as a bot otherwise.       |
 | `randomize_magnitude` |     `15`      | The magnitude of the randomization. If randomization is enabled, the repeat delay will be `repeat` plus or minus a random value up to this amount. |
-|       `toggle`        |    `False`    | Toggle RapidFire state on keypress rather than needing to be held.                                                                                 |
+|       `toggle`        |    `False`    | Toggle RapidFire state on keypress rather than needing to be held. Toggle functionality starts after the `wait` period.                            |
 
 ### Example Code
 

--- a/docs/rapidfire.md
+++ b/docs/rapidfire.md
@@ -12,9 +12,9 @@ Some instances where this may be useful are:
 
 ## Keycodes
 
-| Key     | Description                                          |
-| :------ | :--------------------------------------------------- |
-| `KC.RF` | Repeatedly sends the specified keycode while pressed |
+| Key         | Description                                          |
+| :---------- | :--------------------------------------------------- |
+| `KC.RF(kc)` | Repeatedly sends the specified keycode while pressed |
 
 ## Usage
 
@@ -22,13 +22,13 @@ Each repeat counts as one full cycle of pressing and releasing. RapidFire works 
 
 The RapidFire keycode has a few different options:
 
-|        Option         | Default Value | Description                                                                                                                                        |
-| :-------------------: | :-----------: | :------------------------------------------------------------------------------------------------------------------------------------------------- |
-|       `repeat`        |     `100`     | The delay between repeats. Note: `2` appears to be the minimum effective value. If you run into issues, try increasing this value.                 |
-|        `wait`         |     `200`     | The delay before starting to repeat. Useful if you want to be able to type with keys that have a low `repeat` value.                               |
-|  `randomize_repeat`   |    `False`    | Randomize the value of `repeat`. Useful for making the repetitive input look human in instances where you may be flagged as a bot otherwise.       |
-| `randomize_magnitude` |     `15`      | The magnitude of the randomization. If randomization is enabled, the repeat delay will be `repeat` plus or minus a random value up to this amount. |
-|       `toggle`        |    `False`    | Toggle RapidFire state on keypress rather than needing to be held. Toggle functionality starts after the `wait` period.                            |
+|        Option         | Default Value | Description                                                                                                                                                                           |
+| :-------------------: | :-----------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|       `repeat`        |     `100`     | The delay between repeats in milliseconds. Note: `10` appears to be the minimum effective value. If you run into issues, try increasing this value.                                   |
+|        `wait`         |     `200`     | The delay before starting to repeat in milliseconds. Useful if you want to be able to type with keys that have a low `repeat` value. A value of `0` will result in no waiting period. |
+|  `randomize_repeat`   |    `False`    | Randomize the value of `repeat`. Useful for making the repetitive input look human in instances where you may be flagged as a bot otherwise.                                          |
+| `randomize_magnitude` |     `15`      | The magnitude of the randomization. If randomization is enabled, the repeat delay will be `repeat` plus or minus a random value up to this amount.                                    |
+|       `toggle`        |    `False`    | If set to `True`, activating RapidFire will toggle it on or off. Useful if you don't want to have to keep the button held. Set `wait` to `0` if you would like to toggle on tap.      |
 
 ### Example Code
 
@@ -37,9 +37,14 @@ from kmk.modules.rapidfire import RapidFire
 
 keyboard.modules.append(RapidFire())
 
-# After 200 milliseconds, repeatedly send Shift+A every 75-125 milliseconds until the button is pressed again
+# After 200 milliseconds, repeatedly send Shift+A every 75-125 milliseconds while the button is held
+SPAM_A = KC.RF(KC.LSFT(KC.A), wait=200, repeat=100, randomize_repeat=True, randomize_magnitude=25)
+# Immediately toggle repeatedly sending Enter every 50 milliseconds on tap
+SPAM_ENTER = KC.RF(KC.ENT, toggle=True, wait=0, repeat=50)
+
+
 keyboard.keymap = [[
-    KC.RF(KC.LSFT(KC.A), wait=200, repeat=100, randomize_repeat=True, randomize_magnitude=25, toggle=True)
+    SPAM_A, SPAM_ENTER
     ]]
 
 ```

--- a/docs/rapidfire.md
+++ b/docs/rapidfire.md
@@ -28,6 +28,7 @@ The RapidFire keycode has a few different options:
 |        `wait`         |     `200`     | The delay before starting to repeat. Useful if you want to be able to type with keys that have a low `repeat` value.                               |
 |  `randomize_repeat`   |    `False`    | Randomize the value of `repeat`. Useful for making the repetitive input look human in instances where you may be flagged as a bot otherwise.       |
 | `randomize_magnitude` |     `15`      | The magnitude of the randomization. If randomization is enabled, the repeat delay will be `repeat` plus or minus a random value up to this amount. |
+|       `toggle`        |    `False`    | Toggle RapidFire state on keypress rather than needing to be held.                                                                                 |
 
 ### Example Code
 
@@ -36,9 +37,9 @@ from kmk.modules.rapidfire import RapidFire
 
 keyboard.modules.append(RapidFire())
 
-# After 200 milliseconds, repeatedly send Shift+A every 75-125 milliseconds while the RapidFire key is held 
+# After 200 milliseconds, repeatedly send Shift+A every 75-125 milliseconds until the button is pressed again
 keyboard.keymap = [[
-    KC.RF(KC.LSFT(KC.A), wait=200, repeat=100, randomize_repeat=True, randomize_magnitude=25)
+    KC.RF(KC.LSFT(KC.A), wait=200, repeat=100, randomize_repeat=True, randomize_magnitude=25, toggle=True)
     ]]
 
 ```

--- a/docs/rapidfire.md
+++ b/docs/rapidfire.md
@@ -1,0 +1,43 @@
+# RapidFire
+
+The RapidFire module lets a user send repeated key presses while a key is held.
+
+Some instances where this may be useful are:
+
+- MMOs and other games where you are encouraged to repeatedly spam a key
+- More responsive volume up and volume down
+- Faster cursor key navigation
+- Anywhere else you may need an ergonomic alternative to repetitive key tapping
+
+## Keycodes
+
+| Key     | Description                                          |
+| :------ | :--------------------------------------------------- |
+| `KC.RF` | Repeatedly sends the specified keycode while pressed |
+
+## Usage
+
+Each repeat counts as one full cycle of pressing and releasing. RapidFire works with chording (i.e., holding Shift plus a RapidFire key will repeatedly send the shifted version of that RapidFire key) and chaining (i.e., `KC.RF(KC.LSHIFT(KC.A))`. Multiple RapidFire keys can be held down at the same time, and their timers work independently of each other.
+
+The RapidFire keycode has a few different options:
+
+|        Option         | Default Value | Description                                                                                                                                                  |
+| :-------------------: | :-----------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|       `repeat`        |     `100`     | The delay between repeats. Note: `2` appears to be the minimum effective value. If you run into issues, try increasing this value.           |
+|        `wait`         |     `200`     | The delay before starting to repeat. Useful if you want to be able to type with keys that have a low `repeat` value. |
+|  `randomize_repeat`   |    `False`    | Randomize the value of `repeat`. Useful for making the repetitive input look human in instances where you may be flagged as a bot otherwise.                 |
+| `randomize_magnitude` |     `15`      | The magnitude of the randomization. If randomization is enabled, the repeat delay will be `repeat` plus or minus a random value up to this amount.           |
+
+### Example Code
+
+```python
+from kmk.modules.rapidfire import RapidFire
+
+keyboard.modules.append(RapidFire())
+
+# After 200 milliseconds, repeatedly send Shift+A every 75-125 milliseconds while the RapidFire key is held 
+keyboard.keymap = [[
+    KC.RF(KC.LSFT(KC.A), wait=200, repeat=100, randomize_repeat=True, randomize_magnitude=25)
+    ]]
+
+```

--- a/kmk/modules/rapidfire.py
+++ b/kmk/modules/rapidfire.py
@@ -1,0 +1,82 @@
+from kmk.keys import make_argumented_key
+from kmk.modules import Module
+from random import randint
+
+
+class RapidFireMeta:
+    def __init__(
+        self,
+        kc,
+        repeat=100,
+        wait=200,
+        randomize_repeat=False,
+        randomize_magnitude=15,
+    ):
+        self.kc = kc
+        self.repeat = repeat
+        self.wait = wait
+        self.randomize_repeat = randomize_repeat
+        self.randomize_magnitude = randomize_magnitude
+
+
+class RapidFire(Module):
+    _active_keys = {}
+
+    def __init__(self):
+        make_argumented_key(
+            validator=RapidFireMeta,
+            names=("RF",),
+            on_press=self._rf_pressed,
+            on_release=self._rf_released,
+        )
+
+    def _get_repeat(self, key):
+        if key.meta.randomize_repeat:
+            return key.meta.repeat + randint(
+                -key.meta.randomize_magnitude, key.meta.randomize_magnitude
+            )
+        return key.meta.repeat
+
+    def _on_repeat_timeout(self, key, keyboard):
+        keyboard.tap_key(key.meta.kc)
+        repeat_timeout_key = keyboard.set_timeout(
+            self._get_repeat(key),
+            lambda: self._on_repeat_timeout(key, keyboard),
+        )
+        self._active_keys[key] = repeat_timeout_key
+
+    def _on_wait_timeout(self, key, keyboard):
+        self._on_repeat_timeout(key, keyboard)
+
+    def _rf_pressed(self, key, keyboard, *args, **kwargs):
+        keyboard.tap_key(key.meta.kc)
+        wait_timeout_key = keyboard.set_timeout(
+            key.meta.wait, lambda: self._on_wait_timeout(key, keyboard)
+        )
+        self._active_keys[key] = wait_timeout_key
+
+    def _rf_released(self, key, keyboard, *args, **kwargs):
+        if key in self._active_keys:
+            keyboard.cancel_timeout(self._active_keys[key])
+            self._active_keys.pop(key)
+
+    def during_bootup(self, keyboard):
+        return
+
+    def before_matrix_scan(self, keyboard):
+        return
+
+    def before_hid_send(self, keyboard):
+        return
+
+    def after_hid_send(self, keyboard):
+        return
+
+    def on_powersave_enable(self, keyboard):
+        return
+
+    def on_powersave_disable(self, keyboard):
+        return
+
+    def after_matrix_scan(self, keyboard):
+        return

--- a/kmk/modules/rapidfire.py
+++ b/kmk/modules/rapidfire.py
@@ -8,17 +8,17 @@ class RapidFireMeta:
     def __init__(
         self,
         kc,
-        repeat=100,
-        wait=200,
-        randomize_repeat=False,
-        randomize_magnitude=15,
+        interval=100,
+        timeout=200,
+        randomize=False,
+        randomization_magnitude=15,
         toggle=False,
     ):
         self.kc = kc
-        self.repeat = repeat
-        self.wait = wait
-        self.randomize_repeat = randomize_repeat
-        self.randomize_magnitude = randomize_magnitude
+        self.interval = interval
+        self.timeout = timeout
+        self.randomize = randomize
+        self.randomization_magnitude = randomization_magnitude
         self.toggle = toggle
 
 
@@ -36,11 +36,11 @@ class RapidFire(Module):
         )
 
     def _get_repeat(self, key):
-        if key.meta.randomize_repeat:
-            return key.meta.repeat + randint(
-                -key.meta.randomize_magnitude, key.meta.randomize_magnitude
+        if key.meta.randomize:
+            return key.meta.interval + randint(
+                -key.meta.randomization_magnitude, key.meta.randomization_magnitude
             )
-        return key.meta.repeat
+        return key.meta.interval
 
     def _on_timer_timeout(self, key, keyboard):
         keyboard.tap_key(key.meta.kc)
@@ -57,11 +57,11 @@ class RapidFire(Module):
             self._toggled_keys.remove(key)
             self._deactivate_key(key, keyboard)
             return
-        if key.meta.wait > 0:
+        if key.meta.timeout > 0:
             keyboard.tap_key(key.meta.kc)
             self._waiting_keys.append(key)
             self._active_keys[key] = keyboard.set_timeout(
-                key.meta.wait, lambda: self._on_timer_timeout(key, keyboard)
+                key.meta.timeout, lambda: self._on_timer_timeout(key, keyboard)
             )
         else:
             self._on_timer_timeout(key, keyboard)

--- a/kmk/modules/rapidfire.py
+++ b/kmk/modules/rapidfire.py
@@ -33,20 +33,17 @@ class RapidFire(Module):
             )
         return key.meta.repeat
 
-    def _on_repeat_timeout(self, key, keyboard):
+    def _on_timer_timeout(self, key, keyboard):
         keyboard.tap_key(key.meta.kc)
         repeat_timeout_key = keyboard.set_timeout(
-            self._get_repeat(key), lambda: self._on_repeat_timeout(key, keyboard)
+            self._get_repeat(key), lambda: self._on_timer_timeout(key, keyboard)
         )
         self._active_keys[key] = repeat_timeout_key
-
-    def _on_wait_timeout(self, key, keyboard):
-        self._on_repeat_timeout(key, keyboard)
 
     def _rf_pressed(self, key, keyboard, *args, **kwargs):
         keyboard.tap_key(key.meta.kc)
         wait_timeout_key = keyboard.set_timeout(
-            key.meta.wait, lambda: self._on_wait_timeout(key, keyboard)
+            key.meta.wait, lambda: self._on_timer_timeout(key, keyboard)
         )
         self._active_keys[key] = wait_timeout_key
 

--- a/kmk/modules/rapidfire.py
+++ b/kmk/modules/rapidfire.py
@@ -57,11 +57,14 @@ class RapidFire(Module):
             self._toggled_keys.remove(key)
             self._deactivate_key(key, keyboard)
             return
-        keyboard.tap_key(key.meta.kc)
-        self._waiting_keys.append(key)
-        self._active_keys[key] = keyboard.set_timeout(
-            key.meta.wait, lambda: self._on_timer_timeout(key, keyboard)
-        )
+        if key.meta.wait > 0:
+            keyboard.tap_key(key.meta.kc)
+            self._waiting_keys.append(key)
+            self._active_keys[key] = keyboard.set_timeout(
+                key.meta.wait, lambda: self._on_timer_timeout(key, keyboard)
+            )
+        else:
+            self._on_timer_timeout(key, keyboard)
 
     def _rf_released(self, key, keyboard, *args, **kwargs):
         if key not in self._active_keys:
@@ -70,6 +73,8 @@ class RapidFire(Module):
             if key not in self._waiting_keys:
                 return
             self._toggled_keys.remove(key)
+        if key in self._waiting_keys:
+            self._waiting_keys.remove(key)
         self._deactivate_key(key, keyboard)
 
     def _deactivate_key(self, key, keyboard):

--- a/kmk/modules/rapidfire.py
+++ b/kmk/modules/rapidfire.py
@@ -1,16 +1,12 @@
+from random import randint
+
 from kmk.keys import make_argumented_key
 from kmk.modules import Module
-from random import randint
 
 
 class RapidFireMeta:
     def __init__(
-        self,
-        kc,
-        repeat=100,
-        wait=200,
-        randomize_repeat=False,
-        randomize_magnitude=15,
+        self, kc, repeat=100, wait=200, randomize_repeat=False, randomize_magnitude=15
     ):
         self.kc = kc
         self.repeat = repeat
@@ -40,8 +36,7 @@ class RapidFire(Module):
     def _on_repeat_timeout(self, key, keyboard):
         keyboard.tap_key(key.meta.kc)
         repeat_timeout_key = keyboard.set_timeout(
-            self._get_repeat(key),
-            lambda: self._on_repeat_timeout(key, keyboard),
+            self._get_repeat(key), lambda: self._on_repeat_timeout(key, keyboard)
         )
         self._active_keys[key] = repeat_timeout_key
 

--- a/kmk/modules/rapidfire.py
+++ b/kmk/modules/rapidfire.py
@@ -10,14 +10,14 @@ class RapidFireMeta:
         kc,
         interval=100,
         timeout=200,
-        randomize=False,
+        enable_interval_randomization=False,
         randomization_magnitude=15,
         toggle=False,
     ):
         self.kc = kc
         self.interval = interval
         self.timeout = timeout
-        self.randomize = randomize
+        self.enable_interval_randomization = enable_interval_randomization
         self.randomization_magnitude = randomization_magnitude
         self.toggle = toggle
 
@@ -36,7 +36,7 @@ class RapidFire(Module):
         )
 
     def _get_repeat(self, key):
-        if key.meta.randomize:
+        if key.meta.enable_interval_randomization:
             return key.meta.interval + randint(
                 -key.meta.randomization_magnitude, key.meta.randomization_magnitude
             )

--- a/kmk/modules/rapidfire.py
+++ b/kmk/modules/rapidfire.py
@@ -46,6 +46,8 @@ class RapidFire(Module):
         keyboard.tap_key(key.meta.kc)
         if key in self._waiting_keys:
             self._waiting_keys.remove(key)
+        if key.meta.toggle and key not in self._toggled_keys:
+            self._toggled_keys.append(key)
         self._active_keys[key] = keyboard.set_timeout(
             self._get_repeat(key), lambda: self._on_timer_timeout(key, keyboard)
         )
@@ -56,8 +58,6 @@ class RapidFire(Module):
             self._deactivate_key(key, keyboard)
             return
         keyboard.tap_key(key.meta.kc)
-        if key.meta.toggle:
-            self._toggled_keys.append(key)
         self._waiting_keys.append(key)
         self._active_keys[key] = keyboard.set_timeout(
             key.meta.wait, lambda: self._on_timer_timeout(key, keyboard)

--- a/kmk/modules/rapidfire.py
+++ b/kmk/modules/rapidfire.py
@@ -35,17 +35,15 @@ class RapidFire(Module):
 
     def _on_timer_timeout(self, key, keyboard):
         keyboard.tap_key(key.meta.kc)
-        repeat_timeout_key = keyboard.set_timeout(
+        self._active_keys[key] = keyboard.set_timeout(
             self._get_repeat(key), lambda: self._on_timer_timeout(key, keyboard)
         )
-        self._active_keys[key] = repeat_timeout_key
 
     def _rf_pressed(self, key, keyboard, *args, **kwargs):
         keyboard.tap_key(key.meta.kc)
-        wait_timeout_key = keyboard.set_timeout(
+        self._active_keys[key] = keyboard.set_timeout(
             key.meta.wait, lambda: self._on_timer_timeout(key, keyboard)
         )
-        self._active_keys[key] = wait_timeout_key
 
     def _rf_released(self, key, keyboard, *args, **kwargs):
         if key in self._active_keys:

--- a/kmk/modules/rapidfire.py
+++ b/kmk/modules/rapidfire.py
@@ -21,7 +21,7 @@ class RapidFire(Module):
     def __init__(self):
         make_argumented_key(
             validator=RapidFireMeta,
-            names=("RF",),
+            names=('RF',),
             on_press=self._rf_pressed,
             on_release=self._rf_released,
         )


### PR DESCRIPTION
Implements a module that lets users hold a key to repeatedly send a tap.