### PR TITLE
Parts of feature autorepeat probably left out in rebasing.

### DIFF
--- a/kmk/modules/layers.py
+++ b/kmk/modules/layers.py
@@ -18,7 +18,9 @@ def layer_key_validator(layer, kc=None):
 
 
 def layer_key_validator_lt(layer, kc, prefer_hold=False, repeat=False, **kwargs):
-    return HoldTapKeyMeta(tap=kc, hold=KC.MO(layer), prefer_hold=prefer_hold, repeat=repeat, **kwargs)
+    return HoldTapKeyMeta(
+        tap=kc, hold=KC.MO(layer), prefer_hold=prefer_hold, repeat=repeat, **kwargs
+    )
 
 
 def layer_key_validator_tt(layer, prefer_hold=True, **kwargs):

--- a/kmk/modules/layers.py
+++ b/kmk/modules/layers.py
@@ -17,8 +17,8 @@ def layer_key_validator(layer, kc=None):
     return LayerKeyMeta(layer, kc)
 
 
-def layer_key_validator_lt(layer, kc, prefer_hold=False, **kwargs):
-    return HoldTapKeyMeta(tap=kc, hold=KC.MO(layer), prefer_hold=prefer_hold, **kwargs)
+def layer_key_validator_lt(layer, kc, prefer_hold=False, repeat=False, **kwargs):
+    return HoldTapKeyMeta(tap=kc, hold=KC.MO(layer), prefer_hold=prefer_hold, repeat=repeat, **kwargs)
 
 
 def layer_key_validator_tt(layer, prefer_hold=True, **kwargs):

--- a/kmk/modules/modtap.py
+++ b/kmk/modules/modtap.py
@@ -3,7 +3,7 @@ from kmk.modules.holdtap import HoldTap, HoldTapKeyMeta
 
 
 def mod_tap_validator(
-    kc, mods=None, prefer_hold=True, tap_interrupted=False, tap_time=None
+    kc, mods=None, prefer_hold=True, tap_interrupted=False, tap_time=None, repeat=False
 ):
     '''
     Validates that mod tap keys are correctly used
@@ -14,6 +14,7 @@ def mod_tap_validator(
         prefer_hold=prefer_hold,
         tap_interrupted=tap_interrupted,
         tap_time=tap_time,
+        repeat=repeat
     )
 
 

--- a/kmk/modules/modtap.py
+++ b/kmk/modules/modtap.py
@@ -14,7 +14,7 @@ def mod_tap_validator(
         prefer_hold=prefer_hold,
         tap_interrupted=tap_interrupted,
         tap_time=tap_time,
-        repeat=repeat
+        repeat=repeat,
     )
 
 


### PR DESCRIPTION
Unless I missed something, autorepeat support as merged in #611 is incomplete: the validator won't validate the `repeat` argument.
I have the feeling some parts were left out while rebasing (due to the fact validators and key types were moved around in between).
This PR should fix this overlook.

Also this points out the need to add a few unitary tests...