### PR TITLE
Fixed user_keymaps dead links

### DIFF
--- a/docs/ja/Getting_Started.md
+++ b/docs/ja/Getting_Started.md
@@ -84,7 +84,7 @@ QMK チームが提供している手配線キーボード用の[ガイド](http
 
 RGB や分裂型などの機能を楽しめたい場合は、ビルトイン[モジュール](modules.md)と[拡張機能](extensions.md)を見てみてください！
 
-私たちが提供する、いろんな [ユーザー事例](https://github.com/KMKfw/user_keymaps)や[ドキュメント](https://github.com/KMKfw/kmk_firmware/tree/master/docs)からアイデアを得ることもできます。
+私たちが提供する、いろんな [ユーザー事例](https://github.com/KMKfw/kmk_firmware/tree/master/user_keymaps)や[ドキュメント](https://github.com/KMKfw/kmk_firmware/tree/master/docs)からアイデアを得ることもできます。
 
 
 ## ヘルプ/サポート

--- a/docs/ptBR/Getting_Started.md
+++ b/docs/ptBR/Getting_Started.md
@@ -110,7 +110,7 @@ Confira o que os [módulos](modules.md) e [extensões](extensions.md) podem
 fazer!
 
 Você também pode obter ideias dos vários [exemplos de
-usuários](https://github.com/KMKfw/user_keymaps) que fornecemos e fuce nossa
+usuários](https://github.com/KMKfw/kmk_firmware/tree/master/user_keymaps) que fornecemos e fuce nossa
 [documentação](https://github.com/KMKfw/kmk_firmware/tree/master/docs).
 
 


### PR DESCRIPTION
Links to `user_keymaps` were pointing to repository.