### PR TITLE
implement arbitrary code execution (ACE) over data serial.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@
 - [Mouse keys](mouse_keys.md): Adds mouse keycodes
 - [OneShot](oneshot.md): Adds support for oneshot/sticky keys.
 - [Power](power.md): Power saving features. This is mostly useful when on battery power.
-- [SerialACE](serialace.md): Arbitrary Code Execution over the data serial.
+- [SerialACE](serialace.md): [DANGER - _see module README_] Arbitrary Code Execution over the data serial.
 - [Split](split_keyboards.md): Keyboards split in two. Seems ergonomic!
 - [TapDance](tapdance.md): Different key actions depending on how often it is pressed.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@
 - [Mouse keys](mouse_keys.md): Adds mouse keycodes
 - [OneShot](oneshot.md): Adds support for oneshot/sticky keys.
 - [Power](power.md): Power saving features. This is mostly useful when on battery power.
+- [SerialACE](serialace.md): Arbitrary Code Execution over the data serial.
 - [Split](split_keyboards.md): Keyboards split in two. Seems ergonomic!
 - [TapDance](tapdance.md): Different key actions depending on how often it is pressed.
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -16,7 +16,7 @@ when tapped, and modifier when held.
 - [OneShot](oneshot.md): Adds support for oneshot/sticky keys.
 - [Power](power.md): Power saving features. This is mostly useful when on battery power.
 - [Split](split_keyboards.md): Keyboards split in two. Seems ergonomic!
-- [SerialACE](serialace.md): Arbitrary Code Execution over the data serial.
+- [SerialACE](serialace.md): [DANGER - _see module README_] Arbitrary Code Execution over the data serial.
 - [TapDance](tapdance.md): Different key actions depending on how often it is pressed.
 - [Dynamic Sequences](dynamic_sequences.md): Records a sequence of keypresses and plays it back.
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -16,6 +16,7 @@ when tapped, and modifier when held.
 - [OneShot](oneshot.md): Adds support for oneshot/sticky keys.
 - [Power](power.md): Power saving features. This is mostly useful when on battery power.
 - [Split](split_keyboards.md): Keyboards split in two. Seems ergonomic!
+- [SerialACE](serialace.md): Arbitrary Code Execution over the data serial.
 - [TapDance](tapdance.md): Different key actions depending on how often it is pressed.
 - [Dynamic Sequences](dynamic_sequences.md): Records a sequence of keypresses and plays it back.
 

--- a/docs/serialace.md
+++ b/docs/serialace.md
@@ -1,0 +1,51 @@
+# Serial ACE (Arbitrary Code Execution over serial interface)
+
+> Caution: This module allows unrestricted, arbitrary code execution on your KMK
+> device. That includes potential exploits, such as keyloggers, and unvetted
+> user code that may result in undesired behaviour and/or crashes.
+> This feature is purely experimental in the sense that you probably neither
+> want nor should use it in production.
+> Advanced knowledge of python and the serial console is required, and we will
+> not provide help or support in any way.
+
+This module provides an API to run any valid python code on your keyboard and
+return the result of that code via an additional serial consol (not the one you
+use for the circuitpython debugger).
+
+
+## Prerequisite
+
+Enable the data serial in `boot.py`:
+```python
+import usb_cdc
+usb_cdc.enable(data=True)
+```
+
+
+## Example
+
+Enable the module, just as any other module else:
+```
+from kmk.modules.serialace import SerialACE
+keyboard.modules.append(SerialACE())
+```
+
+Assume the data serial is on `/dev/ttyACM1`.
+Depending on your OS settings, it bay be necessary to explicitly set the serial
+device to raw transmission, no echo:
+```bash
+stty -F /dev/ttyACM1 raw -echo
+```
+
+### Get the List of Active Layers
+```bash
+$ echo "keyboard.active_layers" > /dev/ttyACM1
+$ cat /dev/ttyACM1
+[0]
+```
+
+### "Tap" a Key
+```bash
+$ echo "exec('from kmk.keys import KC; keyboard.tap_key(KC.Y)')" > /dev/ttyACM1
+$ y
+```

--- a/docs/serialace.md
+++ b/docs/serialace.md
@@ -1,12 +1,12 @@
 # Serial ACE (Arbitrary Code Execution over serial interface)
 
-> Caution: This module allows unrestricted, arbitrary code execution on your KMK
-> device. That includes potential exploits, such as keyloggers, and unvetted
-> user code that may result in undesired behaviour and/or crashes.
-> This feature is purely experimental in the sense that you probably neither
-> want nor should use it in production.
-> Advanced knowledge of python and the serial console is required, and we will
-> not provide help or support in any way.
+**Caution: This module allows unrestricted, arbitrary code execution on your KMK
+device. That includes potential exploits, such as keyloggers, and unvetted
+user code that may result in undesired behaviour and/or crashes.
+This feature is purely experimental in the sense that you probably neither
+want nor should use it in production.
+Advanced knowledge of python and the serial console is required, and we will
+not provide help or support in any way.**
 
 This module provides an API to run any valid python code on your keyboard and
 return the result of that code via an additional serial consol (not the one you

--- a/kmk/modules/serialace.py
+++ b/kmk/modules/serialace.py
@@ -1,8 +1,9 @@
 from usb_cdc import data
 
 from kmk.modules import Module
+from kmk.utils import Debug
 
-debug_enabled = False
+debug = Debug(__name__)
 
 
 class SerialACE(Module):
@@ -39,17 +40,18 @@ class SerialACE(Module):
         if idx == -1:
             return
 
-        # Split off command and evaluate
+        # Split off command and evaluate.
         line = self.buffer[:idx]
         self.buffer = self.buffer[idx + 1 :]
+
         try:
-            if debug_enabled:
-                print(f'SerialACE eval({line})')
+            if debug.enabled:
+                debug(f'eval({line})')
             ret = eval(line, {'keyboard': keyboard})
             data.write(bytearray(str(ret) + '\n'))
         except Exception as err:
-            if debug_enabled:
-                print(f'SerialACE error({err})')
+            if debug.enabled:
+                debug(f'error: {err}')
 
     def after_hid_send(self, keyboard):
         pass

--- a/kmk/modules/serialace.py
+++ b/kmk/modules/serialace.py
@@ -1,0 +1,61 @@
+from usb_cdc import data
+
+from kmk.modules import Module
+
+debug_enabled = False
+
+
+class SerialACE(Module):
+    buffer = bytearray()
+
+    def during_bootup(self, keyboard):
+        try:
+            data.timeout = 0
+        except AttributeError:
+            pass
+
+    def before_matrix_scan(self, keyboard):
+        pass
+
+    def after_matrix_scan(self, keyboard):
+        pass
+
+    def process_key(self, keyboard, key, is_pressed, int_coord):
+        return key
+
+    def before_hid_send(self, keyboard):
+        # Serial.data isn't initialized.
+        if not data:
+            return
+
+        # Nothing to parse.
+        if data.in_waiting == 0:
+            return
+
+        self.buffer.extend(data.read())
+        idx = self.buffer.find(b'\n')
+
+        # No full command yet.
+        if idx == -1:
+            return
+
+        # Split off command and evaluate
+        line = self.buffer[:idx]
+        self.buffer = self.buffer[idx + 1 :]
+        try:
+            if debug_enabled:
+                print(f'SerialACE eval({line})')
+            ret = eval(line, {'keyboard': keyboard})
+            data.write(bytearray(str(ret) + '\n'))
+        except Exception as err:
+            if debug_enabled:
+                print(f'SerialACE error({err})')
+
+    def after_hid_send(self, keyboard):
+        pass
+
+    def on_powersave_enable(self, keyboard):
+        pass
+
+    def on_powersave_disable(self, keyboard):
+        pass


### PR DESCRIPTION
Every application needs a gaping hole in security, ready to be exploited.
I don't even remember how I got the idea, but in the past people were asking questions like "*how can I tell my keyboard `x` from my host OS*".
Well, here's an API that allows arbitrary code execution over the built-in data serial (which is different from the REPL/console).
This is as much a proof-of-concept as it is probably a terrible idea.

How to use:
1. enable the data serial in `boot.py`:
```python
import usb_cdc
usb_cdc.enable(data=True)
```
2. load module (obvious)
3. assuming serial on `/dev/ttyACM1` and _explicitly_ set to send `\n` as line break (this is not always the default):
```bash
$ echo "keyboard.active_layers" > /dev/ttyACM1
$ cat /dev/ttyACM1
[0]
$ echo "exec('from kmk.keys import KC; keyboard.tap_key(KC.Y)')" > /dev/ttyACM1
$ y
```

It's in draft because still poc, no docs, not sure if we even want this...