### PR TITLE
remove reference to disfunct KMK_RELEASE.

### DIFF
--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -79,13 +79,5 @@ In case you need it, debugging help can be found [here](debugging.md)
 If you need support with KMK or just want to say hi, find us in 
 [#kmkfw:klar.sh on Matrix](https://matrix.to/#/#kmkfw:klar.sh).  This channel is 
 bridged to Discord [here](https://discordapp.com/widget?id=493256121075761173&theme=dark) 
-for convenience. If you ask for help on chat or open a bug report, if possible 
-please give us your commit SHA, found by running 
-`from kmk.consts import KMK_RELEASE;  print(KMK_RELEASE)` in the REPL on your 
-controller.
- 
-
-
-
-
-
+for convenience. If you ask for help in chat or open a bug report, if possible 
+make sure your copy of KMK is up-to-date.

--- a/docs/ja/Getting_Started.md
+++ b/docs/ja/Getting_Started.md
@@ -99,8 +99,5 @@ RGB や分裂型などの機能を楽しめたい場合は、ビルトイン[モ
 KMK についてサポートが必要な場合や、コミュニケーションをとりたい場合は[こちら](https://matrix.to/#/#kmkfw:klar.sh)。
 このチャネルは[Discord](https://discordapp.com/widget?id=493256121075761173&theme=dark) からも見ることができます。
 
- チャットやバグ報告などでヘルプを求める場合、可能な限り、コントローラーの REPL に`from kmk.consts import KMK_RELEASE;  print(KMK_RELEASE)`を実行することによって表示されるコミットSHAを記載してください。
-
-
-
-
+チャットで助けを求める場合やバグ レポートを開く場合は、可能であれば KMK
+のコピーが最新であることを確認してください。

--- a/docs/ptBR/Getting_Started.md
+++ b/docs/ptBR/Getting_Started.md
@@ -127,7 +127,4 @@ canal [#kmkfw:klar.sh no Matrix](https://matrix.to/#/#kmkfw:klar.sh). Este canal
 tem uma ponte no Discord
 [aqui](https://discordapp.com/widget?id=493256121075761173&theme=dark) por
 conveniência. Se você precisa de ajuda ou pretende abrir um bug report, se
-possível forneça o hash SHA do *commit* utilizado, o qual pode ser obtido
-executando este comando no REPL de seu controlador:
-
-`from kmk.consts import KMK_RELEASE;  print(KMK_RELEASE)`
+possível se possível, verifique se sua cópia do KMK está atualizada.

--- a/docs/ptBR/support.md
+++ b/docs/ptBR/support.md
@@ -6,8 +6,5 @@ tem uma ponte no Discord
 [aqui](https://discordapp.com/widget?id=493256121075761173&theme=dark) por
 conveniência.
 
-Se você precisa de ajuda ou pretende abrir um bug report, se possível forneça o
-hash SHA do *commit* utilizado, o qual pode ser obtido executando este comando
-no REPL de seu controlador:
-
-`from kmk.consts import KMK_RELEASE;  print(KMK_RELEASE)`
+Se você precisa de ajuda ou pretende abrir um bug report, se
+possível se possível, verifique se sua cópia do KMK está atualizada.

--- a/docs/support.md
+++ b/docs/support.md
@@ -5,11 +5,5 @@ on Matrix](https://matrix.to/#/#kmkfw:klar.sh). This channel is bridged to
 Discord [here](https://discordapp.com/widget?id=493256121075761173&theme=dark)
 for convenience.
 
-If you ask for help on chat or open a bug report, if possible please give us
-your commit SHA, found by running
-
-```python
-from kmk.consts import KMK_RELEASE; print(KMK_RELEASE)
-```
-
-in the REPL on your controller.
+If you ask for help in chat or open a bug report, if possible
+make sure your copy of KMK is up-to-date.

--- a/kmk/consts.py
+++ b/kmk/consts.py
@@ -1,10 +1,5 @@
 from micropython import const
 
-try:
-    from kmk.release_info import KMK_RELEASE
-except Exception:
-    KMK_RELEASE = 'copied-from-git'
-
 
 class UnicodeMode:
     NOOP = const(0)

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -1,6 +1,6 @@
 from supervisor import ticks_ms
 
-from kmk.consts import KMK_RELEASE, UnicodeMode
+from kmk.consts import UnicodeMode
 from kmk.hid import BLEHID, USBHID, AbstractHID, HIDModes
 from kmk.keys import KC
 from kmk.kmktime import ticks_add, ticks_diff
@@ -447,8 +447,7 @@ class KMKKeyboard:
                     debug(f'Failed to load extensions {module}: {err}')
 
         if debug.enabled:
-            debug(f'KMKInit(release={KMK_RELEASE})')
-            debug(self)
+            debug(f'init: {self}')
 
     def _main_loop(self):
         self.state_changed = False


### PR DESCRIPTION
resolves #544, reclaiming invaluable low-double-digits of bytes.

I didn't purge the fingerprint generation for mpy-cross builds from the Makefile, because that could actually be usefull.
Translations are courtesy of google translate.