### PR TITLE
anavi/macro-pad-12: Add ANAVI Macro Pad 12

### DIFF
--- a/boards/anavi/macro-pad-12/README.md
+++ b/boards/anavi/macro-pad-12/README.md
@@ -1,0 +1,12 @@
+# ANAVI Macro Pad 12
+
+ANAVI Macro Pad 12 is an open source, programmable mechanical keyboard with 9 hot-swappable mechanical switches, RGB WS2812B underlighting and yellow backlit a rotary encoder and [Seeed XIAO RP2040](https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html).
+
+ANAVI Macro Pad 12 has been designed with the cross platform and open source electronics design automation suite KiCad. All KiCad [files and schematics are available at GitHub](https://github.com/anavitechnology/anavi-macro-pad-12) under [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/).
+
+Extensions enabled by default:
+- [Encoder](/docs/en/encoder.md) Twist control for all the things
+- [LED](/docs/en/led.md) Light your keys up (for backlit)
+- [RGB](/docs/en/rgb.md) Light it up (for underlighting)
+- [MediaKeys](/docs/en/media_keys.md) Control volume and other media functions
+- [PEG_OLED](/docs/peg_oled_display.md) Show information on the mini OLED display

--- a/boards/anavi/macro-pad-12/code.py
+++ b/boards/anavi/macro-pad-12/code.py
@@ -1,0 +1,97 @@
+import board
+
+from kmk.extensions.LED import LED
+from kmk.extensions.media_keys import MediaKeys
+from kmk.extensions.peg_oled_Display import (
+    Oled,
+    OledData,
+    OledDisplayMode,
+    OledReactionType,
+)
+from kmk.extensions.RGB import RGB, AnimationModes
+from kmk.keys import KC
+from kmk.kmk_keyboard import KMKKeyboard
+from kmk.scanners import DiodeOrientation
+
+keyboard = KMKKeyboard()
+
+# I2C pins for the mini OLED display
+keyboard.SCL = board.D5
+keyboard.SDA = board.D4
+
+oled_ext = Oled(
+    OledData(
+        corner_one={0: OledReactionType.STATIC, 1: ['ANAVI Macro Pad 12']},
+        corner_two={0: OledReactionType.STATIC, 1: [' ']},
+        corner_three={0: OledReactionType.STATIC, 1: ['Open Source']},
+        corner_four={0: OledReactionType.STATIC, 1: [' ']},
+    ),
+    oWidth=128,
+    oHeight=64,
+    toDisplay=OledDisplayMode.TXT,
+    flip=False,
+)
+keyboard.extensions.append(oled_ext)
+
+led_ext = LED(
+    led_pin=[
+        board.D0,
+    ],
+    brightness=100,
+    brightness_step=5,
+    brightness_limit=100,
+    breathe_center=1.5,
+    animation_mode=AnimationModes.STATIC,
+    animation_speed=1,
+    user_animation=None,
+    val=100,
+)
+keyboard.extensions.append(led_ext)
+
+# WS2812B LED strips on the back
+underglow = RGB(
+    pixel_pin=board.D10,
+    num_pixels=6,
+    val_limit=100,
+    val_default=25,
+    animation_mode=AnimationModes.RAINBOW,
+)
+keyboard.extensions.append(underglow)
+
+# Neopixel on XIAO RP2040
+frontglow = RGB(
+    pixel_pin=board.NEOPIXEL,
+    num_pixels=1,
+    val_limit=100,
+    val_default=25,
+    animation_mode=AnimationModes.RAINBOW,
+)
+keyboard.extensions.append(frontglow)
+
+keyboard.col_pins = (board.D6, board.D8, board.D9)
+keyboard.row_pins = (board.D1, board.D2, board.D3, board.D7)
+keyboard.diode_orientation = DiodeOrientation.COL2ROW
+
+media_keys = MediaKeys()
+keyboard.extensions.append(media_keys)
+
+# Matrix 4x3 keymap, 12 keys in total
+keyboard.keymap = [
+    [
+        KC.N1,
+        KC.N2,
+        KC.N3,
+        KC.N4,
+        KC.N5,
+        KC.N6,
+        KC.N7,
+        KC.N8,
+        KC.N9,
+        KC.N0,
+        KC.A,
+        KC.B,
+    ]
+]
+
+if __name__ == '__main__':
+    keyboard.go()


### PR DESCRIPTION
Add support for ANAVI Macro Pad 12: an open source programmable small hot-swappable mechanical keyboard with 12 keys, mini OLED I2C display and Seeed XIAO RP2040. This is an open source hardware designed with KiCad.

Signed-off-by: Leon Anavi <leon@anavi.org>