### PR TITLE
fix: LED static mode toggling

### DIFF
--- a/kmk/extensions/led.py
+++ b/kmk/extensions/led.py
@@ -230,7 +230,7 @@ class LED(Extension):
     def _key_led_tog(self, *args, **kwargs):
         if self.animation_mode == AnimationModes.STATIC_STANDBY:
             self.animation_mode = AnimationModes.STATIC
-        
+
         if self._enabled:
             self.off()
         self._enabled = not self._enabled


### PR DESCRIPTION
Static animation now gets set to standby instead of none. The off() function has been moved so that it only only activates when toggled, similar to RGB extension