### PR TITLE
fix import typo in cg_swap.md

### DIFF
--- a/docs/cg_swap.md
+++ b/docs/cg_swap.md
@@ -3,7 +3,7 @@ This module allows to swap Ctrl with GUI and vice versa. This will reset on rest
 
 ## Enabling the module
 ```python
-from kmk.module.cg_swap import CgSwap
+from kmk.modules.cg_swap import CgSwap
 # cg_swap disabled on startup
 cg_swap = CgSwap()
 # cg_swap enabled on startup


### PR DESCRIPTION
update doc typo so that import will now correctly point to the `modules` directory rather than the non-existent `module` directory 