### PR TITLE
Feature oneshot stacking

### DIFF
--- a/kmk/modules/oneshot.py
+++ b/kmk/modules/oneshot.py
@@ -1,5 +1,6 @@
 from kmk.keys import make_argumented_key
 from kmk.modules.holdtap import ActivationType, HoldTap, HoldTapKeyMeta
+from kmk.modules.layers import LayerKeyMeta
 from kmk.utils import Debug
 
 debug = Debug(__name__)
@@ -31,7 +32,9 @@ class OneShot(HoldTap):
             if key == current_key:
                 continue
 
-            if isinstance(current_key.meta, OneShotKeyMeta):
+            if (isinstance(current_key.meta, OneShotKeyMeta)) or (
+                isinstance(current_key.meta, LayerKeyMeta)
+            ):
                 keyboard.cancel_timeout(state.timeout_key)
                 if key.meta.tap_time is None:
                     tap_time = self.tap_time
@@ -50,12 +53,13 @@ class OneShot(HoldTap):
             elif state.activated == ActivationType.INTERRUPTED:
                 if is_pressed:
                     send_buffer = True
-                keyboard.set_timeout(0, lambda k=key: self.ht_released(k, keyboard))
+                self.key_buffer.insert(0, (0, key, False))
 
         if send_buffer:
             self.key_buffer.append((int_coord, current_key, is_pressed))
-            keyboard.set_timeout(0, lambda: self.send_key_buffer(keyboard))
             current_key = None
+
+        self.send_key_buffer(keyboard)
 
         return current_key
 

--- a/tests/keyboard_test.py
+++ b/tests/keyboard_test.py
@@ -74,7 +74,14 @@ class KeyboardTest:
                 is_pressed = e[1]
                 self.pins[key_pos].value = is_pressed
                 self.do_main_loop()
-        self.keyboard._main_loop()
+
+        # wait up to 10s for delayed actions to resolve, if there are any
+        timeout = time.time_ns() + 10 * 1_000_000_000
+        while timeout > time.time_ns():
+            self.do_main_loop()
+            if not self.keyboard._timeouts and not self.keyboard._resume_buffer:
+                break
+        assert timeout > time.time_ns(), 'infinite loop detected'
 
         matching = True
         for i in range(max(len(hid_reports), len(assert_reports))):

--- a/tests/test_hold_tap.py
+++ b/tests/test_hold_tap.py
@@ -4,17 +4,16 @@ from kmk.keys import KC
 from kmk.modules.holdtap import HoldTapRepeat
 from kmk.modules.layers import Layers
 from kmk.modules.modtap import ModTap
-from kmk.modules.oneshot import OneShot
 from tests.keyboard_test import KeyboardTest
 
 
 class TestHoldTap(unittest.TestCase):
     def test_holdtap(self):
         keyboard = KeyboardTest(
-            [Layers(), ModTap(), OneShot()],
+            [Layers(), ModTap()],
             [
-                [KC.MT(KC.A, KC.LCTL), KC.LT(1, KC.B), KC.C, KC.D, KC.OS(KC.E)],
-                [KC.N1, KC.N2, KC.N3, KC.N4, KC.N5],
+                [KC.MT(KC.A, KC.LCTL), KC.LT(1, KC.B), KC.C, KC.D],
+                [KC.N1, KC.N2, KC.N3, KC.N4],
             ],
             debug_enabled=False,
         )
@@ -349,76 +348,3 @@ class TestHoldTap(unittest.TestCase):
             [(2, True), (2, False), (2, True), t_after, (2, False)],
             [{KC.A}, {}, {KC.B}, {}],
         )
-
-    def test_oneshot(self):
-        keyboard = KeyboardTest(
-            [Layers(), ModTap(), OneShot()],
-            [
-                [
-                    KC.MT(KC.A, KC.LCTL),
-                    KC.LT(1, KC.B),
-                    KC.C,
-                    KC.D,
-                    KC.OS(KC.E, tap_time=50),
-                ],
-                [KC.N1, KC.N2, KC.N3, KC.N4, KC.N5],
-            ],
-            debug_enabled=False,
-        )
-        t_within = 40
-        t_after = 60
-
-        # OS
-        keyboard.test(
-            'OS timed out',
-            [(4, True), (4, False), t_after],
-            [{KC.E}, {}],
-        )
-
-        keyboard.test(
-            'OS interrupt within tap time',
-            [(4, True), (4, False), t_within, (3, True), (3, False)],
-            [{KC.E}, {KC.D, KC.E}, {KC.E}, {}],
-        )
-
-        keyboard.test(
-            'OS interrupt, multiple within tap time',
-            [(4, True), (4, False), (3, True), (3, False), (2, True), (2, False)],
-            [{KC.E}, {KC.D, KC.E}, {KC.E}, {}, {KC.C}, {}],
-        )
-
-        keyboard.test(
-            'OS interrupt, multiple interleaved',
-            [(4, True), (4, False), (3, True), (2, True), (2, False), (3, False)],
-            [{KC.E}, {KC.D, KC.E}, {KC.D}, {KC.C, KC.D}, {KC.D}, {}],
-        )
-
-        keyboard.test(
-            'OS interrupt, multiple interleaved',
-            [(4, True), (4, False), (3, True), (2, True), (3, False), (2, False)],
-            [{KC.E}, {KC.D, KC.E}, {KC.D}, {KC.C, KC.D}, {KC.C}, {}],
-        )
-
-        keyboard.test(
-            'OS interrupt within tap time, hold',
-            [(4, True), (3, True), (4, False), t_after, (3, False)],
-            [{KC.E}, {KC.D, KC.E}, {KC.D}, {}],
-        )
-
-        keyboard.test(
-            'OS hold with multiple interrupt keys',
-            [
-                (4, True),
-                t_within,
-                (3, True),
-                (3, False),
-                (2, True),
-                (2, False),
-                (4, False),
-            ],
-            [{KC.E}, {KC.D, KC.E}, {KC.E}, {KC.C, KC.E}, {KC.E}, {}],
-        )
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -1,0 +1,83 @@
+import unittest
+
+from kmk.keys import KC
+from kmk.modules.oneshot import OneShot
+from tests.keyboard_test import KeyboardTest
+
+
+class TestHoldTap(unittest.TestCase):
+    def test_oneshot(self):
+        keyboard = KeyboardTest(
+            [OneShot()],
+            [
+                [
+                    KC.A,
+                    KC.B,
+                    KC.C,
+                    KC.D,
+                    KC.OS(KC.E, tap_time=50),
+                    KC.OS(KC.F, tap_time=50),
+                ],
+                [KC.N0, KC.N1, KC.N2, KC.N3, KC.N4],
+            ],
+            debug_enabled=False,
+        )
+        t_within = 40
+        t_after = 60
+
+        keyboard.test(
+            'OS timed out',
+            [(4, True), (4, False), t_after],
+            [{KC.E}, {}],
+        )
+
+        keyboard.test(
+            'OS interrupt within tap time',
+            [(4, True), (4, False), t_within, (3, True), (3, False)],
+            [{KC.E}, {KC.D, KC.E}, {KC.E}, {}],
+        )
+
+        keyboard.test(
+            'OS interrupt, multiple within tap time',
+            [(4, True), (4, False), (3, True), (3, False), (2, True), (2, False)],
+            [{KC.E}, {KC.D, KC.E}, {KC.E}, {}, {KC.C}, {}],
+        )
+
+        keyboard.test(
+            'OS interrupt, multiple interleaved',
+            [(4, True), (4, False), (3, True), (2, True), (2, False), (3, False)],
+            [{KC.E}, {KC.D, KC.E}, {KC.D}, {KC.C, KC.D}, {KC.D}, {}],
+        )
+
+        keyboard.test(
+            'OS interrupt, multiple interleaved',
+            [(4, True), (4, False), (3, True), (2, True), (3, False), (2, False)],
+            [{KC.E}, {KC.D, KC.E}, {KC.D}, {KC.C, KC.D}, {KC.C}, {}],
+        )
+
+        keyboard.test(
+            'OS interrupt within tap time, hold',
+            [(4, True), (3, True), (4, False), t_after, (3, False)],
+            [{KC.E}, {KC.D, KC.E}, {KC.D}, {}],
+        )
+
+        keyboard.test(
+            'OS interrupt within tap time, hold',
+            [(4, True), (4, False), (3, True), t_after, (3, False)],
+            [{KC.E}, {KC.D, KC.E}, {KC.E}, {}],
+        )
+
+
+        keyboard.test(
+            'OS hold with multiple interrupt keys',
+            [
+                (4, True),
+                t_within,
+                (3, True),
+                (3, False),
+                (2, True),
+                (2, False),
+                (4, False),
+            ],
+            [{KC.E}, {KC.D, KC.E}, {KC.E}, {KC.C, KC.E}, {KC.E}, {}],
+        )

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -1,6 +1,7 @@
 import unittest
 
 from kmk.keys import KC
+from kmk.modules.layers import Layers
 from kmk.modules.oneshot import OneShot
 from tests.keyboard_test import KeyboardTest
 
@@ -8,17 +9,17 @@ from tests.keyboard_test import KeyboardTest
 class TestHoldTap(unittest.TestCase):
     def test_oneshot(self):
         keyboard = KeyboardTest(
-            [OneShot()],
+            [Layers(), OneShot()],
             [
                 [
-                    KC.A,
-                    KC.B,
+                    KC.OS(KC.MO(1), tap_time=50),
+                    KC.MO(1),
                     KC.C,
                     KC.D,
                     KC.OS(KC.E, tap_time=50),
                     KC.OS(KC.F, tap_time=50),
                 ],
-                [KC.N0, KC.N1, KC.N2, KC.N3, KC.N4],
+                [KC.N0, KC.N1, KC.N2, KC.N3, KC.OS(KC.LSFT, tap_time=50), KC.TRNS],
             ],
             debug_enabled=False,
         )
@@ -93,7 +94,7 @@ class TestHoldTap(unittest.TestCase):
                 (3, True),
                 (3, False),
             ],
-            [{KC.E}, {KC.E, KC.F}, {KC.E, KC.F, KC.D}, {KC.E, KC.F}, {KC.F}, {}],
+            [{KC.E}, {KC.E, KC.F}, {KC.E, KC.F, KC.D}, {KC.E, KC.F}, {KC.E}, {}],
         )
 
         keyboard.test(
@@ -108,4 +109,39 @@ class TestHoldTap(unittest.TestCase):
                 (3, False),
             ],
             [{KC.E}, {KC.E, KC.F}, {KC.E}, {}, {KC.D}, {}],
+        )
+
+        keyboard.test(
+            'OS stacking with OS-layer',
+            [
+                (0, True),
+                (0, False),
+                (4, True),
+                (4, False),
+                (1, True),
+                (1, False),
+            ],
+            [{KC.LSFT}, {KC.LSFT, KC.N1}, {KC.LSFT}, {}],
+        )
+
+        keyboard.test(
+            'OS stacking with layer change',
+            [
+                (1, True),
+                (4, True),
+                (4, False),
+                (1, False),
+                (4, True),
+                (4, False),
+                (2, True),
+                (2, False),
+            ],
+            [
+                {KC.LSFT},
+                {KC.LSFT, KC.E},
+                {KC.LSFT, KC.E, KC.C},
+                {KC.LSFT, KC.E},
+                {KC.LSFT},
+                {},
+            ],
         )

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -67,7 +67,6 @@ class TestHoldTap(unittest.TestCase):
             [{KC.E}, {KC.D, KC.E}, {KC.E}, {}],
         )
 
-
         keyboard.test(
             'OS hold with multiple interrupt keys',
             [
@@ -80,4 +79,33 @@ class TestHoldTap(unittest.TestCase):
                 (4, False),
             ],
             [{KC.E}, {KC.D, KC.E}, {KC.E}, {KC.C, KC.E}, {KC.E}, {}],
+        )
+
+        keyboard.test(
+            'OS stacking within timeout reset',
+            [
+                (4, True),
+                (4, False),
+                t_within,
+                (5, True),
+                (5, False),
+                t_within,
+                (3, True),
+                (3, False),
+            ],
+            [{KC.E}, {KC.E, KC.F}, {KC.E, KC.F, KC.D}, {KC.E, KC.F}, {KC.F}, {}],
+        )
+
+        keyboard.test(
+            'OS stacking timed out',
+            [
+                (4, True),
+                (4, False),
+                (5, True),
+                (5, False),
+                t_after,
+                (3, True),
+                (3, False),
+            ],
+            [{KC.E}, {KC.E, KC.F}, {KC.E}, {}, {KC.D}, {}],
         )


### PR DESCRIPTION
resolves #427
resolves #535

Oneshot keys automatically stack and reset timeouts. I'm not going to implement an option to toggle that off, unless there's a real world application / request.