### PR TITLE
Feature pointing device panning

### DIFF
--- a/docs/en/boot.md
+++ b/docs/en/boot.md
@@ -30,6 +30,7 @@ bootcfg(
     midi: bool = True,
     mouse: bool = True,
     nkro: bool = False,
+    pan: bool = False,
     storage: bool = True,
     usb_id: Optional[tuple[str, str]] = None,
     **kwargs,
@@ -98,6 +99,11 @@ Enable n-key rollover support. If the default keyboard is enabled, this option
 will replace the standard 6-key rollover endpoint with an n-key rollover one.
 This is technically not a standard HID endpoint, but if you want this, you
 probably know what you're doing.
+
+
+#### pan
+Enable panning, aka horizontal scrolling, for the pointing device, aka mouse,
+hid endpoint.
 
 
 #### storage

--- a/docs/en/mouse_keys.md
+++ b/docs/en/mouse_keys.md
@@ -19,7 +19,14 @@ keyboard.modules.append(MouseKeys())
 | `KC.MB_BTN5`              | mouse button 5                       |
 | `KC.MW_UP`                | Mouse wheel up                       |
 | `KC.MW_DOWN`, `KC.MW_DN`  | Mouse wheel down                     |
+| `KC.MW_LEFT`, `KC.MW_LT`  | Mouse pan left                       |
+| `KC.MW_RIGHT`, `KC.MW_RT` | Mouse pan right                      |
 | `KC.MS_UP`                | Move mouse cursor up                 |
 | `KC.MS_DOWN`, `KC.MS_DN`  | Move mouse cursor down               |
 | `KC.MS_LEFT`, `KC.MS_LT`  | Move mouse cursor left               |
 | `KC.MS_RIGHT`, `KC.MS_RT` | Move mouse cursor right              |
+
+
+**Note**:
+Support for panning (mouse wheel left/right) `boot.py` has to be explicitly
+enabled in `boot.py` with the [`bootcfg` module](boot.md#panning).

--- a/kmk/bootcfg.py
+++ b/kmk/bootcfg.py
@@ -18,6 +18,7 @@ def bootcfg(
     midi: bool = True,
     mouse: bool = True,
     nkro: bool = False,
+    pan: bool = False,
     storage: bool = True,
     usb_id: Optional[tuple[str, str]] = None,
     **kwargs,
@@ -50,7 +51,12 @@ def bootcfg(
         else:
             devices.append(usb_hid.Device.KEYBOARD)
     if mouse:
-        devices.append(usb_hid.Device.MOUSE)
+        if pan:
+            from kmk.hid_reports import pointer
+
+            devices.append(pointer.POINTER)
+        else:
+            devices.append(usb_hid.Device.MOUSE)
     if consumer_control:
         devices.append(usb_hid.Device.CONSUMER_CONTROL)
     if devices:

--- a/kmk/hid_reports/pointer.py
+++ b/kmk/hid_reports/pointer.py
@@ -1,0 +1,75 @@
+import usb_hid
+
+report_descriptor = bytes(
+    (
+        0x05,
+        0x01,  # Usage Page (Generic Desktop Ctrls)
+        0x09,
+        0x02,  # Usage (Mouse)
+        0xA1,
+        0x01,  # Collection (Application)
+        0x09,
+        0x01,  #   Usage (Pointer)
+        0xA1,
+        0x00,  #   Collection (Physical)
+        0x85,
+        0x02,  #     10, 11 Report ID (2)
+        0x05,
+        0x09,  #     Usage Page (Button)
+        0x19,
+        0x01,  #     Usage Minimum (0x01)
+        0x29,
+        0x05,  #     Usage Maximum (0x05)
+        0x15,
+        0x00,  #     Logical Minimum (0)
+        0x25,
+        0x01,  #     Logical Maximum (1)
+        0x95,
+        0x05,  #     Report Count (5)
+        0x75,
+        0x01,  #     Report Size (1)
+        0x81,
+        0x02,  #     Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+        0x95,
+        0x01,  #     Report Count (1)
+        0x75,
+        0x03,  #     Report Size (3)
+        0x81,
+        0x01,  #     Input (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+        0x05,
+        0x01,  #     Usage Page (Generic Desktop Ctrls)
+        0x09,
+        0x30,  #     Usage (X)
+        0x09,
+        0x31,  #     Usage (Y)
+        0x09,
+        0x38,  #     Usage (Wheel)
+        0x05,
+        0x0C,  #     Usage Page (Consumer Devices)
+        0x0A,
+        0x38,
+        0x02,  #     Usage (AC Pan)
+        0x15,
+        0x81,  #     Logical Minimum (-127)
+        0x25,
+        0x7F,  #     Logical Maximum (127)
+        0x95,
+        0x04,  #     Report Count (4)
+        0x75,
+        0x08,  #     Report Size (8)
+        0x81,
+        0x06,  #     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+        0xC0,  #   End Collection
+        0xC0,  # End Collection
+    )
+)
+
+
+POINTER = usb_hid.Device(
+    report_descriptor=report_descriptor,
+    usage_page=0x01,
+    usage=0x02,
+    report_ids=(0x02,),
+    in_report_lengths=(5,),
+    out_report_lengths=(0,),
+)

--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -52,6 +52,7 @@ class Axis:
 
 
 class AX:
+    P = Axis(3)
     W = Axis(2)
     X = Axis(0)
     Y = Axis(1)

--- a/kmk/modules/mouse_keys.py
+++ b/kmk/modules/mouse_keys.py
@@ -10,6 +10,8 @@ _ML = const(4)
 _MR = const(8)
 _WU = const(16)
 _WD = const(32)
+_WL = const(64)
+_WR = const(128)
 
 
 class MouseKeys(Module):
@@ -51,6 +53,16 @@ class MouseKeys(Module):
             ),
             on_press=self._mw_down_press,
             on_release=self._mw_down_release,
+        )
+        make_key(
+            names=('MW_LEFT', 'MW_LT'),
+            on_press=self._mw_left_press,
+            on_release=self._mw_left_release,
+        )
+        make_key(
+            names=('MW_RIGHT', 'MW_RT'),
+            on_press=self._mw_right_press,
+            on_release=self._mw_right_release,
         )
         make_key(
             names=('MS_UP',),
@@ -124,6 +136,10 @@ class MouseKeys(Module):
             AX.W.move(keyboard, 1)
         if self._movement & _WD:
             AX.W.move(keyboard, -1)
+        if self._movement & _WL:
+            AX.P.move(keyboard, -1)
+        if self._movement & _WR:
+            AX.P.move(keyboard, 1)
 
     def _maybe_start_move(self, mask):
         self._movement |= mask
@@ -148,6 +164,18 @@ class MouseKeys(Module):
 
     def _mw_down_release(self, key, keyboard, *args, **kwargs):
         self._maybe_stop_move(_WD)
+
+    def _mw_left_press(self, key, keyboard, *args, **kwargs):
+        self._maybe_start_move(_WL)
+
+    def _mw_left_release(self, key, keyboard, *args, **kwargs):
+        self._maybe_stop_move(_WL)
+
+    def _mw_right_press(self, key, keyboard, *args, **kwargs):
+        self._maybe_start_move(_WR)
+
+    def _mw_right_release(self, key, keyboard, *args, **kwargs):
+        self._maybe_stop_move(_WR)
 
     def _ms_up_press(self, key, keyboard, *args, **kwargs):
         self._maybe_start_move(_MU)


### PR DESCRIPTION
depends on #795 unfortunately.

Pointing device panning (aka horizontal scrolling), technically similar parts of #793, but created independently:
* new HID report, enabled through `bootcfg`
* new mouse keys
* docs