### PR TITLE
fix trackball module forcing reports to zero

### DIFF
--- a/kmk/modules/pimoroni_trackball.py
+++ b/kmk/modules/pimoroni_trackball.py
@@ -78,15 +78,18 @@ class TrackballHandler:
 
 class PointingHandler(TrackballHandler):
     def handle(self, keyboard, trackball, x, y, switch, state):
-        if x >= 0:
+        if x > 0:
             trackball.pointing_device.report_x[0] = x
-        else:
+        elif x < 0:
             trackball.pointing_device.report_x[0] = 0xFF & x
-        if y >= 0:
+        if y > 0:
             trackball.pointing_device.report_y[0] = y
-        else:
+        elif y < 0:
             trackball.pointing_device.report_y[0] = 0xFF & y
-        trackball.pointing_device.hid_pending = x != 0 or y != 0
+
+        if x != 0 or y != 0:
+            trackball.pointing_device.hid_pending = True
+
         if switch == 1:  # Button pressed
             trackball.pointing_device.button_status[
                 0
@@ -110,9 +113,10 @@ class ScrollHandler(TrackballHandler):
         if self.scroll_direction == ScrollDirection.REVERSE:
             y = -y
 
-        pointing_device = trackball.pointing_device
-        pointing_device.report_w[0] = 0xFF & y
-        pointing_device.hid_pending = y != 0
+        if y != 0:
+            pointing_device = trackball.pointing_device
+            pointing_device.report_w[0] = 0xFF & y
+            pointing_device.hid_pending = True
 
         if switch == 1:  # Button pressed
             pointing_device.button_status[0] |= pointing_device.MB_LMB


### PR DESCRIPTION
The pimoroni trackball module "force reset" pointing HID reports to zero if nothing was happening.
That interferes with other modules interfacing with the pointing HID.