### PR TITLE
Improvements to OLED and RGB support

### DIFF
--- a/boards/kyria/kyria_v1_kb2040.py
+++ b/boards/kyria/kyria_v1_kb2040.py
@@ -20,6 +20,8 @@ class KMKKeyboard(_KMKKeyboard):
     diode_orientation = DiodeOrientation.COL2ROW
     data_pin = board.D1
     rgb_pixel_pin = board.D0
+    SCL = board.D3
+    SDA = board.D2
     encoder_pin_0 = board.D9
     encoder_pin_1 = board.D5
 

--- a/boards/kyria/main.py
+++ b/boards/kyria/main.py
@@ -38,14 +38,14 @@ keyboard.extensions.append(rgb_ext)
 
 oled_ext = Oled(
     OledData(
-        labels=[
+        entries=[
             OledData.oled_text_entry(text="Kyria v1.4", x=0, y=0),
             OledData.oled_text_entry(text="KB2040", x=0, y=10),
             OledData.oled_text_entry(text="Layer: ", x=0, y=20),
-            OledData.oled_text_entry(text="BASE", x=42, y=20, layer=0),
-            OledData.oled_text_entry(text="LOWER", x=0, y=30, layer=3),
-            OledData.oled_text_entry(text="RAISE", x=42, y=20, layer=4),
-            OledData.oled_text_entry(text="ADJUST", x=42, y=20, layer=6),
+            OledData.oled_text_entry(text="BASE", x=40, y=20, layer=0),
+            OledData.oled_text_entry(text="LOWER", x=40, y=20, layer=3),
+            OledData.oled_text_entry(text="RAISE", x=40, y=20, layer=4),
+            OledData.oled_text_entry(text="ADJUST", x=40, y=20, layer=6),
         ]
     ),
     oHeight=64,

--- a/boards/kyria/main.py
+++ b/boards/kyria/main.py
@@ -1,35 +1,58 @@
 from kyria_v1_rp2040 import KMKKeyboard
 
-from kmk.extensions.media_keys import MediaKeys
-from kmk.extensions.rgb import RGB, AnimationModes
+from kmk.hid import HIDModes
 from kmk.keys import KC
-from kmk.modules.encoder import EncoderHandler
 from kmk.modules.layers import Layers
 from kmk.modules.modtap import ModTap
 from kmk.modules.split import Split, SplitType
+from kmk.modules.tapdance import TapDance
+from kmk.modules.encoder import EncoderHandler
+from kmk.extensions.rgb import RGB, AnimationModes
+from kmk.extensions.media_keys import MediaKeys
+from kmk.extensions.oled import (
+    Oled,
+    OledData,
+)
+from kmk.extensions.international import International
 
 keyboard = KMKKeyboard()
 keyboard.debug_enabled = True
 
-keyboard.modules.append(Layers())
-keyboard.modules.append(ModTap())
-keyboard.extensions.append(MediaKeys())
-
-# Using drive names (KYRIAL, KYRIAR) to recognize sides; use split_side arg if you're not doing it
-split = Split(split_type=SplitType.UART, use_pio=True)
-keyboard.modules.append(split)
-
-# Uncomment below if you're using encoder
 encoder_handler = EncoderHandler()
 encoder_handler.pins = ((keyboard.encoder_pin_0, keyboard.encoder_pin_1, None, False),)
 
-# Uncomment below if you're having RGB
+keyboard.modules = [Layers(), ModTap(), TapDance()]
+keyboard.extensions = [MediaKeys(), International()]
+
+split = Split(split_type=SplitType.UART, use_pio=True)
+keyboard.modules.append(split)
+
 rgb_ext = RGB(
     pixel_pin=keyboard.rgb_pixel_pin,
     num_pixels=10,
+    val_limit=200,
+    val_default=20,
     animation_mode=AnimationModes.BREATHING_RAINBOW,
 )
 keyboard.extensions.append(rgb_ext)
+
+oled_ext = Oled(
+    OledData(
+        labels=[
+            OledData.oled_text_entry(text="Kyria v1.4", x=0, y=0),
+            OledData.oled_text_entry(text="KB2040", x=0, y=10),
+            OledData.oled_text_entry(text="Layer: ", x=0, y=20),
+            OledData.oled_text_entry(text="BASE", x=42, y=20, layer=0),
+            OledData.oled_text_entry(text="LOWER", x=0, y=30, layer=3),
+            OledData.oled_text_entry(text="RAISE", x=42, y=20, layer=4),
+            OledData.oled_text_entry(text="ADJUST", x=42, y=20, layer=6),
+        ]
+    ),
+    oHeight=64,
+    flip=True,
+)
+
+keyboard.extensions.append(oled_ext)
 
 # Edit your layout below
 # Currently, that's a default QMK Kyria Layout - https://config.qmk.fm/#/splitkb/kyria/rev1/LAYOUT
@@ -37,6 +60,8 @@ ESC_LCTL = KC.MT(KC.ESC, KC.LCTL)
 QUOTE_RCTL = KC.MT(KC.QUOTE, KC.RCTL)
 ENT_LALT = KC.MT(KC.ENT, KC.LALT)
 MINUS_RCTL = KC.MT(KC.MINUS, KC.RCTL)
+
+# fmt: off
 keyboard.keymap = [
     [
         KC.TAB,        KC.Q,          KC.W,          KC.E,          KC.R,          KC.T,                                                                      KC.Y,          KC.U,          KC.I,          KC.O,          KC.P,          KC.BSPC,
@@ -81,8 +106,8 @@ keyboard.keymap = [
                                                      KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,
     ],
 ]
+# fmt: on
 
-# Uncomment below if using an encoder
 # Edit your encoder layout below
 encoder_handler.map = (
     ((KC.VOLD, KC.VOLU),),
@@ -93,7 +118,8 @@ encoder_handler.map = (
     ((KC.MPRV, KC.MNXT),),
     ((KC.MPRV, KC.MNXT),),
 )
-keyboard.modules.append(encoder_handler)
 
-if __name__ == '__main__':
-    keyboard.go()
+keyboard.extensions.append(encoder_handler)
+
+if __name__ == "__main__":
+    keyboard.go(hid_type=HIDModes.USB)

--- a/boards/kyria/main.py
+++ b/boards/kyria/main.py
@@ -101,8 +101,8 @@ keyboard.keymap = [
     ],
     [
         KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.DF(0),      KC.TRNS,       KC.TRNS,                                                                   KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,
-        KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.DF(1),      KC.TRNS,       KC.TRNS,                                                                   KC.RGB_TOG,    KC.RGB_SAI,    KC.RGB_HUI,    KC.RGB_VAI,    KC.RGB_M_P,    KC.TRNS,
-        KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.DF(2),      KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.RGB_SAD,    KC.RGB_HUD,    KC.RGB_VAD,    KC.RGB_M_P,    KC.TRNS,
+        KC.TRNS,       KC.OLED_BRI,   KC.TRNS,       KC.DF(1),      KC.TRNS,       KC.TRNS,                                                                   KC.RGB_TOG,    KC.RGB_SAI,    KC.RGB_HUI,    KC.RGB_VAI,    KC.RGB_M_P,    KC.TRNS,
+        KC.TRNS,       KC.OLED_BRD,   KC.TRNS,       KC.DF(2),      KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.RGB_SAD,    KC.RGB_HUD,    KC.RGB_VAD,    KC.RGB_M_P,    KC.TRNS,
                                                      KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,       KC.TRNS,
     ],
 ]

--- a/kmk/extensions/oled.py
+++ b/kmk/extensions/oled.py
@@ -1,0 +1,136 @@
+import busio
+import gc
+
+from kmk.handlers.stock import passthrough as handler_passthrough
+from kmk.keys import make_key
+import adafruit_displayio_ssd1306
+import displayio
+import terminalio
+from adafruit_display_text import label
+
+from kmk.extensions import Extension
+
+DISPLAY_OFFSET = 10
+
+
+class OledData:
+    def __init__(
+        self,
+        labels=None,
+    ):
+        if labels != None:
+            self.data = labels
+
+
+class Oled(Extension):
+    def __init__(
+        self,
+        views,
+        oWidth=128,
+        oHeight=32,
+        flip: bool = False,
+        device_address=0x3C,
+        brightness=0.8,
+    ):
+        displayio.release_displays()
+        self.rotation = 180 if flip else 0
+        self._views = views.data
+        self._width = oWidth
+        self._height = oHeight
+        self._prevLayers = 0
+        self._device_address = device_address
+        self._brightness = brightness
+        gc.collect()
+
+        make_key(
+            names=('OLED_BRI',), on_press=self._oled_bri, on_release=handler_passthrough
+        )
+        make_key(
+            names=('OLED_BRD',), on_press=self._oled_brd, on_release=handler_passthrough
+        )
+
+    @staticmethod
+    def oled_text_entry(x=0, y=0, text="", layer=None):
+        return {
+            0: label.Label(
+                terminalio.FONT,
+                text=text,
+                color=0xFFFFFF,
+                x=x,
+                y=y + DISPLAY_OFFSET,
+            ),
+            1: layer,
+        }
+
+    @staticmethod
+    def oled_image_entry(x=0, y=0, image="", layer=None):
+        odb = displayio.OnDiskBitmap(image)
+        return {
+            0: displayio.TileGrid(
+                odb, pixel_shader=odb.pixel_shader, x=x, y=y + DISPLAY_OFFSET
+            ),
+            1: layer,
+        }
+
+    def render_oled(self, layer):
+        splash = displayio.Group()
+        self._display.show(splash)
+        print(f"views={self._views}, layer={layer}")
+        for view in self._views:
+            if view[1] == layer or view[1] == None:
+                splash.append(view[0])
+        gc.collect()
+
+    def updateOLED(self, sandbox):
+        self.render_oled(sandbox.active_layers[0])
+        gc.collect()
+
+    def on_runtime_enable(self, sandbox):
+        return
+
+    def on_runtime_disable(self, sandbox):
+        return
+
+    def during_bootup(self, board):
+        displayio.release_displays()
+        i2c = busio.I2C(board.SCL, board.SDA)
+        self._display = adafruit_displayio_ssd1306.SSD1306(
+            displayio.I2CDisplay(i2c, device_address=self._device_address),
+            width=self._width,
+            height=self._height,
+            rotation=self.rotation,
+            brightness=self._brightness,
+        )
+        self.render_oled(0)
+        return
+
+    def before_matrix_scan(self, sandbox):
+        if sandbox.active_layers[0] != self._prevLayers:
+            self._prevLayers = sandbox.active_layers[0]
+            self.updateOLED(sandbox)
+        return
+
+    def after_matrix_scan(self, sandbox):
+        return
+
+    def before_hid_send(self, sandbox):
+        return
+
+    def after_hid_send(self, sandbox):
+        return
+
+    def on_powersave_enable(self, sandbox):
+        return
+
+    def on_powersave_disable(self, sandbox):
+        return
+
+    def _oled_bri(self, *args, **kwargs):
+        self._display.brightness = (
+            self._display.brightness + 0.1 if self._display.brightness < 0.9 else 1.0
+        )
+
+    def _oled_brd(self, *args, **kwargs):
+        self._display.brightness = (
+            self._display.brightness - 0.1 if self._display.brightness > 0.1 else 0.1
+        )

--- a/kmk/extensions/peg_oled_display.py
+++ b/kmk/extensions/peg_oled_display.py
@@ -61,7 +61,6 @@ class Oled(Extension):
 
     def renderOledTextLayer(self, layer):
         splash = displayio.Group()
-        self._display.show(splash)
         splash.append(
             label.Label(
                 terminalio.FONT,
@@ -98,16 +97,17 @@ class Oled(Extension):
                 y=25,
             )
         )
+        self._display.show(splash)
         gc.collect()
 
     def renderOledImgLayer(self, layer):
         splash = displayio.Group()
-        self._display.show(splash)
         odb = displayio.OnDiskBitmap(
             '/' + self.returnCurrectRenderText(layer, self._views[0])
         )
         image = displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
         splash.append(image)
+        self._display.show(splash)
         gc.collect()
 
     def updateOLED(self, sandbox):

--- a/kmk/extensions/peg_rgb_matrix.py
+++ b/kmk/extensions/peg_rgb_matrix.py
@@ -1,11 +1,9 @@
 import neopixel
 
 from storage import getmount
-
 from kmk.extensions import Extension
 from kmk.handlers.stock import passthrough as handler_passthrough
 from kmk.keys import make_key
-from kmk.utils import clamp
 
 
 class Color:

--- a/kmk/extensions/peg_rgb_matrix.py
+++ b/kmk/extensions/peg_rgb_matrix.py
@@ -8,11 +8,15 @@ from kmk.keys import make_key
 
 class Color:
     OFF = [0, 0, 0]
+    BLACK = OFF
     WHITE = [249, 249, 249]
     RED = [255, 0, 0]
+    AZURE = [153, 245, 255]
     BLUE = [0, 0, 255]
+    CYAN = [0, 255, 255]
     GREEN = [0, 255, 0]
     YELLOW = [255, 247, 0]
+    MAGENTA = [255, 0, 255]
     ORANGE = [255, 77, 0]
     PURPLE = [255, 0, 242]
     TEAL = [0, 128, 128]
@@ -180,7 +184,13 @@ class Rgb_matrix(Extension):
         return
 
     def on_powersave_enable(self, sandbox):
-        return
+        if self.neopixel:
+            self.neopixel.brightness = self.neopixel.brightness / 2 if self.neopixel.brightness / 2 > 0 else 0.1
+            if self.disable_auto_write:
+                self.neopixel.show()
 
     def on_powersave_disable(self, sandbox):
-        return
+        if self.neopixel:
+            self.neopixel.brightness = self.brightness
+            if self.disable_auto_write:
+                self.neopixel.show()

--- a/kmk/extensions/peg_rgb_matrix.py
+++ b/kmk/extensions/peg_rgb_matrix.py
@@ -5,6 +5,7 @@ from storage import getmount
 from kmk.extensions import Extension
 from kmk.handlers.stock import passthrough as handler_passthrough
 from kmk.keys import make_key
+from kmk.utils import clamp
 
 
 class Color:
@@ -53,6 +54,9 @@ class Rgb_matrix(Extension):
         self.disable_auto_write = disable_auto_write
         self.split = split
         self.rightSide = rightSide
+        self.brightness_step = 0.1
+        self.brightness = 0
+
         if name.endswith('L'):
             self.rightSide = False
         elif name.endswith('R'):
@@ -65,6 +69,12 @@ class Rgb_matrix(Extension):
         make_key(
             names=('RGB_TOG',), on_press=self._rgb_tog, on_release=handler_passthrough
         )
+        make_key(
+            names=('RGB_BRI',), on_press=self._rgb_bri, on_release=handler_passthrough
+        )
+        make_key(
+            names=('RGB_BRD',), on_press=self._rgb_brd, on_release=handler_passthrough
+        )
 
     def _rgb_tog(self, *args, **kwargs):
         if self.enable:
@@ -72,6 +82,12 @@ class Rgb_matrix(Extension):
         else:
             self.on()
         self.enable = not self.enable
+
+    def _rgb_bri(self, *args, **kwargs):
+        self.increase_brightness()
+
+    def _rgb_brd(self, *args, **kwargs):
+        self.decrease_brightness()
 
     def on(self):
         if self.neopixel:
@@ -87,6 +103,34 @@ class Rgb_matrix(Extension):
             self.neopixel.fill(rgb)
             if self.disable_auto_write:
                 self.neopixel.show()
+
+    def set_brightness(self, brightness=None):
+        if brightness is None:
+            brightness = self.brightness
+
+        if self.neopixel:
+            self.neopixel.brightness = brightness
+            if self.disable_auto_write:
+                self.neopixel.show()
+
+    def increase_brightness(self, step=None):
+        if step is None:
+            step = self.brightness_step
+
+        self.brightness = (
+            self.brightness + step if self.brightness + step <= 1.0 else 1.0
+        )
+
+        self.set_brightness(self.brightness)
+
+    def decrease_brightness(self, step=None):
+        if step is None:
+            step = self.brightness_step
+
+        self.brightness = (
+            self.brightness - step if self.brightness - step >= 0.0 else 0.0
+        )
+        self.set_brightness(self.brightness)
 
     def setBasedOffDisplay(self):
         if self.split:
@@ -121,6 +165,7 @@ class Rgb_matrix(Extension):
         )
         self.num_pixels = board.num_pixels
         self.keyPos = board.led_key_pos
+        self.brightness = board.brightness_limit
         self.on()
         return
 


### PR DESCRIPTION
This pull requests adds a new OLED module that is not constrained by the Peg client which only supports four corners and does not play well with displays any other size than 128x32 at the moment.
The PR also contains some performance improvements to the peg_oled_display and peg_rgb_matrix extensions, primarily by supporting variable brightness for RGB LEDs and for the OLED screens.
This code has been tested on a Kyria v1.4 running Adafruit KB2040 controllers and "standard Kyria" 128x64 OLEDs.