### PR TITLE
Add boilerplate method for board configuration at boot time

### DIFF
--- a/docs/en/boot.md
+++ b/docs/en/boot.md
@@ -1,65 +1,161 @@
 # boot.py
-`boot.py` lives in the root of your keyboard when mounted as a storage device. 
-There is a more detailed explanation in the [circuit python docs](https://docs.circuitpython.org/en/latest/README.html), 
+`boot.py` lives in the root of your keyboard when mounted as a storage device.
+There is a more detailed explanation in the [circuit python docs](https://docs.circuitpython.org/en/latest/README.html),
 however there are some common use cases for your keyboard listed here.
 
-## Hiding device storage
-You can hide your device from showing up as a USB storage by default (this can be overridden 
-at startup if desired, per the example code further down this page).
+
+## KMKs builtin boot configurator
+
+KMK ships with a handy boot configuration function that does all the hard work
+for you.
+The interface may change in the future, but there is a safety mechanism in
+place: if anything goes wrong, it'll boot into a mountable and debuggable
+configuration.
+
+
+###  Signature
 
 ```python
-storage.disable_usb_drive()
+from kmk.bootcfg import bootcfg
+
+bootcfg(
+    # required:
+    sense: [microcontroller.Pin, digitalio.DigitalInOut],
+    # optional:
+    source: Optional[microcontroller.Pin, digitalio.DigitalInOut] = None,
+    boot_device: int = 0,
+    cdc: bool = True,
+    consumer_control: bool = True,
+    keyboard: bool = True,
+    midi: bool = True,
+    mouse: bool = True,
+    storage: bool = True,
+    usb_id: Optional[tuple[str, str]] = None,
+    **kwargs,
+) -> bool
+```
+All optional parameters are set to reflect common Circuipython defaults, however
+they may differ from board specific defaults.
+
+#### Sense and Source
+`sense` and `source` both accept either uninitialized `Pin`s or `DigitalInOut`
+instances for maximum flexibility.
+The boot configuration is only applied if `sense` reads `True` or "high", and
+skipped if it reads `False` or "low".
+
+
+#### boot_device
+Boot HID device configuration for `usb_hid`, see the [usb_hid documentation](https://docs.circuitpython.org/en/latest/shared-bindings/usb_hid/index.html#usb_hid.enable)
+for details.
+
+
+#### cdc
+This will enable or disable the usb endpoint for the serial console with REPL.
+
+
+#### consumer_control
+Enable the HID endpoint for consumer control reports. Those are extra keys for
+things like multimedia control and browser shortcuts.
+
+
+#### keyboard
+Enable the keyboard HID endpoint. Why would you disable that? For a split half
+that isn't connected to USB and needs extra memory for a massive display maybe?
+
+
+#### midi
+It's MIDI over USB. Enabled by default in Circuitpython, but most keyboards don't use it.
+
+
+#### mouse
+Enable the HID endpoint for a pointing device. A pointing device, or mouse, is
+like a keyboard, but with continous instead of binary keys... which also go
+sideways.
+
+
+#### storage
+Disable storage if you don't want your computer to go "there's a new thumb drive
+I have to mount!" everytime you plug in your keyboard.
+
+
+#### usb_id
+A recent addition to Circuitpython 8 is the ability to give your keyboard an
+identity other than "MCU board manufacturer" - "Circuitpython device".
+
+
+#### return value
+`bootcfg` returns `true` if boot configuration applied successfully and `false`
+if it was skipped, in case you want to use the sense pin mechanism for other
+custom boot configurations.
+Any *unexpected* errors are intentionally not handled, in order to be recorded
+to the `boot_out.txt` file for easier debugging.
+
+
+### Example 1
+* diode direction from columns to rows,
+* disabled storage
+* disabled midi
+* disabled mouse
+* custom vendor and device names
+
+```python
+import board
+
+from kmk.bootcfg import bootcfg
+
+bootcfg(
+    sense=board.GP0,  # column
+    source=board.GP8, # row
+    midi=False,
+    mouse=False,
+    storage=False,
+    usb_id=('KMK Keyboards', 'Custom 60% Ergo'),
+)
+
+```
+*Tip*: for a diode direction from rows to columns, switch row and column gpios
+when assigning them to sense and source.
+
+
+### Example 2
+Dedicated switch to disable boot configuration, connected to ground:
+
+```python
+import board
+
+from kmk.bootcfg import bootcfg
+
+bootcfg(sense=board.GP22, ...)
 ```
 
-## Using your keyboard before the OS loads
-You can make your keyboard work in your computer's BIOS and bootloader (useful if you dual-boot).
+### Example 3
+Shut-in mode:
+**Always** apply boot configuration and disable any contact to the outside
+world.
+**Caution**: this an example for a `DigitalInOut` sense pin, and probably an
+unwise thing to do in actuality.
 
 ```python
-usb_hid.enable(boot_device=1)
-```
-
-## Disabling serial communication
-By default, you can connect to your board's serial console, which can be useful for debugging, 
-but may not be desired for everyday use.
-
-```python
-# Equivalent to usb_cdc.enable(console=False, data=False)
-usb_cdc.disable()
-```
-
-## Example code
-Below is a fully working example, which disables USB storage, CDC and enables BIOS mode.
-
-```python
-import supervisor
 import board
 import digitalio
-import storage
-import usb_cdc
-import usb_hid
 
-from kb import KMKKeyboard
-from kmk.scanners import DiodeOrientation
+from kmk.bootcfg import bootcfg
 
+sense = digitalio.DigitalInOut(board.GP42)
+sense.direction = digitalio.Direction.OUTPUT
+sense = True
 
-# If this key is held during boot, don't run the code which hides the storage and disables serial
-# This will use the first row/col pin. Feel free to change it if you want it to be another pin
-col = digitalio.DigitalInOut(KMKKeyboard.col_pins[0])
-row = digitalio.DigitalInOut(KMKKeyboard.row_pins[0])
-
-if KMKKeyboard.diode_orientation == DiodeOrientation.COLUMNS:
-    col.switch_to_output(value=True)
-    row.switch_to_input(pull=digitalio.Pull.DOWN)
-else:
-    col.switch_to_input(pull=digitalio.Pull.DOWN)
-    row.switch_to_output(value=True)
-
-if not row.value:
-    storage.disable_usb_drive()
-    # Equivalent to usb_cdc.enable(console=False, data=False)
-    usb_cdc.disable()
-    usb_hid.enable(boot_device=1)
-
-row.deinit()
-col.deinit()
+bootcfg(
+    sense=sense,
+    cdc=False,
+    consumer_control=False,
+    keyboard=False,
+    midi=False,
+    mouse=False,
+    storage=False,
+)
 ```
+
+We generally advise against importing your keyboard definition and using
+rows/columns to define sense and source pins, because that essentially loads
+the firmware twice, almost doubling boot times.

--- a/docs/en/boot.md
+++ b/docs/en/boot.md
@@ -37,11 +37,28 @@ bootcfg(
 All optional parameters are set to reflect common Circuipython defaults, however
 they may differ from board specific defaults.
 
-#### Sense and Source
-`sense` and `source` both accept either uninitialized `Pin`s or `DigitalInOut`
-instances for maximum flexibility.
+
+#### Sense
+`sense` accepts either uninitialized `Pin`s or `DigitalInOut` instances for
+maximum flexibility.
 The boot configuration is only applied if `sense` reads `True` or "high", and
 skipped if it reads `False` or "low".
+If `sense` is an uninitialized `Pin`, it'll be configured as pulled-up input; it
+wont be further configured if it is a `DigitalInOut`.
+
+
+#### Source
+`source` accepts either uninitialized `Pin`s or `DigitalInOut` instances for
+maximum flexibility.
+It's the "source" of the test voltage to be read by the sense pin.
+If `source` is an uninitialized `Pin`, it'll be configured as a "low" output; it
+wont be further configured if it is a `DigitalInOut`.
+
+Common matrix and direct pin configurations (see also the examples below):
+|diode_orientation |sense pin  |source pin |
+|`COL2ROW`         |column     |row        |
+|`ROW2COL`         |row        |column     |
+|direct pin        |direct pin |`None`     |
 
 
 #### boot_device

--- a/docs/en/boot.md
+++ b/docs/en/boot.md
@@ -55,7 +55,9 @@ If `source` is an uninitialized `Pin`, it'll be configured as a "low" output; it
 wont be further configured if it is a `DigitalInOut`.
 
 Common matrix and direct pin configurations (see also the examples below):
+
 |diode_orientation |sense pin  |source pin |
+|------------------|-----------|-----------|
 |`COL2ROW`         |column     |row        |
 |`ROW2COL`         |row        |column     |
 |direct pin        |direct pin |`None`     |

--- a/kmk/bootcfg.py
+++ b/kmk/bootcfg.py
@@ -1,0 +1,81 @@
+try:
+    from typing import Optional
+except ImportError:
+    pass
+
+import digitalio
+import microcontroller
+import usb_hid
+
+
+def bootcfg(
+    sense: [microcontroller.Pin, digitalio.DigitalInOut],
+    source: Optional[microcontroller.Pin, digitalio.DigitalInOut] = None,
+    boot_device: int = 0,
+    cdc: bool = True,
+    consumer_control: bool = True,
+    keyboard: bool = True,
+    midi: bool = True,
+    mouse: bool = True,
+    storage: bool = True,
+    usb_id: Optional[tuple[str, str]] = None,
+    **kwargs,
+) -> bool:
+
+    if len(kwargs):
+        print('unknown option', kwargs)
+
+    if isinstance(sense, microcontroller.Pin):
+        sense = digitalio.DigitalInOut(sense)
+        sense.direction = digitalio.Direction.INPUT
+        sense.pull = digitalio.Pull.UP
+
+    if isinstance(source, microcontroller.Pin):
+        source = digitalio.DigitalInOut(source)
+        source.direction = digitalio.Direction.OUTPUT
+        source.value = False
+
+    # sense pulled low -> skip boot configuration
+    if not sense.value:
+        return False
+
+    # configure HID devices
+    devices = []
+    if keyboard:
+        devices.append(usb_hid.Device.KEYBOARD)
+    if mouse:
+        devices.append(usb_hid.Device.MOUSE)
+    if consumer_control:
+        devices.append(usb_hid.Device.CONSUMER_CONTROL)
+    if devices:
+        usb_hid.enable(devices, boot_device)
+    else:
+        usb_hid.disable()
+
+    # configure midi over usb
+    if not midi:
+        import usb_midi
+
+        usb_midi.disable()
+
+    # configure usb vendor and product id
+    if usb_id is not None:
+        import supervisor
+
+        if hasattr(supervisor, 'set_usb_identification'):
+            supervisor.set_usb_identification(*usb_id)
+
+    # Entries for cdc (REPL) and storage are intentionally evaluated last to
+    # ensure the board is debuggable, mountable and rescueable, in case any of
+    # the previous code throws an exception.
+    if not cdc:
+        import usb_cdc
+
+        usb_cdc.disable()
+
+    if not storage:
+        import storage
+
+        storage.disable_usb_drive()
+
+    return True


### PR DESCRIPTION
Just an idea how to streamline (read: user-proof) common configurations that happen at boot time.
It this form, it would still have to be manually called in `boot.py`:
```python
import board
from kmk.bootcfg import bootcfg

# Check single pin connected to ground, maybe hardware on-board or direct pin
# Always enable serial console.
bootcfg(board.GP0, no_cdc=False)
# Check a matrix key at position whatever. Diode orientation is fixed from first to second parameter.
# Enable midi.
bootcfg(board.GP9, board.GP0, no_midi=False)
```