### PR TITLE
Fix unittest

### DIFF
--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -60,6 +60,9 @@ def maybe_make_consumer_key(candidate, code, names):
 class KeyAttrDict:
     __cache = {}
 
+    def __iter__(self):
+        return self.__cache.__iter__()
+
     def __setitem__(self, key, value):
         if DEBUG_OUTPUT:
             print(f'__setitem__ {key}, {value}')

--- a/kmk/modules/combos.py
+++ b/kmk/modules/combos.py
@@ -232,8 +232,8 @@ class Combos(Module):
 
         if not combo._remaining:
             self.activate(keyboard, combo)
-            # check if the last buffered key event was a release
-            if self._key_buffer[-1][2] == False:
+            # check if the last buffered key event was a 'release'
+            if not self._key_buffer[-1][2]:
                 keyboard._send_hid()
                 self.deactivate(keyboard, combo)
             self._key_buffer = []

--- a/kmk/modules/combos.py
+++ b/kmk/modules/combos.py
@@ -181,7 +181,7 @@ class Combos(Module):
                     continue
 
                 # Combo matches, but first key released before timeout.
-                elif not combo._remaining:
+                elif not combo._remaining and len(self._matching) == 1:
                     keyboard.cancel_timeout(combo._timeout)
                     self._matching.remove(combo)
                     self.activate(keyboard, combo)
@@ -194,6 +194,9 @@ class Combos(Module):
                         combo._remaining.insert(0, key)
                         self._matching.append(combo)
 
+                elif not combo._remaining:
+                    continue
+
                 # Skip combos that allow tapping.
                 elif combo.fast_reset:
                     continue
@@ -202,8 +205,9 @@ class Combos(Module):
                 elif len(combo._remaining) == len(combo.match) - 1:
                     self._matching.remove(combo)
                     self.reset_combo(keyboard, combo)
-                    self.send_key_buffer(keyboard)
-                    self._key_buffer = []
+                    if not self._matching:
+                        self.send_key_buffer(keyboard)
+                        self._key_buffer = []
 
                 # Anything between first and last key released.
                 else:
@@ -228,6 +232,10 @@ class Combos(Module):
 
         if not combo._remaining:
             self.activate(keyboard, combo)
+            # check if the last buffered key event was a release
+            if self._key_buffer[-1][2] == False:
+                keyboard._send_hid()
+                self.deactivate(keyboard, combo)
             self._key_buffer = []
             self.reset(keyboard)
         else:

--- a/tests/keyboard_test.py
+++ b/tests/keyboard_test.py
@@ -1,6 +1,4 @@
-import random
 import time
-from functools import reduce
 from unittest.mock import Mock, patch
 
 from kmk.hid import HIDModes

--- a/tests/keyboard_test.py
+++ b/tests/keyboard_test.py
@@ -63,6 +63,7 @@ class KeyboardTest:
         hid_send.side_effect = lambda report: hid_reports.append(report[1:])
 
         # inject key switch events
+        self.keyboard._main_loop()
         for e in key_events:
             if isinstance(e, int):
                 starttime_ms = time.time_ns() // 1_000_000
@@ -119,4 +120,6 @@ class KeyboardTest:
 
     def do_main_loop(self):
         self.keyboard._main_loop()
-        time.sleep(0.002)
+        time.sleep(0.001)
+        self.keyboard._main_loop()
+        time.sleep(0.001)

--- a/tests/keyboard_test.py
+++ b/tests/keyboard_test.py
@@ -4,7 +4,7 @@ from functools import reduce
 from unittest.mock import Mock, patch
 
 from kmk.hid import HIDModes
-from kmk.keys import ModifierKey
+from kmk.keys import KC, ModifierKey
 from kmk.kmk_keyboard import KMKKeyboard
 from kmk.scanners import DiodeOrientation
 from kmk.scanners.digitalio import MatrixScanner
@@ -12,6 +12,16 @@ from kmk.scanners.digitalio import MatrixScanner
 
 class DigitalInOut(Mock):
     value = False
+
+
+def code2name(code):
+    for name in KC:
+        try:
+            if KC[name].code == code:
+                return name
+        except AttributeError:
+            pass
+    return code
 
 
 class KeyboardTest:
@@ -46,15 +56,15 @@ class KeyboardTest:
         self.keyboard._init(hid_type=HIDModes.NOOP)
 
     @patch('kmk.hid.AbstractHID.hid_send')
-    def test(self, testname, key_events, assert_hid_reports, hid_send):
+    def test(self, testname, key_events, assert_reports, hid_send):
         if self.debug_enabled:
-            print(testname, key_events, assert_hid_reports)
+            print(testname)
 
-        hid_send_call_arg_list = []
-        hid_send.side_effect = lambda hid_report: hid_send_call_arg_list.append(
-            hid_report[1:]
-        )
+        # setup report recording
+        hid_reports = []
+        hid_send.side_effect = lambda report: hid_reports.append(report[1:])
 
+        # inject key switch events
         for e in key_events:
             if isinstance(e, int):
                 starttime_ms = time.time_ns() // 1_000_000
@@ -66,43 +76,49 @@ class KeyboardTest:
                 self.pins[key_pos].value = is_pressed
                 self.do_main_loop()
 
-        if self.debug_enabled:
-            for hid_report in hid_send_call_arg_list:
-                print(hid_report)
+        matching = True
+        for i in range(max(len(hid_reports), len(assert_reports))):
+            # prepare the generated report codes
+            try:
+                hid_report = hid_reports[i]
+            except IndexError:
+                report_mods = None
+                report_keys = [None]
+            else:
+                report_mods = hid_report[0]
+                report_keys = {code for code in hid_report[2:] if code != 0}
 
-        assert len(hid_send_call_arg_list) >= len(assert_hid_reports)
+            # prepare the desired report codes
+            try:
+                hid_assert = assert_reports[i]
+            except IndexError:
+                assert_mods = None
+                assert_keys = [None]
+            else:
+                assert_mods = 0
+                assert_keys = set()
+                for k in hid_assert:
+                    if isinstance(k, ModifierKey):
+                        assert_mods |= k.code
+                    else:
+                        assert_keys.add(k.code)
 
-        for i, hid_report in enumerate(
-            hid_send_call_arg_list[-len(assert_hid_reports) :]
-        ):
-            hid_report_keys = {code for code in hid_report[2:] if code != 0}
-            assert_keys = {
-                k.code for k in assert_hid_reports[i] if not isinstance(k, ModifierKey)
-            }
+            # accumulate assertion for late evalution, -- makes for a more
+            # helpfull debug output.
+            matching = matching and report_mods == assert_mods
+            matching = matching and report_keys == assert_keys
+
             if self.debug_enabled:
+                report_keys_names = {code2name(c) for c in report_keys}
+                assert_keys_names = {code2name(c) for c in assert_keys}
                 print(
-                    'assert keys:',
-                    hid_report_keys == assert_keys,
-                    hid_report_keys,
-                    assert_keys,
+                    f'assert '
+                    f'mods: {report_mods} == {assert_mods} '
+                    f'keys: {report_keys_names} == {assert_keys_names} '
                 )
-            assert hid_report_keys == assert_keys
 
-            hid_report_modifiers = hid_report[0]
-            assert_modifiers = reduce(
-                lambda mod, all_mods: all_mods | mod,
-                {k.code for k in assert_hid_reports[i] if isinstance(k, ModifierKey)},
-                0,
-            )
-            if self.debug_enabled:
-                print(
-                    'assert mods:',
-                    hid_report_modifiers == assert_modifiers,
-                    hid_report_modifiers,
-                    assert_modifiers,
-                )
-            assert hid_report_modifiers == assert_modifiers
+        assert matching, "reports don't match up"
 
     def do_main_loop(self):
-        for i in range(random.randint(5, 50)):
-            self.keyboard._main_loop()
+        self.keyboard._main_loop()
+        time.sleep(0.002)

--- a/tests/test_hold_tap.py
+++ b/tests/test_hold_tap.py
@@ -220,6 +220,7 @@ class TestHoldTap(unittest.TestCase):
                 (3, False),
             ],
             [
+                {KC.LALT},
                 {KC.LCTL, KC.LALT},
                 {KC.LCTL, KC.LALT, KC.N0},
                 {KC.LCTL, KC.LALT},


### PR DESCRIPTION
Pretty much a complete refactor of the keyboard emulation unittest + fixes to get everything working again.
Current version was impossible to read, had terrible debug output, and most importantly didn't do bjective comparisons of generated and desired keycode reports.
KC has an `__iter__` now, so we can do reverse lookups.