### PR TITLE
Support bare DigitalInOut pins in Encoder module

### DIFF
--- a/kmk/modules/encoder.py
+++ b/kmk/modules/encoder.py
@@ -2,6 +2,7 @@
 
 import busio
 import digitalio
+import microcontroller
 from supervisor import ticks_ms
 
 from kmk.modules import Module
@@ -145,7 +146,10 @@ class EncoderPin:
 
     def prepare_pin(self):
         if self.pin is not None:
-            self.io = digitalio.DigitalInOut(self.pin)
+            if isinstance(self.pin, microcontroller.Pin):
+                self.io = digitalio.DigitalInOut(self.pin)
+            else:
+                self.io = self.pin
             self.io.direction = digitalio.Direction.INPUT
             self.io.pull = digitalio.Pull.UP
         else:

--- a/kmk/modules/encoder.py
+++ b/kmk/modules/encoder.py
@@ -2,7 +2,6 @@
 
 import busio
 import digitalio
-import microcontroller
 from supervisor import ticks_ms
 
 from kmk.modules import Module
@@ -146,10 +145,10 @@ class EncoderPin:
 
     def prepare_pin(self):
         if self.pin is not None:
-            if isinstance(self.pin, microcontroller.Pin):
-                self.io = digitalio.DigitalInOut(self.pin)
-            else:
+            if isinstance(self.pin, digitalio.DigitalInOut):
                 self.io = self.pin
+            else:
+                self.io = digitalio.DigitalInOut(self.pin)
             self.io.direction = digitalio.Direction.INPUT
             self.io.pull = digitalio.Pull.UP
         else:


### PR DESCRIPTION
### Background
I ran into an issue with trying to use a rotary encoder through a GPIO expander module. These modules often give you access to their pins in the form of digitalio.DigitalInOut objects. I made a small adjustment to the Encoder module in KMK to support a pin being some form of DigitalInOut object rather than a microcontroller.Pin object.

### Description of Change
Check if pin is a microcontroller.Pin. If it is, keep the old logic of turning it into a digitalio.DigitalInOut object. If it isn't, just assume it's already a DigitalInOut object and use it as is.