### PR TITLE
Resolve invalid keys to KC.NO instead of ValueError

### DIFF
--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -475,7 +475,9 @@ class KeyAttrDict:
                 break
 
         if not maybe_key:
-            raise ValueError(f'Invalid key: {name}')
+            if debug.enabled:
+                debug(f'Invalid key: {name}')
+            return KC.NO
 
         if debug.enabled:
             debug(f'{name}: {maybe_key}')

--- a/kmk/modules/holdtap.py
+++ b/kmk/modules/holdtap.py
@@ -54,7 +54,7 @@ class HoldTap(Module):
     def __init__(self):
         self.key_buffer = []
         self.key_states = {}
-        if not KC.get('HT'):
+        if KC.get('HT') == KC.NO:
             make_argumented_key(
                 validator=HoldTapKeyMeta,
                 names=('HT',),

--- a/kmk/modules/string_substitution.py
+++ b/kmk/modules/string_substitution.py
@@ -42,12 +42,11 @@ class Phrase:
         self._characters: list[Character] = []
         self._index: int = 0
         for char in string:
-            try:
-                key_code = KC[char]
-                shifted = char.isupper() or key_code.has_modifiers == {2}
-                self._characters.append(Character(key_code, shifted))
-            except ValueError:
+            key_code = KC[char]
+            if key_code == KC.NO:
                 raise ValueError(f'Invalid character in dictionary: {char}')
+            shifted = char.isupper() or key_code.has_modifiers == {2}
+            self._characters.append(Character(key_code, shifted))
 
     def next_character(self) -> None:
         '''Increment the current index for this phrase'''

--- a/tests/test_kmk_keys.py
+++ b/tests/test_kmk_keys.py
@@ -123,12 +123,10 @@ class TestKeys_dot(unittest.TestCase):
         assert primary_key is secondary_key
 
     def test_invalid_key_upper(self):
-        with self.assertRaises(ValueError):
-            KC.INVALID_KEY
+        assert KC.INVALID_KEY == KC.NO
 
     def test_invalid_key_lower(self):
-        with self.assertRaises(ValueError):
-            KC.invalid_key
+        assert KC.invalid_key == KC.NO
 
     def test_custom_key(self):
         created = make_key(
@@ -168,12 +166,10 @@ class TestKeys_index(unittest.TestCase):
         assert upper_key is lower_key
 
     def test_invalid_key_upper(self):
-        with self.assertRaises(ValueError):
-            KC['NOT_A_VALID_KEY']
+        assert KC.INVALID_KEY == KC.NO
 
     def test_invalid_key_lower(self):
-        with self.assertRaises(ValueError):
-            KC['not_a_valid_key']
+        assert KC.invalid_key == KC.NO
 
     def test_custom_key(self):
         created = make_key(
@@ -218,10 +214,10 @@ class TestKeys_get(unittest.TestCase):
         assert primary_key is secondary_key
 
     def test_invalid_key_upper(self):
-        assert KC.get('INVALID_KEY') is None
+        assert KC.get('INVALID_KEY') is KC.NO
 
     def test_invalid_key_lower(self):
-        assert KC.get('not_a_valid_key') is None
+        assert KC.get('not_a_valid_key') is KC.NO
 
     def test_custom_key(self):
         created = make_key(


### PR DESCRIPTION
Don't crash the firmware just because there's a typo or key from an unused module in the keymap.
part of #719