### PR TITLE
Added quickpin support for Frood RP2040 Microcontroller

### DIFF
--- a/kmk/quickpin/pro_micro/frood.py
+++ b/kmk/quickpin/pro_micro/frood.py
@@ -1,0 +1,33 @@
+import board
+
+pinout = [
+    board.TX,
+    board.RX,
+    None,  # GND
+    None,  # GND
+    board.D2,
+    board.D3,
+    board.D4,
+    board.D5,
+    board.D6,
+    board.D7,
+    board.D8,
+    board.D9,
+    board.D12,
+    board.D13,
+    board.D14,
+    board.D15,
+    board.D16,
+    board.D21,
+    board.MOSI,
+    board.MISO,
+    board.SCK,
+    board.D26,
+    board.D27,
+    board.D28,
+    board.D29,
+    None,  # 3.3v
+    None,  # RST
+    None,  # GND
+    None,  # RAW
+]


### PR DESCRIPTION
Added quickpin support for Frood RP2040 Microcontroller by 42keebs (https://github.com/piit79/Frood)

Differs from other controllers supported by quickpin because it has 5 extra pins on the bottom like the Elite Pi. Unlike Elite Pi, it is supported by circuitpython, although the firmware should work on the Elite Pi and similar microcontrollers as well.