### PR TITLE
fix: support CircuitPython 8.0.0-beta3

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -1,3 +1,6 @@
 import supervisor
 
-supervisor.set_next_stack_limit(4096 + 4096)
+if callable(getattr(supervisor, 'set_next_stack_limit', None)):
+    supervisor.set_next_stack_limit(4096 + 4096)
+else:
+    supervisor.runtime.next_stack_limit = 4096 + 4096


### PR DESCRIPTION
CircuitPython 8 changes the API of the `supervisor` module. This fix accounts for the old and new APIs without requiring any other configuration changes.

Fixes https://github.com/KMKfw/kmk_firmware/issues/655

Tested this on a pi pico with both 7.3.3 and 8.0.0-beta4.