### PR TITLE
boards/anavi/macro-pad-10: Set to COL2ROW

### DIFF
--- a/boards/anavi/macro-pad-10/code.py
+++ b/boards/anavi/macro-pad-10/code.py
@@ -56,7 +56,7 @@ keyboard.row_pins = (
     board.D2,
     board.D1,
 )
-keyboard.diode_orientation = DiodeOrientation.ROW2COL
+keyboard.diode_orientation = DiodeOrientation.COL2ROW
 
 media_keys = MediaKeys()
 keyboard.extensions.append(media_keys)


### PR DESCRIPTION
Set diode orientation to COL2ROW as per the latest hardware
revision of ANAVI Macro Pad 10.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>