### PR TITLE
Fix the issue of Lunakey Pico regarding the media keys extension loading

### DIFF
--- a/boards/lunakey_pico/main.py
+++ b/boards/lunakey_pico/main.py
@@ -6,6 +6,7 @@ import time
 from kb import KMKKeyboard
 
 from kmk.extensions.RGB import RGB, AnimationModes
+from kmk.extensions.media_keys import MediaKeys
 from kmk.keys import KC
 from kmk.modules.layers import Layers
 from kmk.modules.modtap import ModTap
@@ -43,6 +44,7 @@ rgb_ext = RGB(
 )
 
 keyboard.modules = [layers_ext, modtap_ext, split]
+keyboard.extensions.append(MediaKeys())
 keyboard.extensions.append(rgb_ext)
 
 if split_side == SplitSide.LEFT:

--- a/boards/lunakey_pico/main.py
+++ b/boards/lunakey_pico/main.py
@@ -5,8 +5,8 @@ import pwmio
 import time
 from kb import KMKKeyboard
 
-from kmk.extensions.RGB import RGB, AnimationModes
 from kmk.extensions.media_keys import MediaKeys
+from kmk.extensions.RGB import RGB, AnimationModes
 from kmk.keys import KC
 from kmk.modules.layers import Layers
 from kmk.modules.modtap import ModTap


### PR DESCRIPTION
It is necessary to load the media keys extension to use the media keys (KC.VOLD, KC.VOLU and so on). However, the current file for Lunakey Pico does not do that. This pull request adds the logic to register the extension for the Lunakey Pico keyboard.