### PR TITLE
Removed erroneous extra ".__iter__()" in KeyAttrDict iterator

### DIFF
--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -435,7 +435,7 @@ class KeyAttrDict:
 
     def __iter__(self):
         for partition in self.__cache:
-            for name in partition.__iter__():
+            for name in partition:
                 yield name
 
     def __setitem__(self, name: str, key: Key):


### PR DESCRIPTION
I propose to remove the extra ".__iter__()" in KeyAttrDict iterator: iterating elements in the partition already implicitly calls its __iter__ method.

Actually when I use the dictionary iterator with this extra call, it triggers an error since an iterator does not have an iterator. This is now no longer the case.

For the story, I had to use this iterator to copy the dictionary and stumbled upon this issue.
Most likely this iterator is not being used in current code (or if it is, how could it be working?).