### PR TITLE
Add keycode for software reload

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -186,6 +186,7 @@
 |Key                    |Description                                                          |
 |-----------------------|---------------------------------------------------------------------|
 |`KC.RESET`             |Restarts the keyboard                                                |
+|`KC.RLOAD`             |Reloads the keyboard software, preserving any serial connections     |
 |`KC.DEBUG`             |Toggle `debug_enabled`, which enables log spew to serial console     |
 |`KC.GESC`              |Escape when tapped, <code>&#96;</code> when pressed with Shift or GUI|
 |`KC.BKDL`              |Backspace when tapped, Delete when pressed with GUI                  |

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -186,7 +186,7 @@
 |Key                    |Description                                                          |
 |-----------------------|---------------------------------------------------------------------|
 |`KC.RESET`             |Restarts the keyboard                                                |
-|`KC.RLOAD`             |Reloads the keyboard software, preserving any serial connections     |
+|`KC.RELOAD`, `KC.RLD`  |Reloads the keyboard software, preserving any serial connections     |
 |`KC.DEBUG`             |Toggle `debug_enabled`, which enables log spew to serial console     |
 |`KC.GESC`              |Escape when tapped, <code>&#96;</code> when pressed with Shift or GUI|
 |`KC.BKDL`              |Backspace when tapped, Delete when pressed with GUI                  |

--- a/kmk/handlers/stock.py
+++ b/kmk/handlers/stock.py
@@ -27,6 +27,10 @@ def reset(*args, **kwargs):
 
     microcontroller.reset()
 
+def reload(*args, **kwargs):
+    import supervisor
+
+    supervisor.reload()
 
 def bootloader(*args, **kwargs):
     import microcontroller

--- a/kmk/handlers/stock.py
+++ b/kmk/handlers/stock.py
@@ -27,10 +27,12 @@ def reset(*args, **kwargs):
 
     microcontroller.reset()
 
+
 def reload(*args, **kwargs):
     import supervisor
 
     supervisor.reload()
+
 
 def bootloader(*args, **kwargs):
     import microcontroller

--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -131,7 +131,7 @@ class KeyAttrDict:
             make_key(code=30 + offset, names=names)
         elif key in ('RESET',):
             make_key(names=('RESET',), on_press=handlers.reset)
-        elif key in ('RELOAD','RLD'):
+        elif key in ('RELOAD', 'RLD'):
             make_key(names=('RELOAD', 'RLD'), on_press=handlers.reload)
         elif key in ('BOOTLOADER',):
             make_key(names=('BOOTLOADER',), on_press=handlers.bootloader)

--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -131,8 +131,8 @@ class KeyAttrDict:
             make_key(code=30 + offset, names=names)
         elif key in ('RESET',):
             make_key(names=('RESET',), on_press=handlers.reset)
-        elif key in ('RELOAD',):
-            make_key(names=('RELOAD',), on_press=handlers.reload)
+        elif key in ('RELOAD','RLD'):
+            make_key(names=('RELOAD', 'RLD'), on_press=handlers.reload)
         elif key in ('BOOTLOADER',):
             make_key(names=('BOOTLOADER',), on_press=handlers.bootloader)
         elif key in ('DEBUG', 'DBG'):

--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -131,6 +131,8 @@ class KeyAttrDict:
             make_key(code=30 + offset, names=names)
         elif key in ('RESET',):
             make_key(names=('RESET',), on_press=handlers.reset)
+        elif key in ('RELOAD',):
+            make_key(names=('RELOAD',), on_press=handlers.reload)
         elif key in ('BOOTLOADER',):
             make_key(names=('BOOTLOADER',), on_press=handlers.bootloader)
         elif key in ('DEBUG', 'DBG'):


### PR DESCRIPTION
Adds `KC.RELOAD` for software reload which makes use of [`supervisor.reload()`](https://docs.circuitpython.org/en/latest/shared-bindings/supervisor/index.html#supervisor.reload). This differs from the current `KC.RESET` because it only reloads the software, preserving any active serial connections and doesn't clear things like tracebacks. Useful for anyone that [turns off auto-reloading](https://docs.circuitpython.org/en/latest/shared-bindings/supervisor/index.html#supervisor.disable_autoreload).