### PR TITLE
Add linter format exception for `kb.py`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ per-file-ignores =
 # your imports in whatever order you want
 	user_keymaps/**/*.py: E131,F401,E501,E241,E131,BLK100,I003
 	boards/**/main.py: E131,F401,E501,E241,E131,BLK100,I003
+	boards/**/kb.py: E131,F401,E501,E241,E131,BLK100,I003
 	tests/test_data/keymaps/**/*.py: F401,E501
 
 [isort]


### PR DESCRIPTION
Apply the the same linter format exceptions to `kb.py` as for `main.py`.