### PR TITLE
Add 'BSPACE' keycode for backspace

### DIFF
--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -220,7 +220,7 @@ class KeyAttrDict:
                     # More ASCII standard keys
                     (40, ('ENTER', 'ENT', '\n')),
                     (41, ('ESCAPE', 'ESC')),
-                    (42, ('BACKSPACE', 'BSPC', 'BKSP')),
+                    (42, ('BACKSPACE', 'BSPACE', 'BSPC', 'BKSP')),
                     (43, ('TAB', '\t')),
                     (44, ('SPACE', 'SPC', ' ')),
                     (45, ('MINUS', 'MINS', '-')),


### PR DESCRIPTION
The KMK documentation lists keycode name `BSPACE` as a valid name for the backspace key: http://kmkfw.io/docs/keycodes#basic-keys

However, using `KC.BSPACE` in one's keymap throws the following error:

```
ValueError: Invalid key: BSPACE
```

To resolve this issue, this PR simply adds `BSPACE` as a valid alias for the backspace key.
