### PR TITLE
Added more examples to the Stringy Keymaps documentation

### DIFF
--- a/docs/en/extension_stringy_keymaps.md
+++ b/docs/en/extension_stringy_keymaps.md
@@ -32,4 +32,4 @@ keyboard.extensions.append(stringyKeymaps)
 It should be noted that these are **not** ASCII. The string is **not** what
 will be sent to the computer. The examples above have no functional difference.
 
-When utilizing layer keycodes, such as `KC.MO(layer)`, it's not possible to use a string like `'MO(layer)'` instead employ the standard notation of e.g. `KC.MO(1)` in your keymap.
+When utilizing argumented keys, such as `KC.MO(layer)`, it's not possible to use a string like `'MO(layer)'` instead employ the standard notation of e.g. `KC.MO(1)` in your keymap.

--- a/docs/en/extension_stringy_keymaps.md
+++ b/docs/en/extension_stringy_keymaps.md
@@ -1,6 +1,7 @@
 # Stringy Keymaps
 
-Enables referring to keys by `'NAME'` rather than `KC.NAME`.
+Enables referring to keys by `'NAME'` rather than `KC.NAME`.\
+This extension allows for a seamless integration of both string-based key references and standard keycodes.
 
 For example:
 
@@ -12,6 +13,9 @@ from kmk.extensions.stringy_keymaps import StringyKeymaps
 
 # Indexed
 # keyboard.keymap = [[ KC['A'], KC['B'], KC['RESET'] ]]
+
+# String names mixed with normal keycodes
+# keyboard.keymap = [[ 'A' , KC.B, KC.RESET ]]
 
 # String names
 keyboard.keymap = [[ 'A' , 'B', 'RESET' ]]
@@ -27,3 +31,5 @@ keyboard.extensions.append(stringyKeymaps)
 
 It should be noted that these are **not** ASCII. The string is **not** what
 will be sent to the computer. The examples above have no functional difference.
+
+When utilizing layer keycodes, such as `KC.MO(layer)`, it's not possible to use a string like `'MO(layer)'` instead employ the standard notation of e.g. `KC.MO(1)` in your keymap.


### PR DESCRIPTION
Following this issue: 
https://github.com/KMKfw/kmk_firmware/issues/669
[Zulip Chat Topic](https://kmkfw.zulipchat.com/#narrow/stream/358347-general/topic/Do.20layers.20MO.281.29.20work.20in.20StringyKeymaps.3F)

I felt the need to update the [Stringy Keymaps documentation](http://kmkfw.io/docs/extension_stringy_keymaps/).
In it's current form the documentation does not mention that it's possible to mix and match string-based key references and standard keycodes.

I added an example showcasing this.

___

The sentence
> Enables referring to keys by 'NAME' rather than KC.NAME.

may lead users to incorrectly assume it applies to layer keycodes like `KC.MO(layer)`, resulting in confusion as it needs to still be referenced using the notation of e.g. `KC.MO(1)` rather than `MO(1)`.

I also added a note for this.



