### PR TITLE
Set encoder resolution on Anavi boards

### DIFF
--- a/boards/anavi/knob1/code.py
+++ b/boards/anavi/knob1/code.py
@@ -15,6 +15,7 @@ knob.extensions.append(media_keys)
 
 # Rotary encoder that also acts as a key
 encoder_handler = EncoderHandler()
+encoder_handler.divisor = 2
 encoder_handler.pins = ((board.D1, board.D2, board.D0),)
 encoder_handler.map = (((KC.VOLD, KC.VOLU, KC.MUTE),),)
 knob.modules.append(encoder_handler)

--- a/boards/anavi/knobs3/code.py
+++ b/boards/anavi/knobs3/code.py
@@ -15,6 +15,7 @@ knob.extensions.append(media_keys)
 
 # Rotary encoders that also acts as keys
 encoder_handler = EncoderHandler()
+encoder_handler.divisor = 2
 encoder_handler.pins = (
     (board.D1, board.D2, board.D0),
     (board.D9, board.D10, board.D3),

--- a/boards/anavi/macro-pad-10/code.py
+++ b/boards/anavi/macro-pad-10/code.py
@@ -78,6 +78,7 @@ keyboard.keymap = [
 
 # Rotary encoder that also acts as a key
 encoder_handler = EncoderHandler()
+encoder_handler.divisor = 2
 encoder_handler.pins = ((board.D8, board.D7, board.D9),)
 encoder_handler.map = (((KC.VOLD, KC.VOLU, KC.MUTE),),)
 keyboard.modules.append(encoder_handler)


### PR DESCRIPTION
With the divisor set to two the encoders work much smoother on the Anavi Knobs 1 and 3 and the MacroPad10.