### PR TITLE
anavi/macro-pad-10: Add ANAVI Macro Pad 10

### DIFF
--- a/boards/anavi/macro-pad-10/README.md
+++ b/boards/anavi/macro-pad-10/README.md
@@ -1,0 +1,11 @@
+# ANAVI Macro Pad 10
+
+ANAVI Macro Pad 10 is an open source, programmable mechanical keyboard with 9 hot-swappable mechanical switches, RGB WS2812B underlighting and yellow backlit a rotary encoder and [Seeed XIAO RP2040](https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html).
+
+ANAVI Macro Pad 10 has been designed with the cross platform and open source electronics design automation suite KiCad. All KiCad [files and schematics are available at GitHub](https://github.com/anavitechnology/anavi-macro-pad-10) under [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/).
+
+Extensions enabled by default:
+- [Encoder](https://github.com/KMKfw/kmk_firmware/tree/master/docs/encoder.md) Twist control for all the things
+- [LED](https://github.com/KMKfw/kmk_firmware/tree/master/docs/led.md) Light your keys up (for backlit)
+- [RGB](https://github.com/KMKfw/kmk_firmware/tree/master/docs/rgb.md) Light it up (for underlighting)
+- [MediaKeys](https://github.com/KMKfw/kmk_firmware/tree/master/docs/media_keys.md) Control volume and other media functions

--- a/boards/anavi/macro-pad-10/code.py
+++ b/boards/anavi/macro-pad-10/code.py
@@ -1,0 +1,86 @@
+import board
+
+from kmk.extensions.LED import LED
+from kmk.extensions.media_keys import MediaKeys
+from kmk.extensions.RGB import RGB, AnimationModes
+from kmk.keys import KC
+from kmk.kmk_keyboard import KMKKeyboard
+from kmk.modules.encoder import EncoderHandler
+from kmk.scanners import DiodeOrientation
+
+print('ANAVI Macro Pad 10')
+
+keyboard = KMKKeyboard()
+led_ext = LED(
+    led_pin=[
+        board.D0,
+    ],
+    brightness=100,
+    brightness_step=5,
+    brightness_limit=100,
+    breathe_center=1.5,
+    animation_mode=AnimationModes.STATIC,
+    animation_speed=1,
+    user_animation=None,
+    val=100,
+)
+keyboard.extensions.append(led_ext)
+
+# WS2812B LED strips on the back
+underglow = RGB(
+    pixel_pin=board.D10,
+    num_pixels=4,
+    val_limit=100,
+    val_default=25,
+    animation_mode=AnimationModes.RAINBOW,
+)
+keyboard.extensions.append(underglow)
+
+# Neopixel on XIAO RP2040
+frontglow = RGB(
+    pixel_pin=board.NEOPIXEL,
+    num_pixels=1,
+    val_limit=100,
+    val_default=25,
+    animation_mode=AnimationModes.RAINBOW,
+)
+keyboard.extensions.append(frontglow)
+
+keyboard.col_pins = (
+    board.D4,
+    board.D5,
+    board.D6,
+)
+keyboard.row_pins = (
+    board.D3,
+    board.D2,
+    board.D1,
+)
+keyboard.diode_orientation = DiodeOrientation.ROW2COL
+
+media_keys = MediaKeys()
+keyboard.extensions.append(media_keys)
+
+# Matrix 3x3 keymap, 9 keys in total
+keyboard.keymap = [
+    [
+        KC.N1,
+        KC.N2,
+        KC.N3,
+        KC.N4,
+        KC.N5,
+        KC.N6,
+        KC.N7,
+        KC.N8,
+        KC.N9,
+    ]
+]
+
+# Rotary encoder that also acts as a key
+encoder_handler = EncoderHandler()
+encoder_handler.pins = ((board.D8, board.D7, board.D9),)
+encoder_handler.map = (((KC.VOLD, KC.VOLU, KC.MUTE),),)
+keyboard.modules.append(encoder_handler)
+
+if __name__ == '__main__':
+    keyboard.go()


### PR DESCRIPTION
Add support for ANAVI Macro Pad 10. This is an open source, programmable mechanical keyboard with 9 hot-swappable mechanical switches, RGB WS2812B underlighting and yellow backlit a rotary encoder and [Seeed XIAO RP2040](https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html).

ANAVI Macro Pad 10 has been designed with the cross platform and open source electronics design automation suite KiCad. All KiCad [files and schematics are available at GitHub](https://github.com/anavitechnology/anavi-macro-pad-10) under [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/).

Best regards,
Leon
