### PR TITLE
Denoise core debugging and improve improve performance.

### DIFF
--- a/kmk/utils.py
+++ b/kmk/utils.py
@@ -1,3 +1,8 @@
+try:
+    from typing import Optional
+except ImportError:
+    pass
+
 from supervisor import ticks_ms
 
 
@@ -16,10 +21,12 @@ class Debug:
     def __init__(self, name: str = __name__):
         self.name = name
 
-    def __call__(self, *message: str) -> None:
+    def __call__(self, *message: str, name: Optional[str] = None) -> None:
+        if not name:
+            name = self.name
         print(ticks_ms(), end=' ')
-        print(self.name, end=': ')
-        print(*message)
+        print(name, end=': ')
+        print(*message, sep='')
 
     @property
     def enabled(self) -> bool:


### PR DESCRIPTION
* Declutter and denoise the debug output in general.
* Avoid f-strings. They're nice to look at, but use a lot of ROM, RAM, and time during formatting.
* Remove all "debug" information from `KMKKeyboard.__repr__`. It's printed out once at init and the info it gave was useless at that point. Even more free memory.
* Add a memory footprint debug info after initialization.