### PR TITLE
Add deinit method to modules and extensions

### DIFF
--- a/kmk/extensions/__init__.py
+++ b/kmk/extensions/__init__.py
@@ -49,3 +49,6 @@ class Extension:
 
     def on_powersave_disable(self, keyboard):
         raise NotImplementedError
+
+    def deinit(self, keyboard):
+        pass

--- a/kmk/extensions/rgb.py
+++ b/kmk/extensions/rgb.py
@@ -247,6 +247,10 @@ class RGB(Extension):
     def on_powersave_disable(self, sandbox):
         self._do_update()
 
+    def deinit(self, sandbox):
+        for pixel in self.pixels:
+            pixel.deinit()
+
     def set_hsv(self, hue, sat, val, index):
         '''
         Takes HSV values and displays it on a single LED/Neopixel

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -500,6 +500,20 @@ class KMKKeyboard:
                 if debug.enabled:
                     debug(f'Error in {ext}.powersave_disable: {err}')
 
+    def deinit(self) -> None:
+        for module in self.modules:
+            try:
+                module.deinit(self)
+            except Exception as err:
+                if debug.enabled:
+                    debug(f'Error in {module}.deinit: {err}')
+        for ext in self.extensions:
+            try:
+                ext.deinit(self.sandbox)
+            except Exception as err:
+                if debug.enabled:
+                    debug(f'Error in {ext}.deinit: {err}')
+
     def go(self, hid_type=HIDModes.USB, secondary_hid_type=None, **kwargs) -> None:
         self._init(hid_type=hid_type, secondary_hid_type=secondary_hid_type, **kwargs)
         try:
@@ -508,6 +522,7 @@ class KMKKeyboard:
         finally:
             debug('Unexpected error: cleaning up')
             self._deinit_hid()
+            self.deinit()
 
     def _init(
         self,

--- a/kmk/modules/__init__.py
+++ b/kmk/modules/__init__.py
@@ -41,3 +41,6 @@ class Module:
 
     def on_powersave_disable(self, keyboard):
         raise NotImplementedError
+
+    def deinit(self, keyboard):
+        pass


### PR DESCRIPTION
Adds a `deinit` method that gets called when `keyboard.go()` terminates. Allows to implement cleanup, like hardware deinit, or writing persistant state to flash.