### PR TITLE
Enhancement global pointing device

### DIFF
--- a/kmk/hid.py
+++ b/kmk/hid.py
@@ -104,7 +104,7 @@ class AbstractHID:
                     for mod in key.has_modifiers:
                         self.add_modifier(mod)
 
-        for axis in axes.values():
+        for axis in axes:
             self.move_axis(axis)
 
     def hid_send(self, evt):
@@ -136,6 +136,7 @@ class AbstractHID:
 
         self.remove_cc()
         self.remove_pd()
+        self.clear_axis()
 
         return self
 
@@ -218,11 +219,14 @@ class AbstractHID:
             self._pd_report[1] = 0x00
 
     def move_axis(self, axis):
-        if axis.delta != 0 or self._pd_report[axis.code + 2] != 0:
-            delta = clamp(axis.delta, -127, 127)
-            axis.delta -= delta
-            self._pd_report[axis.code + 2] = 0xFF & delta
-            self._pd_pending = True
+        delta = clamp(axis.delta, -127, 127)
+        axis.delta -= delta
+        self._pd_report[axis.code + 2] = 0xFF & delta
+        self._pd_pending = True
+
+    def clear_axis(self):
+        for idx in range(2, len(self._pd_report)):
+            self._pd_report[idx] = 0x00
 
 
 class USBHID(AbstractHID):

--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -42,6 +42,10 @@ class Axis:
     def __repr__(self) -> str:
         return f'Axis(code={self.code}, delta={self.delta})'
 
+    def move(self, keyboard: Keyboard, delta: int):
+        keyboard.hid_pending = True
+        self.delta += delta
+
 
 def maybe_make_key(
     code: Optional[int],

--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -33,6 +33,15 @@ ALL_NUMBER_ALIASES = tuple(f'N{x}' for x in ALL_NUMBERS)
 debug = Debug(__name__)
 
 
+class Axis:
+    def __init__(self, code: int) -> None:
+        self.code = code
+        self.delta = 0
+
+    def __repr__(self) -> str:
+        return f'Axis(code={self.code}, delta={self.delta})'
+
+
 def maybe_make_key(
     code: Optional[int],
     names: Tuple[str, ...],

--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -20,6 +20,7 @@ class KeyType:
     SIMPLE = const(0)
     MODIFIER = const(1)
     CONSUMER = const(2)
+    MOUSE = const(3)
 
 
 FIRST_KMK_INTERNAL_KEY = const(1000)
@@ -694,6 +695,10 @@ class ConsumerKey(Key):
     pass
 
 
+class MouseKey(Key):
+    pass
+
+
 def make_key(
     code: Optional[int] = None,
     names: Tuple[str, ...] = tuple(),  # NOQA
@@ -724,6 +729,8 @@ def make_key(
         constructor = ModifierKey
     elif type == KeyType.CONSUMER:
         constructor = ConsumerKey
+    elif type == KeyType.MOUSE:
+        constructor = MouseKey
     else:
         raise ValueError('Unrecognized key type')
 
@@ -754,6 +761,10 @@ def make_shifted_key(code: int, names: Tuple[str, ...]) -> Key:
 
 def make_consumer_key(*args, **kwargs) -> Key:
     return make_key(*args, **kwargs, type=KeyType.CONSUMER)
+
+
+def make_mouse_key(*args, **kwargs) -> Key:
+    return make_key(*args, **kwargs, type=KeyType.MOUSE)
 
 
 # Argumented keys are implicitly internal, so auto-gen of code

--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -43,8 +43,18 @@ class Axis:
         return f'Axis(code={self.code}, delta={self.delta})'
 
     def move(self, keyboard: Keyboard, delta: int):
-        keyboard.hid_pending = True
         self.delta += delta
+        if self.delta:
+            keyboard.axes.add(self)
+            keyboard.hid_pending = True
+        else:
+            keyboard.axes.discard(self)
+
+
+class AX:
+    W = Axis(2)
+    X = Axis(0)
+    Y = Axis(1)
 
 
 def maybe_make_key(

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -49,6 +49,7 @@ class KMKKeyboard:
     #####
     # Internal State
     keys_pressed = set()
+    axes = {}
     _coordkeys_pressed = {}
     hid_type = HIDModes.USB
     secondary_hid_type = None
@@ -88,6 +89,7 @@ class KMKKeyboard:
                 f'  unicode_mode={self.unicode_mode}, ',
                 f'_hid_helper={self._hid_helper},\n',
                 f'  keys_pressed={self.keys_pressed},\n',
+                f'  axes={self.axes},\n',
                 f'  _coordkeys_pressed={self._coordkeys_pressed},\n',
                 f'  hid_pending={self.hid_pending}, ',
                 f'active_layers={self.active_layers}, ',
@@ -100,16 +102,24 @@ class KMKKeyboard:
         if debug.enabled:
             debug(f'coordkeys_pressed={self._coordkeys_pressed}')
             debug(f'keys_pressed={self.keys_pressed}')
+            # debug(f'axis={[ax for ax in self.axis.__iter__()]}')
 
     def _send_hid(self) -> None:
-        if self._hid_send_enabled:
-            hid_report = self._hid_helper.create_report(self.keys_pressed)
-            try:
-                hid_report.send()
-            except KeyError as e:
-                if debug.enabled:
-                    debug(f'HidNotFound(HIDReportType={e})')
+        if not self._hid_send_enabled:
+            return
+
+        self._hid_helper.create_report(self.keys_pressed, self.axes)
+        try:
+            self._hid_helper.send()
+        except KeyError as e:
+            if debug.enabled:
+                debug(f'HidNotFound(HIDReportType={e})')
+
         self.hid_pending = False
+        for axis in self.axes.values():
+            if axis.delta != 0:
+                self.hid_pending = True
+                break
 
     def _handle_matrix_report(self, kevent: KeyEvent) -> None:
         if kevent is not None:

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -49,7 +49,7 @@ class KMKKeyboard:
     #####
     # Internal State
     keys_pressed = set()
-    axes = {}
+    axes = set()
     _coordkeys_pressed = {}
     hid_type = HIDModes.USB
     secondary_hid_type = None
@@ -102,11 +102,13 @@ class KMKKeyboard:
         if debug.enabled:
             debug(f'coordkeys_pressed={self._coordkeys_pressed}')
             debug(f'keys_pressed={self.keys_pressed}')
-            # debug(f'axis={[ax for ax in self.axis.__iter__()]}')
 
     def _send_hid(self) -> None:
         if not self._hid_send_enabled:
             return
+
+        if self.axes and debug.enabled:
+            debug(f'axes={self.axes}')
 
         self._hid_helper.create_report(self.keys_pressed, self.axes)
         try:
@@ -116,10 +118,9 @@ class KMKKeyboard:
                 debug(f'HidNotFound(HIDReportType={e})')
 
         self.hid_pending = False
-        for axis in self.axes.values():
-            if axis.delta != 0:
-                self.hid_pending = True
-                break
+
+        for axis in self.axes:
+            axis.move(self, 0)
 
     def _handle_matrix_report(self, kevent: KeyEvent) -> None:
         if kevent is not None:

--- a/kmk/modules/adns9800.py
+++ b/kmk/modules/adns9800.py
@@ -4,9 +4,9 @@ import microcontroller
 
 import time
 
+from kmk.keys import AX
 from kmk.modules import Module
 from kmk.modules.adns9800_firmware import firmware
-from kmk.modules.mouse_keys import PointingDevice
 
 
 class REG:
@@ -70,7 +70,6 @@ class ADNS9800(Module):
     DIR_READ = 0x7F
 
     def __init__(self, cs, sclk, miso, mosi, invert_x=False, invert_y=False):
-        self.pointing_device = PointingDevice()
         self.cs = digitalio.DigitalInOut(cs)
         self.cs.direction = digitalio.Direction.OUTPUT
         self.spi = busio.SPI(clock=sclk, MOSI=mosi, MISO=miso)
@@ -203,27 +202,14 @@ class ADNS9800(Module):
             if self.invert_y:
                 delta_y *= -1
 
-            if delta_x < 0:
-                self.pointing_device.report_x[0] = (delta_x & 0xFF) | 0x80
-            else:
-                self.pointing_device.report_x[0] = delta_x & 0xFF
+            if delta_x:
+                AX.X.move(delta_x)
 
-            if delta_y < 0:
-                self.pointing_device.report_y[0] = (delta_y & 0xFF) | 0x80
-            else:
-                self.pointing_device.report_y[0] = delta_y & 0xFF
+            if delta_y:
+                AX.Y.move(delta_y)
 
             if keyboard.debug_enabled:
                 print('Delta: ', delta_x, ' ', delta_y)
-            self.pointing_device.hid_pending = True
-
-        if self.pointing_device.hid_pending:
-            keyboard._hid_helper.hid_send(self.pointing_device._evt)
-            self.pointing_device.hid_pending = False
-            self.pointing_device.report_x[0] = 0
-            self.pointing_device.report_y[0] = 0
-
-        return
 
     def after_matrix_scan(self, keyboard):
         return

--- a/kmk/modules/easypoint.py
+++ b/kmk/modules/easypoint.py
@@ -4,8 +4,8 @@ Extension handles usage of AS5013 by AMS
 
 from supervisor import ticks_ms
 
+from kmk.keys import AX
 from kmk.modules import Module
-from kmk.modules.mouse_keys import PointingDevice
 
 I2C_ADDRESS = 0x40
 I2X_ALT_ADDRESS = 0x41
@@ -44,7 +44,6 @@ class Easypoint(Module):
         self._i2c_bus = i2c
 
         # HID parameters
-        self.pointing_device = PointingDevice()
         self.polling_interval = 20
         self.last_tick = ticks_ms()
 
@@ -82,12 +81,8 @@ class Easypoint(Module):
             return
         else:
             # Set the X/Y from easypoint
-            self.pointing_device.report_x[0] = x
-            self.pointing_device.report_y[0] = y
-
-            self.pointing_device.hid_pending = x != 0 or y != 0
-
-        return
+            AX.X.move(keyboard, x)
+            AX.Y.move(keyboard, y)
 
     def after_matrix_scan(self, keyboard):
         return
@@ -96,9 +91,6 @@ class Easypoint(Module):
         return
 
     def after_hid_send(self, keyboard):
-        if self.pointing_device.hid_pending:
-            keyboard._hid_helper.hid_send(self.pointing_device._evt)
-            self._clear_pending_hid()
         return
 
     def on_powersave_enable(self, keyboard):
@@ -106,13 +98,6 @@ class Easypoint(Module):
 
     def on_powersave_disable(self, keyboard):
         return
-
-    def _clear_pending_hid(self):
-        self.pointing_device.hid_pending = False
-        self.pointing_device.report_x[0] = 0
-        self.pointing_device.report_y[0] = 0
-        self.pointing_device.report_w[0] = 0
-        self.pointing_device.button_status[0] = 0
 
     def _read_raw_state(self):
         '''Read data from AS5013'''

--- a/kmk/modules/layers.py
+++ b/kmk/modules/layers.py
@@ -114,17 +114,15 @@ class Layers(HoldTap):
         '''
         As MO(layer) but with mod active
         '''
-        keyboard.hid_pending = True
         # Sets the timer start and acts like MO otherwise
-        keyboard.keys_pressed.add(key.meta.kc)
+        keyboard.add_key(key.meta.kc)
         self._mo_pressed(key, keyboard, *args, **kwargs)
 
     def _lm_released(self, key, keyboard, *args, **kwargs):
         '''
         As MO(layer) but with mod active
         '''
-        keyboard.hid_pending = True
-        keyboard.keys_pressed.discard(key.meta.kc)
+        keyboard.remove_key(key.meta.kc)
         self._mo_released(key, keyboard, *args, **kwargs)
 
     def _tg_pressed(self, key, keyboard, *args, **kwargs):

--- a/kmk/modules/mouse_keys.py
+++ b/kmk/modules/mouse_keys.py
@@ -106,21 +106,18 @@ class MouseKeys(Module):
             if self.move_step < self.max_speed:
                 self.move_step = self.move_step + 1
             if self._right_activated:
-                keyboard.axes['X'].delta += self.move_step
+                keyboard.axes['X'].move(keyboard, self.move_step)
             if self._left_activated:
-                keyboard.axes['X'].delta -= self.move_step
+                keyboard.axes['X'].move(keyboard, -self.move_step)
             if self._up_activated:
-                keyboard.axes['Y'].delta -= self.move_step
+                keyboard.axes['Y'].move(keyboard, -self.move_step)
             if self._down_activated:
-                keyboard.axes['Y'].delta += self.move_step
-            keyboard.hid_pending = True
+                keyboard.axes['Y'].move(keyboard, self.move_step)
 
         if self._mw_up_activated:
-            keyboard.axes['W'].delta += self.move_step
-            keyboard.hid_pending = True
+            keyboard.axes['W'].move(keyboard, 1)
         if self._mw_down_activated:
-            keyboard.axes['W'].delta -= self.move_step
-            keyboard.hid_pending = True
+            keyboard.axes['W'].move(keyboard, -1)
 
     def before_hid_send(self, keyboard):
         return

--- a/kmk/modules/mouse_keys.py
+++ b/kmk/modules/mouse_keys.py
@@ -1,5 +1,5 @@
 from kmk.hid import HID_REPORT_SIZES, HIDReportTypes
-from kmk.keys import Axis, make_key, make_mouse_key
+from kmk.keys import AX, make_key, make_mouse_key
 from kmk.kmktime import PeriodicTimer
 from kmk.modules import Module
 
@@ -90,9 +90,6 @@ class MouseKeys(Module):
         )
 
     def during_bootup(self, keyboard):
-        keyboard.axes['W'] = Axis(2)
-        keyboard.axes['X'] = Axis(0)
-        keyboard.axes['Y'] = Axis(1)
         self._timer = PeriodicTimer(self.acc_interval)
 
     def before_matrix_scan(self, keyboard):
@@ -106,18 +103,18 @@ class MouseKeys(Module):
             if self.move_step < self.max_speed:
                 self.move_step = self.move_step + 1
             if self._right_activated:
-                keyboard.axes['X'].move(keyboard, self.move_step)
+                AX.X.move(keyboard, self.move_step)
             if self._left_activated:
-                keyboard.axes['X'].move(keyboard, -self.move_step)
+                AX.X.move(keyboard, -self.move_step)
             if self._up_activated:
-                keyboard.axes['Y'].move(keyboard, -self.move_step)
+                AX.Y.move(keyboard, -self.move_step)
             if self._down_activated:
-                keyboard.axes['Y'].move(keyboard, self.move_step)
+                AX.Y.move(keyboard, self.move_step)
 
         if self._mw_up_activated:
-            keyboard.axes['W'].move(keyboard, 1)
+            AX.W.move(keyboard, 1)
         if self._mw_down_activated:
-            keyboard.axes['W'].move(keyboard, -1)
+            AX.W.move(keyboard, -1)
 
     def before_hid_send(self, keyboard):
         return


### PR DESCRIPTION
We're currently handling pointing device HIDs completely independent and agnostic of one another.
That requires duplicate code and when using more than one PD HID module, they interfere with each other.

This is an attempt to consolidate and build a central API for axis movement.
Mouse keys can be handled just like keyboard and consumer control keys. Unfortunately that doesn't work with axes, because they have continuous states (the amount of movement), not binary (pressed/released). I'm still undecided about the exact implementation details and open to suggestions.