### PR TITLE
build zip of .mpy files with GitHub Action, resolve #270

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,44 @@
+name: Build
+on:
+  push:
+    branches: ['main', 'master']
+env:
+  mpy-cross-path: "https://adafruit-circuit-python.s3.amazonaws.com/bin/mpy-cross/"
+  mpy-cross-name: "mpy-cross.static-amd64-linux-"
+  mpy-cross-8-release: "8.0.5"
+jobs:
+  Compile:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "A ${{ github.event_name }} event trigged build of branch ${{ github.ref }}, repository ${{ github.repository }}"
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Cache mpy-cross
+        id: cache-mpy-cross
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-mpy-cross-8
+        with:
+          path: ${{ github.workspace }}/mpy-cross
+          key: ${{ env.mpy-cross-name }}${{ env.mpy-cross-8-release }}
+      - if: ${{ steps.cache-mpy-cross.outputs.cache-hit != 'true' }}
+        name: install mpy-cross
+        run: |
+          wget --no-verbose "${{ env.mpy-cross-path }}${{ env.mpy-cross-name }}${{ env.mpy-cross-8-release }}" -O ${{ github.workspace }}/mpy-cross; \
+          chmod +x ${{ github.workspace }}/mpy-cross
+
+      - name: get short git sha
+        id: sha
+        run: echo "SHA=`git rev-parse --short HEAD`" >> $GITHUB_OUTPUT
+
+      - name: compile
+        run: PATH=.:$PATH make compile
+      - name: List build dir
+        run: |
+          ls -la .compiled/kmk/
+      - name: upload zip
+        uses: actions/upload-artifact@v3
+        with:
+          name: kmk-${{ steps.sha.outputs.SHA }}+mpy-cross-${{ env.mpy-cross-8-release }}
+          path: .compiled/kmk/


### PR DESCRIPTION
This is a fairly trivial GH Action that automatically runs `make compile` and uploads the zip (for an example of what this looks like, see Artifacts [here](https://github.com/rrotter/kmk_firmware/actions/runs/5035251976)). As configured this will only run on merge/push to the master branch. Only supports CircuitPython 8, would be easy to add other versions if need be.

This was requested in #270.