### PR TITLE
fix pystack exhaust during resume_process_key.

### DIFF
--- a/kmk/modules/layers.py
+++ b/kmk/modules/layers.py
@@ -1,6 +1,6 @@
 '''One layer isn't enough. Adds keys to get to more of them'''
 from kmk.keys import KC, make_argumented_key
-from kmk.modules.holdtap import ActivationType, HoldTap, HoldTapKeyMeta
+from kmk.modules.holdtap import HoldTap, HoldTapKeyMeta
 from kmk.utils import Debug
 
 debug = Debug(__name__)
@@ -72,20 +72,6 @@ class Layers(HoldTap):
             on_press=self.ht_pressed,
             on_release=self.ht_released,
         )
-
-    def process_key(self, keyboard, key, is_pressed, int_coord):
-        current_key = super().process_key(keyboard, key, is_pressed, int_coord)
-
-        for key, state in self.key_states.items():
-            if key == current_key:
-                continue
-
-            # on interrupt: key must be translated here, because it was asigned
-            # before the layer shift happend.
-            if state.activated == ActivationType.INTERRUPTED:
-                current_key = keyboard._find_key_in_map(int_coord)
-
-        return current_key
 
     def _df_pressed(self, key, keyboard, *args, **kwargs):
         '''

--- a/kmk/modules/oneshot.py
+++ b/kmk/modules/oneshot.py
@@ -29,7 +29,13 @@ class OneShot(HoldTap):
             elif state.activated == ActivationType.RELEASED and is_pressed:
                 state.activated = ActivationType.INTERRUPTED
             elif state.activated == ActivationType.INTERRUPTED:
-                self.ht_released(key, keyboard)
+                if is_pressed:
+                    keyboard.remove_key(key.meta.tap)
+                    self.key_buffer.append((int_coord, current_key, is_pressed))
+                    keyboard.set_timeout(False, lambda: self.send_key_buffer(keyboard))
+                    current_key = None
+                else:
+                    self.ht_released(key, keyboard)
 
         return current_key
 
@@ -37,6 +43,7 @@ class OneShot(HoldTap):
         '''Register HoldTap mechanism and activate os key.'''
         self.ht_pressed(key, keyboard, *args, **kwargs)
         self.ht_activate_tap(key, keyboard, *args, **kwargs)
+        self.send_key_buffer(keyboard)
         return keyboard
 
     def osk_released(self, key, keyboard, *args, **kwargs):

--- a/kmk/modules/tapdance.py
+++ b/kmk/modules/tapdance.py
@@ -48,8 +48,11 @@ class TapDance(HoldTap):
             if state.activated == ActivationType.RELEASED:
                 keyboard.cancel_timeout(state.timeout_key)
                 self.ht_activate_tap(_key, keyboard)
-                keyboard._send_hid()
-                self.ht_deactivate_tap(_key, keyboard, delayed=False)
+                self.send_key_buffer(keyboard)
+                self.ht_deactivate_tap(_key, keyboard)
+                keyboard.resume_process_key(self, key, is_pressed, int_coord)
+                key = None
+
                 del self.key_states[_key]
                 del self.td_counts[state.tap_dance]
 
@@ -114,6 +117,6 @@ class TapDance(HoldTap):
         state = self.key_states[key]
         if state.activated == ActivationType.RELEASED:
             self.ht_activate_tap(key, keyboard, *args, **kwargs)
-            keyboard._send_hid()
+            self.send_key_buffer(keyboard)
             del self.td_counts[state.tap_dance]
         super().on_tap_time_expired(key, keyboard, *args, **kwargs)

--- a/tests/keyboard_test.py
+++ b/tests/keyboard_test.py
@@ -74,6 +74,7 @@ class KeyboardTest:
                 is_pressed = e[1]
                 self.pins[key_pos].value = is_pressed
                 self.do_main_loop()
+        self.keyboard._main_loop()
 
         matching = True
         for i in range(max(len(hid_reports), len(assert_reports))):

--- a/tests/test_hold_tap.py
+++ b/tests/test_hold_tap.py
@@ -300,25 +300,25 @@ class TestHoldTap(unittest.TestCase):
         keyboard.test(
             'OS interrupt within tap time',
             [(4, True), (4, False), t_within, (3, True), (3, False)],
-            [{KC.E}, {KC.D, KC.E}, {}],
+            [{KC.E}, {KC.D, KC.E}, {KC.E}, {}],
         )
 
         keyboard.test(
             'OS interrupt, multiple within tap time',
             [(4, True), (4, False), (3, True), (3, False), (2, True), (2, False)],
-            [{KC.E}, {KC.D, KC.E}, {}, {KC.C}, {}],
+            [{KC.E}, {KC.D, KC.E}, {KC.E}, {}, {KC.C}, {}],
         )
 
         keyboard.test(
             'OS interrupt, multiple interleaved',
             [(4, True), (4, False), (3, True), (2, True), (2, False), (3, False)],
-            [{KC.E}, {KC.D, KC.E}, {KC.C, KC.D}, {KC.D}, {}],
+            [{KC.E}, {KC.D, KC.E}, {KC.D}, {KC.C, KC.D}, {KC.D}, {}],
         )
 
         keyboard.test(
             'OS interrupt, multiple interleaved',
             [(4, True), (4, False), (3, True), (2, True), (3, False), (2, False)],
-            [{KC.E}, {KC.D, KC.E}, {KC.C, KC.D}, {KC.C}, {}],
+            [{KC.E}, {KC.D, KC.E}, {KC.D}, {KC.C, KC.D}, {KC.C}, {}],
         )
 
         keyboard.test(

--- a/tests/test_tapdance.py
+++ b/tests/test_tapdance.py
@@ -71,7 +71,7 @@ class TestTapDance(unittest.TestCase):
         keyboard.test(
             'Tap x1 interrupted',
             [(0, True), (0, False), (4, True), (4, False)],
-            [{KC.N0}, {KC.N4}, {}],
+            [{KC.N0}, {}, {KC.N4}, {}],
         )
 
         keyboard.test(


### PR DESCRIPTION
resolves: #585

Instead of handling resumed key events in a deep stack, buffer them until the next main loop iteration. New resume events that may be emitted during handling of old resumes are prepended to that buffer, i.e. take precedence over events that happen deeper into the buffer/event stack. Logical replay order is thus preserved.

This obviously constitutes an architectural change to the way we handle buffered or deferred key events and is open for debate.
In my opinion it's cleaner and easier to debug than handling key events from wherever and whenever in the code, especially from within anonymous timeout callbacks. No more `keyboard._send_hid()` littered throughout modules. No more multiple key events during processing timeouts. One API to rule them all! (ok, well, almost)