### PR TITLE
Fixed image link in quickpin.md docs

### DIFF
--- a/docs/en/quickpin.md
+++ b/docs/en/quickpin.md
@@ -15,7 +15,7 @@ microcontrollers with only a single line change and less mistakes.
 
 ## Pro micro footprint pinout
 
-![pro micro footprint pins](./img/pro_micro_pinout.png)
+![pro micro footprint pins](../img/pro_micro_pinout.png)
 
 ## Example
 


### PR DESCRIPTION
The image `'pro_micro_pinout.png'` in the `quickpin.md` docs was linking to here: 
https://github.com/KMKfw/kmk_firmware/blob/master/docs/en/img/pro_micro_pinout.png - which does not exist.

Now it gets correctly linked to: 
https://github.com/KMKfw/kmk_firmware/blob/master/docs/img/pro_micro_pinout.png