### PR TITLE
fix KC["_"] resolving to BLE_REFRESH

### DIFF
--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -189,7 +189,7 @@ class KeyAttrDict:
             )
         elif key in ('HID_SWITCH', 'HID'):
             make_key(names=('HID_SWITCH', 'HID'), on_press=handlers.hid_switch)
-        elif key in ('BLE_REFRESH'):
+        elif key in ('BLE_REFRESH',):
             make_key(names=('BLE_REFRESH',), on_press=handlers.ble_refresh)
         else:
             maybe_key = first_truthy(

--- a/tests/test_kmk_keys.py
+++ b/tests/test_kmk_keys.py
@@ -239,6 +239,9 @@ class TestKeys_get(unittest.TestCase):
         created = make_key(names=('ThIs_Is_A_StRaNgE_kEy',))
         assert created is KC.get('ThIs_Is_A_StRaNgE_kEy')
 
+    def test_underscore(self):
+        assert KC.get('_')
+
 
 # Some of these test appear silly, but they're testing we get the
 # same, single, instance back when requested through KC and that


### PR DESCRIPTION
The key names for `BLE_REFRESH` was a string instead of a tuple. That matched `KC['_']` and threw an error.
I put a unit test for underscore in, probably overkill, but shouldn't do any harm.
