### PR TITLE
readme: remove authorship and maintainer list blurb

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ is **not** a bug tracker, and it is **not** necessarily monitored by the
 maintainer crew, though we may lurk there sometimes.) This channel is bridged
 to Discord [here](https://discord.gg/QBHUUpeGUd) for convenience.
 
-
 ## Features
 
 - Fully configured through a single, easy to understand Python file that lives
@@ -43,20 +42,6 @@ to Discord [here](https://discord.gg/QBHUUpeGUd) for convenience.
 KMK requires [CircuitPython](https://circuitpython.org/) version 7.0 or higher.
 Our getting started guide can be found
 [here](/docs/en/Getting_Started.md).
-
-## The KMK Team
-
-KMK was originally authored by @klardotsh and @kdb424 over the winter of
-2018-19, and has been contributed to by numerous others since. Contributions
-are welcome from all, whether it's in the form of code, documentation, hardware
-designs, feature ideas, or anything else that comes to mind. A list of KMK's
-contributors can be found [on
-GitHub](https://github.com/KMKfw/kmk_firmware/graphs/contributors).
-
-> While Adafruit employees and affiliates are occasionally found in the commit
-> log and their help has been crucial to KMK's success, KMK is not an official
-> Adafruit project, and the Core team is not compensated by Adafruit for its
-> development.
 
 ## Code Style
 


### PR DESCRIPTION
As the branch name suggests, this started as somewhat of a formal farewell and thanks to the original co-author and four-years-running co-maintainer of KMK, @kdb424, who has relayed to us that he would like to step down from the project effective immediately. I was going to add somewhat of a `Maintainers Emeritus` subheading as a thanks, but instead will just propose removing the entire "team" blurb from the README: it doesn't serve too many useful purposes that the Git log cannot at this point anyway.

Thanks, kdb. I'm sure we'll build some more silly toy projects together soon. Four years almost to the day from starting this project is about time we kick around some new wild idea anyway, yeah? :)