### PR TITLE
Update peg_oled_display.py

### DIFF
--- a/kmk/extensions/peg_oled_display.py
+++ b/kmk/extensions/peg_oled_display.py
@@ -123,9 +123,9 @@ class Oled(Extension):
     def on_runtime_disable(self, sandbox):
         return
 
-    def during_bootup(self, board):
+    def during_bootup(self, keyboard):
         displayio.release_displays()
-        i2c = busio.I2C(board.SCL, board.SDA)
+        i2c = busio.I2C(keyboard.SCL, keyboard.SDA)
         self._display = adafruit_displayio_ssd1306.SSD1306(
             displayio.I2CDisplay(i2c, device_address=0x3C),
             width=self._width,


### PR DESCRIPTION
It's been bugging me how this extension created i2c object with board.SDA and board.SCL.
My MCU board of choice doesn't have SDA and SCL in it's board module, yet somehow it works as long as SDA and SCL are defined in keyboard and i2c isn't(srsly, why do example boards all have i2c = board.I2C in their keyboard class? Lulu has it twice!)

Again, it somehow works without changes to the oled extension, I just fail to see how.
Anyway, here's a small tweak that also works, also as long as there's no i2c object, but it seems more correct?