### PR TITLE
Remove supervisor stack limit from boot.py

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -1,3 +1,0 @@
-import supervisor
-
-supervisor.set_next_stack_limit(4096 + 4096)

--- a/docs/en/flashing.md
+++ b/docs/en/flashing.md
@@ -9,9 +9,7 @@ Linux).
 Given `make` and `rsync` are available on your system (in `$PATH`), the
 following will copy the `kmk` tree to your CircuitPython device, and will copy
 the file defined as `USER_KEYMAP` as your `main.py`. It will also copy our
-`boot.py`, which allocates a larger stack size (simply - more of the device's
-RAM will be available to KMK and your keyboard config) than CircuitPython's
-default. If any of these files exist on your CircuitPython device already, they
+`boot.py`. If any of these files exist on your CircuitPython device already, they
 will be overwritten without a prompt.
 
 If you get permissions errors here, **don't run make as root or with sudo**. See


### PR DESCRIPTION
That awful hack is finally no longer necessary.

obsoletes #656
resolves #655