### PR TITLE
Relax unit test timing conditions

### DIFF
--- a/tests/test_holdtap.py
+++ b/tests/test_holdtap.py
@@ -11,8 +11,8 @@ class TestHoldTap(unittest.TestCase):
         KC.clear()
 
         self.t_within = 2 * KeyboardTest.loop_delay_ms
-        self.t_after = 6 * KeyboardTest.loop_delay_ms
-        tap_time = 5 * KeyboardTest.loop_delay_ms
+        self.t_after = 10 * KeyboardTest.loop_delay_ms
+        tap_time = (self.t_after + self.t_within) // 2
 
         # overide default timeouts
         HoldTap.tap_time = tap_time

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -9,7 +9,7 @@ from tests.keyboard_test import KeyboardTest
 class TestOneshot(unittest.TestCase):
     def test_oneshot(self):
         t_within = 2 * KeyboardTest.loop_delay_ms
-        t_after = 7 * KeyboardTest.loop_delay_ms
+        t_after = 10 * KeyboardTest.loop_delay_ms
         timeout = (t_after + t_within) // 2
 
         # overide default timeouts


### PR DESCRIPTION
Unit tests keep occasionally failing because of timing constraints.
These are trial-and-error values, may need adjusting in the future.