### PR TITLE
anavi-arrows: Add ANAVI Arrows

### DIFF
--- a/boards/anavi/anavi-arrows/README.md
+++ b/boards/anavi/anavi-arrows/README.md
@@ -1,0 +1,12 @@
+# ANAVI Arrows
+
+ANAVI Arrows is an open source, programmable mechanical keyboard with 4 hot-swappable mechanical switches, RGB WS2812B underlighting and yellow backlit a rotary encoder, [Seeed XIAO RP2040](https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html) and a mini OLED I2C yellow-blue display.
+
+ANAVI Arrows has been designed with the cross platform and open source electronics design automation suite KiCad. All KiCad [files and schematics are available at GitHub](https://github.com/anavitechnology/anavi-arrows) under [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/).
+
+Extensions enabled by default:
+- [Encoder](/docs/en/encoder.md) Twist control for all the things
+- [LED](/docs/en/led.md) Light your keys up (for backlit)
+- [RGB](/docs/en/rgb.md) Light it up (for underlighting)
+- [MediaKeys](/docs/en/media_keys.md) Control volume and other media functions
+- [PEG_OLED](/docs/peg_oled_display.md) Show information on the mini OLED display

--- a/boards/anavi/anavi-arrows/arrows.py
+++ b/boards/anavi/anavi-arrows/arrows.py
@@ -1,0 +1,20 @@
+'''
+KMK keyboard for ANAVI Arrows
+
+This is a macro pad with 4 mechanical switches based on the RP2040. Each key is
+attached to a single GPIO, so the KMK matrix scanner needs to be overridden.
+'''
+
+import board
+
+from kmk.kmk_keyboard import KMKKeyboard
+from kmk.scanners.keypad import KeysScanner
+
+
+class AnaviArrows(KMKKeyboard):
+    '''
+    Default keyboard config for ANAVI Arrows.
+    '''
+
+    def __init__(self):
+        self.matrix = KeysScanner([board.D1, board.D2, board.D3, board.D6])

--- a/boards/anavi/anavi-arrows/code.py
+++ b/boards/anavi/anavi-arrows/code.py
@@ -1,0 +1,90 @@
+import board
+
+from arrows import AnaviArrows
+
+from kmk.extensions.LED import LED
+from kmk.extensions.media_keys import MediaKeys
+from kmk.extensions.peg_oled_Display import (
+    Oled,
+    OledData,
+    OledDisplayMode,
+    OledReactionType,
+)
+from kmk.extensions.RGB import RGB, AnimationModes
+from kmk.keys import KC
+from kmk.modules.encoder import EncoderHandler
+
+keyboard = AnaviArrows()
+
+# I2C pins for the mini OLED display
+keyboard.SCL = board.D5
+keyboard.SDA = board.D4
+
+# fmt: off
+keyboard.keymap = [
+    [
+        KC.RIGHT, KC.DOWN, KC.LEFT, KC.UP,
+    ]
+]
+# fmt: on
+
+oled_ext = Oled(
+    OledData(
+        corner_one={0: OledReactionType.STATIC, 1: ['ANAVI Arrows']},
+        corner_two={0: OledReactionType.STATIC, 1: [' ']},
+        corner_three={0: OledReactionType.STATIC, 1: ['Open Source']},
+        corner_four={0: OledReactionType.STATIC, 1: [' ']},
+    ),
+    oWidth=128,
+    oHeight=64,
+    toDisplay=OledDisplayMode.TXT,
+    flip=False,
+)
+keyboard.extensions.append(oled_ext)
+
+led_ext = LED(
+    led_pin=[
+        board.D0,
+    ],
+    brightness=100,
+    brightness_step=5,
+    brightness_limit=100,
+    breathe_center=1.5,
+    animation_mode=AnimationModes.STATIC,
+    animation_speed=1,
+    user_animation=None,
+    val=100,
+)
+keyboard.extensions.append(led_ext)
+
+# WS2812B LED strips on the back
+underglow = RGB(
+    pixel_pin=board.D10,
+    num_pixels=4,
+    val_limit=100,
+    val_default=25,
+    animation_mode=AnimationModes.RAINBOW,
+)
+keyboard.extensions.append(underglow)
+
+# Neopixel on XIAO RP2040
+frontglow = RGB(
+    pixel_pin=board.NEOPIXEL,
+    num_pixels=1,
+    val_limit=100,
+    val_default=25,
+    animation_mode=AnimationModes.RAINBOW,
+)
+keyboard.extensions.append(frontglow)
+
+media_keys = MediaKeys()
+keyboard.extensions.append(media_keys)
+
+# Rotary encoder that also acts as a key
+encoder_handler = EncoderHandler()
+encoder_handler.pins = ((board.D8, board.D7, board.D9),)
+encoder_handler.map = (((KC.VOLD, KC.VOLU, KC.MUTE),),)
+keyboard.modules.append(encoder_handler)
+
+if __name__ == '__main__':
+    keyboard.go()


### PR DESCRIPTION
Add support for ANAVI Arrows: an open source programmable mini hot-swappable mechanical keyboard with 4 keys, a rotary encoder, mini OLED I2C yellow-blue display and Seeed XIAO RP2040. This is an open source hardware device designed with KiCad.

Signed-off-by: Leon Anavi <leon@anavi.org>