### PR TITLE
add continue-with-module-nr-idx to key processing

### DIFF
--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -191,6 +191,10 @@ class KMKKeyboard:
 
         return self
 
+    def resume_process_key(self, key, is_pressed, int_coord, module):
+        index = self.modules.index(module) + 1
+        self.pre_process_key(key, is_pressed, int_coord, index)
+
     def remove_key(self, keycode):
         self.keys_pressed.discard(keycode)
         return self.process_key(keycode, False)

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -158,8 +158,8 @@ class KMKKeyboard:
     def debug_enabled(self, enabled):
         debug.enabled = enabled
 
-    def pre_process_key(self, key, is_pressed, int_coord=None):
-        for module in self.modules:
+    def pre_process_key(self, key, is_pressed, int_coord=None, index=0):
+        for module in self.modules[index:]:
             try:
                 key = module.process_key(self, key, is_pressed, int_coord)
                 if key is None:

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -1,9 +1,15 @@
+try:
+    from typing import Optional
+except ImportError:
+    pass
+
 from supervisor import ticks_ms
 
 from kmk.consts import UnicodeMode
 from kmk.hid import BLEHID, USBHID, AbstractHID, HIDModes
-from kmk.keys import KC
+from kmk.keys import KC, Key
 from kmk.kmktime import ticks_add, ticks_diff
+from kmk.modules import Module
 from kmk.scanners.keypad import MatrixScanner
 from kmk.utils import Debug
 
@@ -191,7 +197,13 @@ class KMKKeyboard:
 
         return self
 
-    def resume_process_key(self, key, is_pressed, int_coord, module):
+    def resume_process_key(
+        self,
+        key: Key,
+        is_pressed: bool,
+        int_coord: Optional[int],
+        module: Module,
+    ) -> None:
         index = self.modules.index(module) + 1
         self.pre_process_key(key, is_pressed, int_coord, index)
 

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -199,10 +199,10 @@ class KMKKeyboard:
 
     def resume_process_key(
         self,
+        module: Module,
         key: Key,
         is_pressed: bool,
-        int_coord: Optional[int],
-        module: Module,
+        int_coord: Optional[int] = None,
     ) -> None:
         index = self.modules.index(module) + 1
         self.pre_process_key(key, is_pressed, int_coord, index)

--- a/kmk/modules/combos.py
+++ b/kmk/modules/combos.py
@@ -266,7 +266,7 @@ class Combos(Module):
             if new_key is None:
                 new_key = keyboard._find_key_in_map(int_coord)
 
-            keyboard.pre_process_key(new_key, is_pressed, int_coord, self._next_module)
+            keyboard.resume_process_key(new_key, is_pressed, int_coord, self)
             keyboard._send_hid()
 
     def activate(self, keyboard, combo):

--- a/kmk/modules/combos.py
+++ b/kmk/modules/combos.py
@@ -4,6 +4,7 @@ except ImportError:
     pass
 import kmk.handlers.stock as handlers
 from kmk.keys import Key, make_key
+from kmk.kmk_keyboard import KMKKeyboard
 from kmk.modules import Module
 
 
@@ -108,7 +109,7 @@ class Combos(Module):
         else:
             return self.on_release(keyboard, key, int_coord)
 
-    def on_press(self, keyboard, key: Optional[Key], int_coord):
+    def on_press(self, keyboard: KMKKeyboard, key: Key, int_coord: Optional[int]):
         # refill potential matches from timed-out matches
         if not self._matching:
             self._matching = list(self._reset)
@@ -157,11 +158,12 @@ class Combos(Module):
             # There's no matching combo: send and reset key buffer
             self.send_key_buffer(keyboard)
             self._key_buffer = []
-            key = keyboard._find_key_in_map(int_coord)
+            if int_coord is not None:
+                key = keyboard._find_key_in_map(int_coord)
 
         return key
 
-    def on_release(self, keyboard, key: Optional[Key], int_coord):
+    def on_release(self, keyboard: KMKKeyboard, key: Key, int_coord: Optional[int]):
         for combo in self._active:
             if key in combo.match:
                 # Deactivate combo if it matches current key.

--- a/kmk/modules/combos.py
+++ b/kmk/modules/combos.py
@@ -257,10 +257,12 @@ class Combos(Module):
 
     def send_key_buffer(self, keyboard):
         for (int_coord, key, is_pressed) in self._key_buffer:
-            try:
-                new_key = keyboard._coordkeys_pressed[int_coord]
-            except KeyError:
-                new_key = None
+            new_key = None
+            if not is_pressed:
+                try:
+                    new_key = keyboard._coordkeys_pressed[int_coord]
+                except KeyError:
+                    new_key = None
             if new_key is None:
                 new_key = keyboard._find_key_in_map(int_coord)
 

--- a/kmk/modules/combos.py
+++ b/kmk/modules/combos.py
@@ -81,6 +81,7 @@ class Combos(Module):
         )
 
     def during_bootup(self, keyboard):
+        self._next_module = keyboard.modules.index(self) + 1
         self.reset(keyboard)
 
     def before_matrix_scan(self, keyboard):
@@ -263,9 +264,7 @@ class Combos(Module):
             if new_key is None:
                 new_key = keyboard._find_key_in_map(int_coord)
 
-            keyboard._coordkeys_pressed[int_coord] = new_key
-
-            keyboard.process_key(new_key, is_pressed)
+            keyboard.pre_process_key(new_key, is_pressed, int_coord, self._next_module)
             keyboard._send_hid()
 
     def activate(self, keyboard, combo):

--- a/kmk/modules/combos.py
+++ b/kmk/modules/combos.py
@@ -82,7 +82,6 @@ class Combos(Module):
         )
 
     def during_bootup(self, keyboard):
-        self._next_module = keyboard.modules.index(self) + 1
         self.reset(keyboard)
 
     def before_matrix_scan(self, keyboard):
@@ -268,7 +267,7 @@ class Combos(Module):
             if new_key is None:
                 new_key = keyboard._find_key_in_map(int_coord)
 
-            keyboard.resume_process_key(new_key, is_pressed, int_coord, self)
+            keyboard.resume_process_key(self, new_key, is_pressed, int_coord)
             keyboard._send_hid()
 
     def activate(self, keyboard, combo):

--- a/kmk/modules/holdtap.py
+++ b/kmk/modules/holdtap.py
@@ -49,7 +49,7 @@ class HoldTap(Module):
         )
 
     def during_bootup(self, keyboard):
-        self._next_module = keyboard.modules.index(self) + 1
+        return
 
     def before_matrix_scan(self, keyboard):
         return
@@ -178,22 +178,22 @@ class HoldTap(Module):
     def send_key_buffer(self, keyboard):
         for (int_coord, key) in self.key_buffer:
             new_key = keyboard._find_key_in_map(int_coord)
-            keyboard.resume_process_key(new_key, True, int_coord, self)
+            keyboard.resume_process_key(self, new_key, True, int_coord)
 
         keyboard._send_hid()
         self.key_buffer.clear()
 
     def ht_activate_hold(self, key, keyboard, *args, **kwargs):
-        keyboard.pre_process_key(key.meta.hold, True, index=self._next_module)
+        keyboard.resume_process_key(self, key.meta.hold, True)
 
     def ht_deactivate_hold(self, key, keyboard, *args, **kwargs):
-        keyboard.pre_process_key(key.meta.hold, False, index=self._next_module)
+        keyboard.resume_process_key(self, key.meta.hold, False)
 
     def ht_activate_tap(self, key, keyboard, *args, **kwargs):
-        keyboard.pre_process_key(key.meta.tap, True, index=self._next_module)
+        keyboard.resume_process_key(self, key.meta.tap, True)
 
     def ht_deactivate_tap(self, key, keyboard, *args, **kwargs):
-        keyboard.pre_process_key(key.meta.tap, False, index=self._next_module)
+        keyboard.resume_process_key(self, key.meta.tap, False)
 
     def ht_activate_on_interrupt(self, key, keyboard, *args, **kwargs):
         if key.meta.prefer_hold:

--- a/kmk/modules/holdtap.py
+++ b/kmk/modules/holdtap.py
@@ -49,7 +49,7 @@ class HoldTap(Module):
         )
 
     def during_bootup(self, keyboard):
-        return
+        self._next_module = keyboard.modules.index(self) + 1
 
     def before_matrix_scan(self, keyboard):
         return
@@ -176,25 +176,24 @@ class HoldTap(Module):
             del self.key_states[key]
 
     def send_key_buffer(self, keyboard):
-        key_buffer = self.key_buffer
-        self.key_buffer = []
-        for (int_coord, key) in key_buffer:
+        for (int_coord, key) in self.key_buffer:
             new_key = keyboard._find_key_in_map(int_coord)
-            keyboard.pre_process_key(new_key, True, int_coord)
+            keyboard.pre_process_key(new_key, True, int_coord, self._next_module)
+
         keyboard._send_hid()
         self.key_buffer.clear()
 
     def ht_activate_hold(self, key, keyboard, *args, **kwargs):
-        keyboard.process_key(key.meta.hold, True)
+        keyboard.pre_process_key(key.meta.hold, True, index=self._next_module)
 
     def ht_deactivate_hold(self, key, keyboard, *args, **kwargs):
-        keyboard.process_key(key.meta.hold, False)
+        keyboard.pre_process_key(key.meta.hold, False, index=self._next_module)
 
     def ht_activate_tap(self, key, keyboard, *args, **kwargs):
-        keyboard.process_key(key.meta.tap, True)
+        keyboard.pre_process_key(key.meta.tap, True, index=self._next_module)
 
     def ht_deactivate_tap(self, key, keyboard, *args, **kwargs):
-        keyboard.process_key(key.meta.tap, False)
+        keyboard.pre_process_key(key.meta.tap, False, index=self._next_module)
 
     def ht_activate_on_interrupt(self, key, keyboard, *args, **kwargs):
         if key.meta.prefer_hold:

--- a/kmk/modules/holdtap.py
+++ b/kmk/modules/holdtap.py
@@ -178,7 +178,7 @@ class HoldTap(Module):
     def send_key_buffer(self, keyboard):
         for (int_coord, key) in self.key_buffer:
             new_key = keyboard._find_key_in_map(int_coord)
-            keyboard.pre_process_key(new_key, True, int_coord, self._next_module)
+            keyboard.resume_process_key(new_key, True, int_coord, self)
 
         keyboard._send_hid()
         self.key_buffer.clear()

--- a/kmk/modules/layers.py
+++ b/kmk/modules/layers.py
@@ -87,20 +87,6 @@ class Layers(HoldTap):
 
         return current_key
 
-    def send_key_buffer(self, keyboard):
-        for (int_coord, old_key) in self.key_buffer:
-            new_key = keyboard._find_key_in_map(int_coord)
-
-            # adding keys late to _coordkeys_pressed isn't pretty,
-            # but necessary to mitigate race conditions when multiple
-            # keys are pressed during a tap-interrupted hold-tap.
-            keyboard._coordkeys_pressed[int_coord] = new_key
-            new_key.on_press(keyboard)
-
-            keyboard._send_hid()
-
-        self.key_buffer.clear()
-
     def _df_pressed(self, key, keyboard, *args, **kwargs):
         '''
         Switches the default layer


### PR DESCRIPTION
This is an approach to make modules with side effects more consistent (related to #495).
At the moment, I think only hold-tap (and it's decendents) and combos profit. Modified keys can be re-inserted into the `process_key` pipeline after the module that modified them, basically "picking up where they left of". It's not a super clean, automatic thing for all modules (yet), I acknowledge that; but it's a simple enough solution, doesn't break unit-tests or changes too much of the core firmware.
Input from contributors of #495 is of course welcome, especially towards perceived effectivenes.