### PR TITLE
implement global debug interface.

### DIFF
--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -4,8 +4,7 @@ import kmk.handlers.stock as handlers
 from kmk.consts import UnicodeMode
 from kmk.key_validators import key_seq_sleep_validator, unicode_mode_key_validator
 from kmk.types import UnicodeModeKeyMeta
-
-DEBUG_OUTPUT = False
+from kmk.utils import Debug
 
 FIRST_KMK_INTERNAL_KEY = const(1000)
 NEXT_AVAILABLE_KEY = 1000
@@ -18,6 +17,8 @@ ALL_ALPHAS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 ALL_NUMBERS = '1234567890'
 # since KC.1 isn't valid Python, alias to KC.N1
 ALL_NUMBER_ALIASES = tuple(f'N{x}' for x in ALL_NUMBERS)
+
+debug = Debug(__name__)
 
 
 def maybe_make_key(code, names, *args, **kwargs):
@@ -412,12 +413,11 @@ class KeyAttrDict:
             maybe_key = func(key)
             if maybe_key:
                 break
-
         else:
             raise ValueError(f'Invalid key: {key}')
 
-        if DEBUG_OUTPUT:
-            print(f'{key}: {maybe_key}')
+        if debug.enabled:
+            debug(f'{key}: {maybe_key}')
 
         return self.__cache[key]
 

--- a/kmk/modules/layers.py
+++ b/kmk/modules/layers.py
@@ -3,6 +3,9 @@ from kmk.key_validators import layer_key_validator
 from kmk.keys import KC, make_argumented_key
 from kmk.modules.holdtap import ActivationType, HoldTap
 from kmk.types import HoldTapKeyMeta
+from kmk.utils import Debug
+
+debug = Debug(__name__)
 
 
 def layer_key_validator_lt(layer, kc, prefer_hold=False, **kwargs):
@@ -88,12 +91,14 @@ class Layers(HoldTap):
         Switches the default layer
         '''
         keyboard.active_layers[-1] = key.meta.layer
+        self._print_debug(keyboard)
 
     def _mo_pressed(self, key, keyboard, *args, **kwargs):
         '''
         Momentarily activates layer, switches off when you let go
         '''
         keyboard.active_layers.insert(0, key.meta.layer)
+        self._print_debug(keyboard)
 
     @staticmethod
     def _mo_released(key, keyboard, *args, **kwargs):
@@ -110,6 +115,7 @@ class Layers(HoldTap):
             del keyboard.active_layers[del_idx]
         except ValueError:
             pass
+        __class__._print_debug(__class__, keyboard)
 
     def _lm_pressed(self, key, keyboard, *args, **kwargs):
         '''
@@ -145,3 +151,8 @@ class Layers(HoldTap):
         '''
         keyboard.active_layers.clear()
         keyboard.active_layers.insert(0, key.meta.layer)
+
+    def _print_debug(self, keyboard):
+        # debug(f'__getitem__ {key}')
+        if debug.enabled:
+            debug(f'active_layers={keyboard.active_layers}')

--- a/kmk/utils.py
+++ b/kmk/utils.py
@@ -1,2 +1,30 @@
+from supervisor import ticks_ms
+
+
 def clamp(x, bottom=0, top=100):
     return min(max(bottom, x), top)
+
+
+_debug_enabled = False
+
+
+class Debug:
+    '''default usage:
+    debug = Debug(__name__)
+    '''
+
+    def __init__(self, name=__name__):
+        self.name = name
+
+    def __call__(self, message):
+        print(f'{ticks_ms()} {self.name}: {message}')
+
+    @property
+    def enabled(self):
+        global _debug_enabled
+        return _debug_enabled
+
+    @enabled.setter
+    def enabled(self, enabled):
+        global _debug_enabled
+        _debug_enabled = enabled


### PR DESCRIPTION
A "universal" debug interface that:
- can be used from anywhere in the code base (no access to `KMKKeyboard.debug_enabled` required)
- shows where the message is coming from (named debug instances)
- has timestamps... I'm amazed we had to go without one for so long
- could easily be extended to optionally show other metrics, like stack size or differential memory at ever message

Originally I planned to have the is-debug-enabled-check also in the debug class. Then I noticed that we have f-strings everywhere now, and those would be evaluated before the check happens, wasting precious CPU cycles.
I quite like the syntax of f-strings, but is it worth keeping and carrying an `if debug.enabled:` through the code?