### PR TITLE
fix stack exhaustion for certain hold-tap actions

### DIFF
--- a/kmk/modules/modtap.py
+++ b/kmk/modules/modtap.py
@@ -1,4 +1,3 @@
-import kmk.handlers.stock as handlers
 from kmk.keys import make_argumented_key
 from kmk.modules.holdtap import HoldTap, HoldTapKeyMeta
 
@@ -32,15 +31,3 @@ class ModTap(HoldTap):
             on_press=self.ht_pressed,
             on_release=self.ht_released,
         )
-
-    def ht_activate_hold(self, key, keyboard, *args, **kwargs):
-        handlers.default_pressed(key.meta.hold, keyboard, None)
-
-    def ht_deactivate_hold(self, key, keyboard, *args, **kwargs):
-        handlers.default_released(key.meta.hold, keyboard, None)
-
-    def ht_activate_tap(self, key, keyboard, *args, **kwargs):
-        handlers.default_pressed(key.meta.tap, keyboard, None)
-
-    def ht_deactivate_tap(self, key, keyboard, *args, **kwargs):
-        handlers.default_released(key.meta.tap, keyboard, None)

--- a/kmk/modules/tapdance.py
+++ b/kmk/modules/tapdance.py
@@ -49,7 +49,7 @@ class TapDance(HoldTap):
                 keyboard.cancel_timeout(state.timeout_key)
                 self.ht_activate_tap(_key, keyboard)
                 keyboard._send_hid()
-                self.ht_deactivate_tap(_key, keyboard)
+                self.ht_deactivate_tap(_key, keyboard, delayed=False)
                 del self.key_states[_key]
                 del self.td_counts[state.tap_dance]
 


### PR DESCRIPTION
resolves #566.
This was a bit more involved than anticipated. The "problem" is, that the hold-tap logic isn't using the pre-processing pipeline to convert hold-tap keys to regular keys. Hold-tap keys are more or less handled as dead keys that tap the resulting hold/tap key, instead of "converting" the hold-tap key into the respective result. It's an algorithmical nuance and I'm not sure atm which implementation would be more resource efficient, considering a trade-off between speed and memory consumption.