### PR TITLE
Speed up and reduce memory footprint of debug template

### DIFF
--- a/kmk/utils.py
+++ b/kmk/utils.py
@@ -16,8 +16,10 @@ class Debug:
     def __init__(self, name: str = __name__):
         self.name = name
 
-    def __call__(self, message: str) -> None:
-        print(f'{ticks_ms()} {self.name}: {message}')
+    def __call__(self, *message: str) -> None:
+        print(ticks_ms(), end=' ')
+        print(self.name, end=': ')
+        print(*message)
 
     @property
     def enabled(self) -> bool:


### PR DESCRIPTION
This is one of this stupid "lets see what happens" hacks that turn out to be unexpectedly effective.
Makes debug messages so much faster (~1ms instead of ~4ms), reduces static memory consumption by ~100k, and even reduces dynamic memory consumption because there's no re-formatting-string-allocation going on.

There's an argument to be had about removing f-strings where possible and replacing them with staticly formatted equivalents.