### PR TITLE
Explicitly define CircuitPython 7.0 or higher as the minimum supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ channel below.
 - Bluetooth HID and split keyboards. No more wires.
 
 ## Getting Started
-
+KMK requires [CircuitPython](https://circuitpython.org/) version 7.0 or higher.
 Our getting started guide can be found
-[here](https://github.com/KMKfw/kmk_firmware/blob/master/docs/Getting_Started.md)
+[here](https://github.com/KMKfw/kmk_firmware/blob/master/docs/Getting_Started.md).
 
 ## The KMK Team
 

--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -1,14 +1,14 @@
 # Getting Started
 > Life was like a box of chocolates. You never know what you're gonna get.
 
-KMK is a keyboard focused layer that sits on top of [CircuitPython](https://circuitpython.org/). As such, it should work with most [boards that support CircuitPython](https://circuitpython.org/downloads). It is best to use the last stable version (>7.0).
+KMK is a keyboard focused layer that sits on top of [CircuitPython](https://circuitpython.org/). As such, it should work with most [boards that support CircuitPython](https://circuitpython.org/downloads). KMK requries CircuitPython version 7.0 or above.
 Known working and recommended devices can be found [here](Officially_Supported_Microcontrollers.md)
 
 <br>
 
 ## TL;DR Quick start guide
 > To infinity and beyond!
-1. [Install CircuitPython on your board](https://learn.adafruit.com/welcome-to-circuitpython/installing-circuitpython). With most boards, it should be as easy as drag and dropping the firmware on the drive
+1. [Install CircuitPython version 7.0 or higher on your board](https://learn.adafruit.com/welcome-to-circuitpython/installing-circuitpython). With most boards, it should be as easy as drag and dropping the firmware on the drive
 2. Get a [copy of KMK](https://github.com/KMKfw/kmk_firmware/archive/refs/heads/master.zip) from the master branch 
 3. Unzip it and copy the KMK folder and the boot.py file at the root of the USB drive corresponding to your board (often appearing as CIRCUITPY)
 4. Create a new *code.py* or *main.py* file in the same root directory (same level as boot.py) with the example content hereunder: 


### PR DESCRIPTION
As per the conversation in #205, I've specified 7.0 as the explicit minimum version for KMK in preparation for static typing and made the requirement more apparent by placing it on the main readme.