### PR TITLE
[usb] Allow kb to lost usb connection without getting lost

### DIFF
--- a/kmk/hid.py
+++ b/kmk/hid.py
@@ -1,3 +1,4 @@
+import supervisor
 import usb_hid
 from micropython import const
 
@@ -229,6 +230,9 @@ class USBHID(AbstractHID):
                 continue
 
     def hid_send(self, evt):
+        if not supervisor.runtime.usb_connected:
+            return
+
         # int, can be looked up in HIDReportTypes
         reporting_device_const = evt[0]
 


### PR DESCRIPTION
When the usb connection is lost (for example when plugged into a pc that
keep the usb powered when shut down) the kb is lost and need to be
unpluged to be rebooted.

My guess is that the failling `hid_report.send()` change some internal
state that could not recover by itself.

This prevent even trying to send the report when the usb is not
connected. This fix has been tested working on me and another discord
user so far. The result seems consistent even if the test period has not
been very long yet.