### PR TITLE
Corrected Right Angle Bracket shortened version

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -152,7 +152,7 @@
 |`KC.COLON`              |`KC.COLN`          |`:`                |
 |`KC.DOUBLE_QUOTE`       |`KC.DQUO`, `KC.DQT`|`"`                |
 |`KC.LEFT_ANGLE_BRACKET` |`KC.LABK`, `KC.LT` |`<`                |
-|`KC.RIGHT_ANGLE_BRACKET`|`KC.RABK`, `KC.GT` |`>`                |
+|`KC.RIGHT_ANGLE_BRACKET`|`KC.RABK`, `KC.RT` |`>`                |
 |`KC.QUESTION`           |`KC.QUES`          |`?`                |
 
 ## [International Keys]


### PR DESCRIPTION
Fixed a minor typo where the right angle bracket shortened version said "GT" instead of "RT"