### PR TITLE
fix(irisr2/nicenano): fix grossly incorrect coordinate mapping

### DIFF
--- a/boards/keebio/iris/kb.py
+++ b/boards/keebio/iris/kb.py
@@ -22,19 +22,11 @@ class KMKKeyboard(_KMKKeyboard):
     data_pin = board.P0_20
     powersave_pin = board.P0_13
 
-    # Buckle up friends, the bottom row of this keyboard is wild, and making
-    # our layouts match, visually, what the keyboard looks like, requires some
-    # surgery on the bottom two rows of coords
-
-    # Row index 3 is actually perfectly sane and we _could_ expose it
-    # just like the above three rows, however, visually speaking, the
-    # top-right thumb cluster button (when looking at the left-half PCB)
-    # is more inline with R3, so we'll jam that key (and its mirror) in here
     # flake8: noqa
     coord_mapping = [
-     0,  1,  2,  3,  4,  5,          36, 35, 34, 33, 32, 31,
-     6,  7,  8,  9, 10, 11,          42, 41, 40, 39, 38, 37,
-    12, 13, 14, 15, 16, 17,          48, 47, 46, 45, 44, 43,
-    18, 19, 20, 21, 22, 23, 26,  57, 54, 53, 52, 51, 50, 49,
-                28, 29, 30,          60, 59, 58,
+     0,  1,  2,  3,  4,  5,          35, 34, 33, 32, 31, 30,
+     6,  7,  8,  9, 10, 11,          41, 40, 39, 38, 37, 36,
+    12, 13, 14, 15, 16, 17,          47, 46, 45, 44, 43, 42,
+    18, 19, 20, 21, 22, 23, 26,  56, 53, 52, 51, 50, 49, 48,
+                27, 28, 29,          59, 58, 57,
     ]


### PR DESCRIPTION
I hit the ever-feared factory reset (internal storage wipe) bug of NiceNanos on my Keebio Iris R2 (yes, the socketed ones that went out of production years ago - I built one in 2018 and the other in 2019 some time on the old PCBs) and had to set KMK up from scratch. This PR is the first of two bits of learning from that (unpleasant) experience: that somehow the Iris kb.py (I can't type backticks, GESC must be broken... make that three things) was almost entirely off by one on coord map indicies on the right half, so I couldn't even hit enter.

This allows me to hit enter, and indeed, all other keys (including some on the left half that were wrong).