### PR TITLE
Enhancement holdtap repeat unittest

### DIFF
--- a/kmk/modules/modtap.py
+++ b/kmk/modules/modtap.py
@@ -2,31 +2,11 @@ from kmk.keys import make_argumented_key
 from kmk.modules.holdtap import HoldTap, HoldTapKeyMeta
 
 
-def mod_tap_validator(
-    kc, mods=None, prefer_hold=True, tap_interrupted=False, tap_time=None
-):
-    '''
-    Validates that mod tap keys are correctly used
-    '''
-    return ModTapKeyMeta(
-        kc=kc,
-        mods=mods,
-        prefer_hold=prefer_hold,
-        tap_interrupted=tap_interrupted,
-        tap_time=tap_time,
-    )
-
-
-class ModTapKeyMeta(HoldTapKeyMeta):
-    def __init__(self, kc=None, mods=None, **kwargs):
-        super().__init__(tap=kc, hold=mods, **kwargs)
-
-
 class ModTap(HoldTap):
     def __init__(self):
         super().__init__()
         make_argumented_key(
-            validator=mod_tap_validator,
+            validator=HoldTapKeyMeta,
             names=('MT',),
             on_press=self.ht_pressed,
             on_release=self.ht_released,

--- a/tests/test_hold_tap.py
+++ b/tests/test_hold_tap.py
@@ -272,6 +272,65 @@ class TestHoldTap(unittest.TestCase):
 
         # TODO test TT
 
+    def test_holdtap_repeat(self):
+        keyboard = KeyboardTest(
+            [ModTap()],
+            [[KC.MT(KC.A, KC.B, repeat=True, tap_time=50)]],
+            debug_enabled=False,
+        )
+
+        t_within = 40
+        t_after = 60
+
+        keyboard.test(
+            'repeat tap',
+            [
+                (0, True),
+                (0, False),
+                t_within,
+                (0, True),
+                t_after,
+                (0, False),
+                (0, True),
+                (0, False),
+                t_after,
+            ],
+            [{KC.A}, {}, {KC.A}, {}, {KC.A}, {}],
+        )
+
+        keyboard.test(
+            'repeat hold',
+            [
+                (0, True),
+                t_after,
+                (0, False),
+                t_within,
+                (0, True),
+                (0, False),
+                (0, True),
+                (0, False),
+                t_after,
+            ],
+            [{KC.B}, {}, {KC.B}, {}, {KC.B}, {}],
+        )
+
+        keyboard.test(
+            'no repeat after tap_time',
+            [
+                (0, True),
+                (0, False),
+                t_after,
+                (0, True),
+                t_after,
+                (0, False),
+                t_after,
+                (0, True),
+                (0, False),
+                t_after,
+            ],
+            [{KC.A}, {}, {KC.B}, {}, {KC.A}, {}],
+        )
+
     def test_oneshot(self):
         keyboard = KeyboardTest(
             [Layers(), ModTap(), OneShot()],


### PR DESCRIPTION
Adds a unittest for the "holdtap repeat" feature.
And to make the test pass and deduplicate code: replaces the modtap validator its parent's (as suggested in #616).