### PR TITLE
remove not-implemented keycodes from docs

### DIFF
--- a/docs/en/keycodes.md
+++ b/docs/en/keycodes.md
@@ -151,8 +151,8 @@
 |`KC.PIPE`               |                   |<code>&#124;</code>|
 |`KC.COLON`              |`KC.COLN`          |`:`                |
 |`KC.DOUBLE_QUOTE`       |`KC.DQUO`, `KC.DQT`|`"`                |
-|`KC.LEFT_ANGLE_BRACKET` |`KC.LABK`, `KC.LT` |`<`                |
-|`KC.RIGHT_ANGLE_BRACKET`|`KC.RABK`, `KC.GT` |`>`                |
+|`KC.LEFT_ANGLE_BRACKET` |`KC.LABK`          |`<`                |
+|`KC.RIGHT_ANGLE_BRACKET`|`KC.RABK`          |`>`                |
 |`KC.QUESTION`           |`KC.QUES`          |`?`                |
 
 ## [International Keys]


### PR DESCRIPTION
resolves #631

We can't do `KC.LT`, because it collides with layer tap; ergo also remove `KC.GT`.