### PR TITLE
Without this, when I set keyboard.keymap I have random memory error.

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -1,0 +1,3 @@
+import supervisor
+
+supervisor.set_next_stack_limit(4096 + 4096)

--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -10,6 +10,7 @@ from kmk.consts import UnicodeMode
 from kmk.key_validators import key_seq_sleep_validator, unicode_mode_key_validator
 from kmk.types import UnicodeModeKeyMeta
 from kmk.utils import Debug
+import gc
 
 # Type aliases / forward declaration; can't use the proper types because of circular imports.
 Keyboard = object
@@ -424,6 +425,7 @@ class KeyAttrDict:
         if len(self.__cache[-1]) >= self.__partition_size:
             self.__cache.append({})
         self.__cache[-1][name] = key
+        gc.collect()
         return key
 
     def __getattr__(self, name: str):


### PR DESCRIPTION
I'm not sure if I do a good thing, but without it, I can't run it on nice!nano without a memory error.
I need to bring back supervisor in boot.py and add a gc.collect() somewhere in keys construction.

In my code I initialize split keyboard with Bluetooth +
Add leds and oled display +
Add code for multimedia and mouse key.

I have two scanner (matrix and RotaryioEncoder)

Then set keymap with base, raise, lower set (64+4 key) and sometimes I have memory error. 

After this modification, just before calling keyboard.go,  gc.mem_free() report 15k

Note: I try to add a new board, avalanche (https://github.com/vlkv/avalanche)
Later (After fixing the memory problem, I will make a pull for the board.



