### PR TITLE
Update ble_hid.md - Fixed Bad Instruction

### DIFF
--- a/docs/ble_hid.md
+++ b/docs/ble_hid.md
@@ -2,11 +2,9 @@
 Bluetooth connections help clean up the wire mess!
 
 ## CircuitPython
-If not running KMKPython, this does require the adafruit_ble library from Adafruit.
-This can be downloaded
-[here](https://github.com/adafruit/Adafruit_CircuitPython_BLE/tree/master/adafruit_ble).
-It is part of the [Adafruit CircuitPython Bundle](https://github.com/adafruit/Adafruit_CircuitPython_Bundle).
-Simply put this in the "root" of your CircuitPython device. If unsure, it's the folder with main.py in it, and should be the first folder you see when you open the device.
+If not running KMKPython, this does require the [adafruit_ble library from Adafruit](https://github.com/adafruit/Adafruit_CircuitPython_BLE/tree/master/adafruit_ble).
+It's part of the Adafruit CircuitPython Bundle, which can be downloaded [here](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/tag/20220715).
+Get the bundle version that corresponds to the CircuitPython version installed on your device. Unzip the bundle and open the "lib" folder to locate the "adafruit_ble" library. Selectively copy that library (the entire "adafruit_ble" folder) and place it into the "lib" folder located at the root of your CIRCUITPY device. If unsure, the root is the main device storage folder where your main.py (or code.py) file is located. The "lib" folder should have been created when you installed CircuitPython. If not, just create one to place the ble library.
 
 ## Enabling BLE
 
@@ -22,12 +20,10 @@ if __name__ == '__main__':
 
 ## Changing the advertise name
 There are two ways to change the advertising name. The first would be to
-[change the name of the drive](https://learn.adafruit.com/welcome-to-circuitpython/the-circuitpy-drive).
+[change the name of the drive](https://learn.adafruit.com/welcome-to-circuitpython/renaming-circuitpy).
 The second would be to change the keyboard.go() like this.
 
 ```python
 if __name__ == '__main__':
-    keyboard.go(hid_type=HIDModes.BLE, ble_name='KMKeyboard')
+    keyboard.go(hid_type=HIDModes.BLE, ble_name='KMKKeyboard')
 ```
-
-

--- a/docs/ble_hid.md
+++ b/docs/ble_hid.md
@@ -2,7 +2,7 @@
 Bluetooth connections help clean up the wire mess!
 
 ## CircuitPython
-If not running KMKPython, this does require the [adafruit_ble library from Adafruit](https://github.com/adafruit/Adafruit_CircuitPython_BLE/tree/master/adafruit_ble).
+This does require the [adafruit_ble library from Adafruit](https://github.com/adafruit/Adafruit_CircuitPython_BLE/tree/master/adafruit_ble).
 It's part of the Adafruit CircuitPython Bundle, which can be downloaded [here](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/tag/20220715).
 Get the bundle version that corresponds to the CircuitPython version installed on your device. Unzip the bundle and open the "lib" folder to locate the "adafruit_ble" library. Selectively copy that library (the entire "adafruit_ble" folder) and place it into the "lib" folder located at the root of your CIRCUITPY device. If unsure, the root is the main device storage folder where your main.py (or code.py) file is located. The "lib" folder should have been created when you installed CircuitPython. If not, just create one to place the ble library.
 


### PR DESCRIPTION
1. Corrected and clarified bad instruction. This document tells you to place the "adafruit_ble" library at the device root. It should be placed in the "lib" directory. 
2. Provided a more direct link to get the Adafruit CircuitPython Bundle. New link provides better detail from Adafruit for how and what to download.
3. Corrected the link to instructions for renaming the CIRCUITPY drive.