### PR TITLE
fix: Include Z and 0 in CapsWords ranges

### DIFF
--- a/kmk/modules/capsword.py
+++ b/kmk/modules/capsword.py
@@ -6,8 +6,8 @@ class CapsWord(Module):
     # default timeout is 8000
     # alphabets, numbers and few more keys will not disable capsword
     def __init__(self, timeout=8000):
-        self._alphabets = range(KC.A.code, KC.Z.code)
-        self._numbers = range(KC.N1.code, KC.N0.code)
+        self._alphabets = range(KC.A.code, KC.Z.code + 1)
+        self._numbers = range(KC.N1.code, KC.N0.code + 1)
         self.keys_ignored = [
             KC.MINS,
             KC.BSPC,

--- a/tests/test_capsword.py
+++ b/tests/test_capsword.py
@@ -4,7 +4,8 @@ from kmk.keys import KC
 from kmk.modules.capsword import CapsWord
 from tests.keyboard_test import KeyboardTest
 
-#TODO: Add tests for custom and default ignored keys, custom and default timeouts
+# TODO: Add tests for custom and default ignored keys, custom and default timeouts
+
 
 class TestCapsWord(unittest.TestCase):
     def setUp(self):
@@ -19,8 +20,44 @@ class TestCapsWord(unittest.TestCase):
     def test_capsword(self):
         self.kb.test(
             'CapsWord',
-            [(1, True), (1, False), (0, True), (0, False), (1, True), (1, False), (2, True), (2, False), (3, True), (3, False), (4, True), (4, False), (1, True), (1, False), (5, True), (5, False), (1, True), (1, False)],
-            [{KC.A}, {}, {KC.LSFT, KC.A}, {}, {KC.LSFT, KC.Z}, {}, {KC.N1}, {}, {KC.N0}, {}, {KC.LSFT, KC.A}, {}, {KC.SPC}, {}, {KC.A}, {}],
+            [
+                (1, True),
+                (1, False),
+                (0, True),
+                (0, False),
+                (1, True),
+                (1, False),
+                (2, True),
+                (2, False),
+                (3, True),
+                (3, False),
+                (4, True),
+                (4, False),
+                (1, True),
+                (1, False),
+                (5, True),
+                (5, False),
+                (1, True),
+                (1, False),
+            ],
+            [
+                {KC.A},
+                {},
+                {KC.LSFT, KC.A},
+                {},
+                {KC.LSFT, KC.Z},
+                {},
+                {KC.N1},
+                {},
+                {KC.N0},
+                {},
+                {KC.LSFT, KC.A},
+                {},
+                {KC.SPC},
+                {},
+                {KC.A},
+                {},
+            ],
         )
 
 

--- a/tests/test_capsword.py
+++ b/tests/test_capsword.py
@@ -1,0 +1,28 @@
+import unittest
+
+from kmk.keys import KC
+from kmk.modules.capsword import CapsWord
+from tests.keyboard_test import KeyboardTest
+
+#TODO: Add tests for custom and default ignored keys, custom and default timeouts
+
+class TestCapsWord(unittest.TestCase):
+    def setUp(self):
+        self.kb = KeyboardTest(
+            [CapsWord()],
+            [
+                [KC.CW, KC.A, KC.Z, KC.N1, KC.N0, KC.SPC],
+            ],
+            debug_enabled=False,
+        )
+
+    def test_capsword(self):
+        self.kb.test(
+            'CapsWord',
+            [(1, True), (1, False), (0, True), (0, False), (1, True), (1, False), (2, True), (2, False), (3, True), (3, False), (4, True), (4, False), (1, True), (1, False), (5, True), (5, False), (1, True), (1, False)],
+            [{KC.A}, {}, {KC.LSFT, KC.A}, {}, {KC.LSFT, KC.Z}, {}, {KC.N1}, {}, {KC.N0}, {}, {KC.LSFT, KC.A}, {}, {KC.SPC}, {}, {KC.A}, {}],
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Before, the allowed alphabet of characters for CapsWords was exclusive of the letter Z, and the allowed number set was exclusive of the number 0.

Now, those characters are included, so using them won't interrupt CapsWords.