### PR TITLE
update dactyl readme file(s)

### DIFF
--- a/boards/dactyl/README.md
+++ b/boards/dactyl/README.md
@@ -11,7 +11,7 @@ KMK's rendition of the Dactyl requires two micro controllers rather than the ori
 
 ## Case Files Generator
 
-[Dactyl Keyboard Configurator](https://ryanis.cool/dactyl), created by [rianadon](https://github.com/rianadon), is a web based file generator that negates composing case files using a programming language, which was a requirement when using the GitHub repository for this board, by instead compiling case files based on options and parameters configured in a web front end.
+[Dactyl Generator](https://ryanis.cool/dactyl), created by [rianadon](https://github.com/rianadon), is a web based file generator that negates composing case files using a programming language, which was a requirement when using the GitHub repository for this board, by instead compiling case files based on options and parameters configured in a web front end.
 
 ## KMK Specifics
 

--- a/boards/dactyl/README.md
+++ b/boards/dactyl/README.md
@@ -9,6 +9,10 @@ Hardware Availability: [Case Files](https://github.com/adereth/dactyl-keyboard)
 
 KMK's rendition of the Dactyl requires two micro controllers rather than the original implementation of a micro controller and I/O expander. 
 
+## Case Files Generator
+
+[Dactyl Keyboard Configurator](https://ryanis.cool/dactyl), created by [rianadon](https://github.com/rianadon), is a web based file generator that negates composing case files using a programming language, which was a requirement when using the GitHub repository for this board, by instead compiling case files based on options and parameters configured in a web front end.
+
 ## KMK Specifics
 
 Extentions enabled by default  

--- a/boards/dactyl_lightcycle/README.md
+++ b/boards/dactyl_lightcycle/README.md
@@ -13,7 +13,7 @@ KMK's rendition of the Dactyl Lightcycle requires two micro controllers, rather 
 
 ## Case Files Generator
 
-[Dactyl Keyboard Configurator](https://ryanis.cool/dactyl), created by [rianadon](https://github.com/rianadon), is a web based file generator that negates composing case files using a programming language, which was a requirement when using the GitHub repository for this board, by instead compiling case files based on options and parameters configured in a web front end.
+[Dactyl Generator](https://ryanis.cool/dactyl), created by [rianadon](https://github.com/rianadon), is a web based file generator that negates composing case files using a programming language, which was a requirement when using the GitHub repository for this board, by instead compiling case files based on options and parameters configured in a web front end.
 
 ## KMK Specifics
 

--- a/boards/dactyl_lightcycle/README.md
+++ b/boards/dactyl_lightcycle/README.md
@@ -11,6 +11,10 @@ Differences from the Dactyl are:
 
 KMK's rendition of the Dactyl Lightcycle requires two micro controllers, rather than the Dactyl's original implementation of a micro controller and I/O expander. 
 
+## Case Files Generator
+
+[Dactyl Keyboard Configurator](https://ryanis.cool/dactyl), created by [rianadon](https://github.com/rianadon), is a web based file generator that negates composing case files using a programming language, which was a requirement when using the GitHub repository for this board, by instead compiling case files based on options and parameters configured in a web front end.
+
 ## KMK Specifics
 
 Extentions enabled by default:

--- a/boards/dactyl_manuform/README.md
+++ b/boards/dactyl_manuform/README.md
@@ -50,7 +50,7 @@ e.g. in the case of `4x6` variant:
 
 ## Case Files Generator
 
-[Dactyl Keyboard Configurator](https://ryanis.cool/dactyl), created by [rianadon](https://github.com/rianadon), is a web based file generator that negates composing case files using a programming language, which was a requirement when using the GitHub repository for this board, by instead compiling case files based on options and parameters configured in a web front end.
+[Dactyl Generator](https://ryanis.cool/dactyl), created by [rianadon](https://github.com/rianadon), is a web based file generator that negates composing case files using a programming language, which was a requirement when using the GitHub repository for this board, by instead compiling case files based on options and parameters configured in a web front end.
 
 ## KMK Specifics
 

--- a/boards/dactyl_manuform/README.md
+++ b/boards/dactyl_manuform/README.md
@@ -48,6 +48,10 @@ e.g. in the case of `4x6` variant:
 ### `main.py`  
 `keyboard.keymap` element: For each layer, append with keycodes in the respective extended bottom row positions.
 
+## Case Files Generator
+
+[Dactyl Keyboard Configurator](https://ryanis.cool/dactyl), created by [rianadon](https://github.com/rianadon), is a web based file generator that negates composing case files using a programming language, which was a requirement when using the GitHub repository for this board, by instead compiling case files based on options and parameters configured in a web front end.
+
 ## KMK Specifics
 
 Extentions enabled by default:  

--- a/boards/dactyl_manuform_mini/README.md
+++ b/boards/dactyl_manuform_mini/README.md
@@ -48,7 +48,7 @@ e.g. in the case of `4x6` variant:
 
 ## Case Files Generator
 
-[Dactyl Keyboard Configurator](https://ryanis.cool/dactyl), created by [rianadon](https://github.com/rianadon), is a web based file generator that negates composing case files using a programming language, which was a requirement when using the GitHub repository for this board, by instead compiling case files based on options and parameters configured in a web front end.
+[Dactyl Generator](https://ryanis.cool/dactyl), created by [rianadon](https://github.com/rianadon), is a web based file generator that negates composing case files using a programming language, which was a requirement when using the GitHub repository for this board, by instead compiling case files based on options and parameters configured in a web front end.
 
 ## KMk Specifics
 

--- a/boards/dactyl_manuform_mini/README.md
+++ b/boards/dactyl_manuform_mini/README.md
@@ -46,6 +46,10 @@ e.g. in the case of `4x6` variant:
 ### `main.py`  
 `keyboard.keymap` element: For each layer, append with keycodes in the respective extended bottom row positions.
 
+## Case Files Generator
+
+[Dactyl Keyboard Configurator](https://ryanis.cool/dactyl), created by [rianadon](https://github.com/rianadon), is a web based file generator that negates composing case files using a programming language, which was a requirement when using the GitHub repository for this board, by instead compiling case files based on options and parameters configured in a web front end.
+
 ## KMk Specifics
 
 Extentions enabled by default:  


### PR DESCRIPTION
update `readme.md` files of the following boards to include Dactyl Keyboard Configurator site information:
- dactyl
- dactyl_lightcycle
- dactyl_manuform
- dactyl_manuform_mini 