### PR TITLE
feat: add permissive_hold option to holdtap

### DIFF
--- a/docs/en/modtap.md
+++ b/docs/en/modtap.md
@@ -31,11 +31,14 @@ keyboard.modules.append(modtap)
 ## Custom HoldTap Behavior
 The full ModTap signature is as follows:
 ```python
-KC.MT(KC.TAP, KC.HOLD, prefer_hold=True, tap_interrupted=False, tap_time=None, repeat=HoldTapRepeat.NONE)
+KC.MT(KC.TAP, KC.HOLD, prefer_hold=True, permissive_hold=False, tap_interrupted=False, tap_time=None, repeat=HoldTapRepeat.NONE)
 ```
 * `prefer_hold`: decides which keycode the ModTap key resolves to when another
   key is pressed before the timeout finishes. When `True` the hold keycode is
   chosen, the tap keycode when `False`.
+* `permissive_hold`: decides which keycode the ModTap key resolves to when
+  another key is pressed and released before the timeout finishes. When
+  `True` the hold keycode is chosen, the tap keycode when `False`.
 * `tap_interrupted`: decides if the timeout will interrupt at the first other
   key press/down, or after the first other key up/release. Set to `True` for
   interrupt on release.

--- a/tests/test_hold_tap.py
+++ b/tests/test_hold_tap.py
@@ -419,6 +419,88 @@ class TestHoldTap(unittest.TestCase):
             [{KC.E}, {KC.D, KC.E}, {KC.E}, {KC.C, KC.E}, {KC.E}, {}],
         )
 
+    def test_holdtap_permissive_hold(self):
+        keyboard = KeyboardTest(
+            [ModTap()],
+            [
+                [
+                    KC.MT(
+                        KC.A,
+                        KC.LSHIFT,
+                        tap_time=50,
+                        prefer_hold=False,
+                        permissive_hold=True,
+                    ),
+                    KC.B,
+                    KC.MT(KC.C, KC.LCTL, tap_time=50, prefer_hold=False),
+                ]
+            ],
+            debug_enabled=False,
+        )
+
+        t_within = 40
+        t_after = 60
+
+        keyboard.test(
+            'nested tap',
+            [
+                (0, True),
+                t_within,
+                (1, True),
+                (1, False),
+                (0, False),
+            ],
+            [{KC.LSHIFT}, {KC.LSHIFT, KC.B}, {KC.LSHIFT}, {}],
+        )
+
+        keyboard.test(
+            'standard hold tap',
+            [
+                (0, True),
+                t_after,
+                (1, True),
+                (1, False),
+                (0, False),
+            ],
+            [{KC.LSHIFT}, {KC.LSHIFT, KC.B}, {KC.LSHIFT}, {}],
+        )
+
+        keyboard.test(
+            'key released after mod',
+            [
+                (0, True),
+                t_within,
+                (1, True),
+                (0, False),
+                (1, False),
+            ],
+            [{KC.A}, {KC.B, KC.A}, {KC.B}, {}],
+        )
+
+        keyboard.test(
+            'nested modtap',
+            [
+                (0, True),
+                t_within,
+                (2, True),
+                (2, False),
+                (0, False),
+            ],
+            [{KC.LSHIFT}, {KC.LSHIFT, KC.C}, {KC.LSHIFT}, {}],
+        )
+
+        keyboard.test(
+            'overlapping modtap',
+            [
+                (0, True),
+                t_within,
+                (2, True),
+                (2, False),
+                (0, False),
+            ],
+            [{KC.LSHIFT}, {KC.LSHIFT, KC.C}, {KC.LSHIFT}, {}],
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_hold_tap.py
+++ b/tests/test_hold_tap.py
@@ -489,18 +489,6 @@ class TestHoldTap(unittest.TestCase):
             [{KC.LSHIFT}, {KC.LSHIFT, KC.C}, {KC.LSHIFT}, {}],
         )
 
-        keyboard.test(
-            'overlapping modtap',
-            [
-                (0, True),
-                t_within,
-                (2, True),
-                (2, False),
-                (0, False),
-            ],
-            [{KC.LSHIFT}, {KC.LSHIFT, KC.C}, {KC.LSHIFT}, {}],
-        )
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds a `permissive_hold` parameter to HoldTap keys that operates in the same fashion as the QMK option of the same name.

See https://docs.qmk.fm/#/tap_hold?id=permissive-hold