### PR TITLE
Add `dactyl_manuform_carbonfet` board

### DIFF
--- a/boards/dactyl_manuform_carbonfet/4x5/kb.py
+++ b/boards/dactyl_manuform_carbonfet/4x5/kb.py
@@ -1,0 +1,38 @@
+import board
+
+from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
+from kmk.quickpin.pro_micro.avr_promicro import translate as avr
+from kmk.quickpin.pro_micro.boardsource_blok import pinout as pins
+from kmk.scanners import DiodeOrientation
+
+
+class KMKKeyboard(_KMKKeyboard):
+    row_pins = (
+        pins[avr['C6']],
+        pins[avr['D7']],
+        pins[avr['E6']],
+        pins[avr['B4']],
+        pins[avr['B5']],
+    )
+    col_pins = (
+        pins[avr['F7']],
+        pins[avr['B1']],
+        pins[avr['B3']],
+        pins[avr['B2']],
+        pins[avr['B6']],
+    )
+    diode_orientation = DiodeOrientation.COLUMNS
+    data_pin = pins[avr['D0']]
+    # data_pin2 =
+    # rgb_pixel_pin = pins[avr['D3']]
+    # num_pixels = 12
+
+    # flake8: noqa
+    # fmt: off
+    coord_mapping = [
+        0,  1,  2,  3,  4,                    25, 26, 27, 28, 29,
+        5,  6,  7,  8,  9,                    30, 31, 32, 33, 34,
+        10, 11, 12, 13, 14,                   35, 36, 37, 38, 39,
+            16, 17,     22, 18, 19,   40, 41, 47,     42, 43,
+                        21, 23, 24,   45, 46, 48
+    ]

--- a/boards/dactyl_manuform_carbonfet/4x5/main.py
+++ b/boards/dactyl_manuform_carbonfet/4x5/main.py
@@ -1,0 +1,62 @@
+from kb import KMKKeyboard
+
+from kmk.keys import KC
+from kmk.modules.holdtap import HoldTap
+from kmk.modules.layers import Layers
+from kmk.modules.split import Split
+
+keyboard = KMKKeyboard()
+
+keyboard.modules.append(Layers())
+keyboard.modules.append(HoldTap())
+
+split = Split(
+    data_pin=keyboard.data_pin
+    # data_pin2=keyboard.data_pin2
+)
+keyboard.modules.append(split)
+
+G_A = KC.HT(KC.A, KC.LGUI)
+H_W = KC.HT(KC.W, KC.HYPR)
+A_S = KC.HT(KC.s, KC.LALT)
+M_E = KC.HT(KC.E, KC.MEH)
+C_D = KC.HT(KC.D, KC.LCTL)
+S_F = KC.HT(KC.F, KC.LSFT)
+S_J = KC.HT(KC.J, KC.RSFT)
+C_K = KC.HT(KC.D, KC.RCTL)
+M_I = KC.HT(KC.I, KC.MEH)
+A_L = KC.HT(KC.L, KC.LALT)
+H_O = KC.HT(KC.O, KC.HYPR)
+G_SCLN = KC.HT(KC.SCLN, KC.RGUI)
+ALTCTL = KC.LALT(KC.LCTL)
+
+keyboard.keymap = [
+    [   # 0
+        KC.Q,     H_W,     M_E, KC.R,     KC.T,                                             KC.Y, KC.U,     M_I,     H_O,    KC.P,
+        G_A,      A_S,     C_D,  S_F,     KC.G,                                             KC.H,  S_J,     C_K,     A_L,  G_SCLN,
+        KC.Z,    KC.X,    KC.C, KC.V,     KC.B,                                             KC.N, KC.M, KC.COMM,  KC.DOT, KC.SLSH,
+              KC.LEFT, KC.RGHT,       KC.MO(1),  KC.SPC,  KC.DEL,      KC.BSPC, KC.ENT, KC.MO(2),         KC.UP, KC.DOWN,
+                                        KC.ESC,  KC.HOME, KC.BSLS,     KC.QUOT, KC.END,   KC.TAB,
+    ],
+    [  #1
+        KC.F1,   KC.F2,   KC.F3,  KC.F4,  KC.INS,                                       KC.NLCK,  KC.P7,  KC.P8,   KC.P9,  KC.PMNS,
+        KC.F5,   KC.F6,   KC.F7,  KC.F8, KC.PSCR,                                       KC.PAST,  KC.P4,  KC.P5,   KC.P6,  KC.PPLS,
+        KC.F9,  KC.F10,  KC.F11, KC.F12, KC.PAUS,                                       KC.PSLS,  KC.P1,  KC.P2,   KC.P3,  KC.PENT,
+               KC.CAPS, KC.TRNS,         KC.TRNS, KC.NO, KC.NO,      KC.LALT, KC.RSFT, KC.MO(3),          KC.P0, KC.PDOT,
+                                           KC.NO, KC.NO, KC.NO,      KC.RGUI, KC.RCTL,   ALTCTL,
+    ],
+    [  #2
+        KC.EXLM,   KC.AT, KC.HASH,  KC.DLR,  KC.PERC,                                      KC.CIRC, KC.AMPR, KC.ASTR,  KC.GRV, KC.TILD,
+        KC.N1,     KC.N2,   KC.N3,   KC.N4,    KC.N5,                                        KC.N6,   KC.N7,   KC.N8,   KC.N9,   KC.N0,
+        KC.MINS, KC.PLUS, KC.LBRC, KC.LPRN,  KC.LCBR,                                      KC.RCBR, KC.RPRN, KC.RBRC, KC.UNDS,  KC.EQL,
+                 KC.PGDN, KC.PGUP,          KC.MO(3), KC.LSFT, KC.LALT,      KC.NO, KC.NO, KC.TRNS,          KC.TRNS, KC.SLCK,
+                                              ALTCTL, KC.LCTL, KC.LGUI,      KC.NO, KC.NO,   KC.NO,
+    ],
+    [  #3
+        KC.NO,    KC.NO, KC.NO,    KC.NO,   KC.NO,                                  KC.NO,  KC.NO, KC.NO, KC.NO, KC.NO,
+        KC.DEBUG, KC.NO, KC.NO, KC.RESET,   KC.NO,                                  KC.NO, KC.RLD, KC.NO, KC.NO, KC.NO,
+        KC.NO,    KC.NO, KC.NO,    KC.NO,   KC.NO,                                  KC.NO,  KC.NO, KC.NO, KC.NO, KC.NO,
+                  KC.NO, KC.NO,           KC.TRNS, KC.NO, KC.NO,    KC.NO, KC.NO, KC.TRNS,         KC.NO, KC.NO,
+                                            KC.NO, KC.NO, KC.NO,    KC.NO, KC.NO, KC.NO,
+    ],
+]

--- a/boards/dactyl_manuform_carbonfet/4x6/kb.py
+++ b/boards/dactyl_manuform_carbonfet/4x6/kb.py
@@ -1,0 +1,39 @@
+import board
+
+from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
+from kmk.quickpin.pro_micro.avr_promicro import translate as avr
+from kmk.quickpin.pro_micro.boardsource_blok import pinout as pins
+from kmk.scanners import DiodeOrientation
+
+
+class KMKKeyboard(_KMKKeyboard):
+    row_pins = (
+        pins[avr['D4']],
+        pins[avr['C6']],
+        pins[avr['D7']],
+        pins[avr['E6']],
+        pins[avr['B4']],
+        pins[avr['B5']],
+    )
+    col_pins = (
+        pins[avr['F7']],
+        pins[avr['B1']],
+        pins[avr['B3']],
+        pins[avr['B2']],
+        pins[avr['B6']],
+    )
+    diode_orientation = DiodeOrientation.COLUMNS
+    data_pin = pins[avr['D0']]
+    # data_pin2 =
+    # rgb_pixel_pin = pins[avr['D3']]
+    # num_pixels = 12
+    
+    # flake8: noqa
+    # fmt: off
+    coord_mapping = [
+        0,  1,  2,  3,  4,  5,                     30, 31, 32, 33, 34, 35,
+        6,  7,  8,  9,  10, 11,                    36, 37, 38, 39, 40, 41,
+        12, 13, 14, 15, 16, 17,                    42, 43, 44, 45, 46, 47,
+                20, 21,     22, 23, 29,    48, 49, 56,     50, 51,
+                                27, 28,    54, 55, 57
+    ]

--- a/boards/dactyl_manuform_carbonfet/4x6/main.py
+++ b/boards/dactyl_manuform_carbonfet/4x6/main.py
@@ -1,0 +1,58 @@
+from kb import KMKKeyboard
+
+from kmk.keys import KC
+from kmk.modules.holdtap import HoldTap
+from kmk.modules.layers import Layers
+from kmk.modules.split import Split
+
+keyboard = KMKKeyboard()
+
+keyboard.modules.append(Layers())
+keyboard.modules.append(HoldTap())
+
+split = Split(
+    data_pin=keyboard.data_pin
+    # data_pin2=
+)
+keyboard.modules.append(split)
+
+A_D = KC.HT(KC.D, KC.LALT)
+C_F = KC.HT(KC.F, KC.LCTL)
+S_SPC = KC.HT(KC.SPC, KC.LSFT)
+S_ENT = KC.HT(KC.ENT, KC.RSFT)
+C_J = KC.HT(KC.J, KC.RCTL)
+A_K = KC.HT(KC.L, KC.LALT)
+M_HOME = KC.HT(KC.HOME, KC.MEH)
+H_END = KC.HT(KC.END, KC.HYPR)
+ALTCTL = KC.LALT(KC.LCTL)
+
+keyboard.keymap = [
+    [   # 0
+        KC.GRV,  KC.Q,    KC.W,    KC.E, KC.R,   KC.T,                                         KC.Y, KC.U,    KC.I,    KC.O,    KC.P, KC.BSLS,
+        KC.CAPS, KC.A,    KC.S,     A_D,  C_F,   KC.G,                                         KC.H,  C_J,     A_K,    KC.L, KC.SCLN, KC.QUOT,
+        KC.LBRC, KC.Z,    KC.X,    KC.C, KC.V,   KC.B,                                         KC.N, KC.M, KC.COMM,  KC.DOT, KC.SLSH, KC.RBRC,
+                       KC.LEFT, KC.RGHT,       KC.MO(1), S_SPC,  KC.DEL,       KC.BSPC, S_ENT, KC.MO(2),         KC.UP, KC.DOWN,
+                                                KC.ESC,  M_HOME, KC.LGUI,      KC.RGUI, H_END, KC.TAB,
+    ],
+    [  #1
+        KC.TRNS, KC.F1,   KC.F2,   KC.F3,  KC.F4,  KC.INS,                                      KC.NLCK, KC.P7, KC.P8,   KC.P9, KC.PMNS, KC.TRNS,
+        KC.TRNS, KC.F5,   KC.F6,   KC.F7,  KC.F8, KC.PSCR,                                      KC.PAST, KC.P4, KC.P5,   KC.P6, KC.PPLS, KC.TRNS,
+        KC.TRNS, KC.F9,  KC.F10,  KC.F11, KC.F12, KC.PAUS,                                      KC.PSLS, KC.P1, KC.P2,   KC.P3, KC.PENT, KC.TRNS,
+                        KC.TRNS, KC.TRNS,         KC.TRNS, KC.NO, KC.NO,      KC.LALT, KC.RSFT, KC.MO(3),       KC.P0, KC.PDOT,
+                                                    KC.NO, KC.NO, KC.NO,      KC.RGUI, KC.RCTL, ALTCTL,
+    ],
+    [  #2
+        KC.TRNS, KC.EXLM,   KC.AT, KC.HASH,  KC.DLR,  KC.PERC,                                      KC.CIRC, KC.AMPR, KC.ASTR, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS,   KC.N1,   KC.N2,   KC.N3,   KC.N4,    KC.N5,                                        KC.N6,   KC.N7,   KC.N8,   KC.N9,   KC.N0, KC.TRNS,
+        KC.TRNS, KC.MINS, KC.PLUS, KC.LPRN, KC.LCBR,  KC.TRNS,                                      KC.TRNS, KC.RCBR, KC.RPRN, KC.UNDS,  KC.EQL, KC.TRNS,
+                          KC.PGDN, KC.PGUP,          KC.MO(3), KC.LSFT, KC.LALT,      KC.NO, KC.NO, KC.TRNS,          KC.TRNS, KC.SLCK,
+                                                       ALTCTL, KC.LCTL, KC.LGUI,      KC.NO, KC.NO,
+    ],
+    [  #3
+        KC.NO, KC.NO,    KC.NO, KC.NO,    KC.NO,   KC.NO,                                  KC.NO,  KC.NO, KC.NO, KC.NO, KC.NO, KC.NO,
+        KC.NO, KC.DEBUG, KC.NO, KC.NO, KC.RESET,   KC.NO,                                  KC.NO, KC.RLD, KC.NO, KC.NO, KC.NO, KC.NO,
+        KC.NO, KC.NO,    KC.NO, KC.NO,    KC.NO,   KC.NO,                                  KC.NO,  KC.NO, KC.NO, KC.NO, KC.NO, KC.NO,
+                         KC.NO, KC.NO,           KC.TRNS, KC.NO, KC.NO,    KC.NO, KC.NO, KC.TRNS,         KC.NO, KC.NO,
+                                                   KC.NO, KC.NO, KC.NO,    KC.NO, KC.NO, KC.NO,
+    ],
+]

--- a/boards/dactyl_manuform_carbonfet/5x6/kb.py
+++ b/boards/dactyl_manuform_carbonfet/5x6/kb.py
@@ -1,0 +1,41 @@
+import board
+
+from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
+from kmk.quickpin.pro_micro.avr_promicro import translate as avr
+from kmk.quickpin.pro_micro.boardsource_blok import pinout as pins
+from kmk.scanners import DiodeOrientation
+
+
+class KMKKeyboard(_KMKKeyboard):
+    row_pins = (
+        pins[avr['D4']],
+        pins[avr['C6']],
+        pins[avr['D7']],
+        pins[avr['E6']],
+        pins[avr['B4']],
+        pins[avr['B5']],
+    )
+    col_pins = (
+        pins[avr['F6']],
+        pins[avr['F7']],
+        pins[avr['B1']],
+        pins[avr['B3']],
+        pins[avr['B2']],
+        pins[avr['B6']],
+    )
+    diode_orientation = DiodeOrientation.COLUMNS
+    data_pin = pins[avr['D0']]
+    # data_pin2 =
+    # rgb_pixel_pin = pins[avr['D3']]
+    # num_pixels = 12
+
+    # flake8: noqa
+    # fmt: off
+    coord_mapping = [
+        0,  1,  2,  3,  4,  5,                     36, 37, 38, 39, 40, 41,
+        6,  7,  8,  9,  10, 11,                    42, 43, 44, 45, 46, 47,
+        12, 13, 14, 15, 16, 17,                    48, 49, 50, 51, 52, 53,
+        18, 19, 20, 21, 22, 23,                    54, 55, 56, 57, 58, 59,
+                26, 27,     28, 29, 35,    60, 61, 68,     62, 63,
+                                33, 34,    66, 67, 69
+    ]

--- a/boards/dactyl_manuform_carbonfet/5x6/main.py
+++ b/boards/dactyl_manuform_carbonfet/5x6/main.py
@@ -1,0 +1,52 @@
+from kb import KMKKeyboard
+
+from kmk.keys import KC
+from kmk.modules.holdtap import HoldTap
+from kmk.modules.layers import Layers
+from kmk.modules.split import Split
+
+keyboard = KMKKeyboard()
+
+keyboard.modules.append(Layers())
+keyboard.modules.append(HoldTap())
+
+split = Split(
+    data_pin=keyboard.data_pin
+    # data_pin2=
+)
+keyboard.modules.append(split)
+
+L1_HOME = KC.LT(1, KC.HOME)
+L2_END = KC.LT(2, KC.END)
+M_DEL = KC.HT(KC.DEL, KC.MEH)
+H_BSPC = KC.HT(KC.BSPC, KC.HYPR)
+A_TAB = KC.HT(KC.TAB, KC.LALT)
+ALTCTL = KC.LALT(KC.LCTL)
+SFTGUI = KC.LSFT(KC.LGUI)
+
+keyboard.keymap = [
+    [   # 0
+        KC.ESC,  KC.N1,   KC.N2,   KC.N3, KC.N4,   KC.N5,                                         KC.N6, KC.N7,   KC.N8,   KC.N9,   KC.N0,  KC.GRV,
+        KC.CAPS,  KC.Q,    KC.W,    KC.E,  KC.R,    KC.T,                                          KC.Y,  KC.U,    KC.I,    KC.O,    KC.P, KC.BSLS,
+        KC.LSFT,  KC.A,    KC.S,    KC.D,  KC.F,    KC.G,                                          KC.H,  KC.J,    KC.K,    KC.L, KC.SCLN, KC.RSFT,
+        KC.LCTL,  KC.Z,    KC.X,    KC.C,  KC.V,    KC.B,                                          KC.N,  KC.M, KC.COMM,  KC.DOT, KC.SLSH, KC.RCTL,
+                        KC.LEFT, KC.RGHT,       KC.MO(1), KC.SPC,   A_TAB,      KC.LALT, KC.ENT, KC.MO(2),        KC.UP, KC.DOWN,
+                                                 KC.HOME,  M_DEL, KC.LGUI,      KC.RGUI, H_BSPC, KC.END,
+    ],
+    [  #1
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,    KC.TRNS,    KC.TRNS,                                      KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,    KC.TRNS,    KC.TRNS,                                      KC.NLCK,   KC.P7,   KC.P8,   KC.P9, KC.PMNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.UNDS, KC.MINS, KC.KC.LBRC, KC.KC.RBRC,                                      KC.PAST,   KC.P4,   KC.P5,   KC.P6, KC.PPLS, KC.TRNS,
+        KC.TRNS, KC.TRNS,  KC.EQL, KC.PLUS, KC.KC.LCBR, KC.KC.RCBR,                                      KC.PSLS,   KC.P1,   KC.P2,   KC.P3, KC.PENT, KC.TRNS,
+                          KC.TRNS, KC.TRNS,                KC.TRNS, KC.NO, KC.NO,      KC.LALT, KC.RSFT,  SFTGUI,            KC.P0, KC.PDOT,
+                                                             KC.NO, KC.NO, KC.NO,      KC.RGUI, KC.RCTL,  ALTCTL,
+    ],
+    [  #2
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,                                      KC.TRNS,  KC.TRNS,  KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS,   KC.F1,   KC.F2,   KC.F3,   KC.F4,  KC.INS,                                      KC.TRNS,  KC.TRNS,  KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS,   KC.F5,   KC.F6,   KC.F7,   KC.F8, KC.PSCR,                                      KC.TRNS, KC.RESET, KC.DEBUG, KC.TRNS,  KC.RLD, KC.TRNS,
+        KC.TRNS,   KC.F9,  KC.F10,  KC.F11,  KC.F12, KC.PAUS,                                      KC.TRNS,  KC.TRNS,  KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+                          KC.PGDN, KC.PGUP,           SFTGUI, KC.LSFT, KC.LALT,      KC.NO, KC.NO, KC.TRNS,            KC.TRNS, KC.SLCK,
+                                                      ALTCTL, KC.LCTL, KC.LGUI,      KC.NO, KC.NO,   KC.NO,
+    ],
+]

--- a/boards/dactyl_manuform_carbonfet/5x7/kb.py
+++ b/boards/dactyl_manuform_carbonfet/5x7/kb.py
@@ -1,0 +1,42 @@
+import board
+
+from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
+from kmk.quickpin.pro_micro.avr_promicro import translate as avr
+from kmk.quickpin.pro_micro.boardsource_blok import pinout as pins
+from kmk.scanners import DiodeOrientation
+
+
+class KMKKeyboard(_KMKKeyboard):
+    row_pins = (
+        pins[avr['D4']],
+        pins[avr['C6']],
+        pins[avr['D7']],
+        pins[avr['E6']],
+        pins[avr['B4']],
+        pins[avr['B5']],
+    )
+    col_pins = (
+        pins[avr['F5']],
+        pins[avr['F6']],
+        pins[avr['F7']],
+        pins[avr['B1']],
+        pins[avr['B3']],
+        pins[avr['B2']],
+        pins[avr['B6']],
+    )
+    diode_orientation = DiodeOrientation.COLUMNS
+    data_pin = pins[avr['D0']]
+    # data_pin2 =
+    # rgb_pixel_pin = pins[avr['D3']]
+    # num_pixels = 12
+
+    # flake8: noqa
+    # fmt: off
+    coord_mapping = [
+        0,  1,  2,  3,  4,  5,  6,              42, 43, 44, 45, 46, 47, 48,
+        7,  8,  9,  10, 11, 12, 13,             49, 50, 51, 52, 53, 54, 55,
+        14, 15, 16, 17, 18, 19, 20,             56, 75, 58, 59, 60, 61, 62,
+        21, 22, 23, 24, 25, 26,                     64, 65, 66, 67, 68, 69,
+        28, 29, 30, 31,     32, 33, 34,     71, 72, 80,     73, 74, 75, 76,
+                                40, 41,     78, 79, 81
+    ]

--- a/boards/dactyl_manuform_carbonfet/5x7/main.py
+++ b/boards/dactyl_manuform_carbonfet/5x7/main.py
@@ -1,0 +1,49 @@
+from kb import KMKKeyboard
+
+from kmk.keys import KC
+from kmk.modules.holdtap import HoldTap
+from kmk.modules.layers import Layers
+from kmk.modules.split import Split
+
+keyboard = KMKKeyboard()
+
+keyboard.modules.append(Layers())
+keyboard.modules.append(HoldTap())
+
+split = Split(
+    data_pin=keyboard.data_pin
+    # data_pin2=
+)
+keyboard.modules.append(split)
+
+M_DEL = KC.HT(KC.DEL, KC.MEH)
+H_BSPC = KC.HT(KC.BSPC, KC.HYPR)
+ALTCTL = KC.LALT(KC.LCTL)
+SFTGUI = KC.LSFT(KC.LGUI)
+
+keyboard.keymap = [
+    [   # 0
+        KC.ESC,    KC.N1,   KC.N2,   KC.N3, KC.N4,    KC.N5, KC.PSCR,                        KC.INS,    KC.N6, KC.N7,   KC.N8,   KC.N9,   KC.N0,  KC.GRV,
+        KC.TAB,     KC.Q,    KC.W,    KC.E,  KC.R,     KC.T, KC.MINS,                        KC.EQL,     KC.Y,  KC.U,    KC.I,    KC.O,    KC.P, KC.BSLS,
+        KC.CAPS,    KC.A,    KC.S,    KC.D,  KC.F,     KC.G, KC.LBRC,                       KC.RBRC,     KC.H,  KC.J,    KC.K,    KC.L, KC.SCLN, KC.QUOT,
+        KC.LSFT,    KC.Z,    KC.X,    KC.C,  KC.V,     KC.B,                                             KC.N,  KC.M, KC.COMM,  KC.DOT, KC.SLSH, KC.RSFT,
+        KC.LCTL, KC.LGUI, KC.LEFT, KC.RGHT,        KC.MO(1),  KC.SPC,  KC.DEL,      KC.BSPC, KC.ENT, KC.MO(2),          KC.UP, KC.DOWN, KC.RGUI, KC.RCTL,
+                                                    KC.LALT, KC.HOME, KC.PGUP,      KC.PGDN, KC.END,  KC.RALT,
+    ],
+    [  #1
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,                      KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,                      KC.TRNS, KC.NLCK,   KC.P7,   KC.P8,   KC.P9, KC.PMNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,                      KC.TRNS, KC.PAST,   KC.P4,   KC.P5,   KC.P6, KC.PPLS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,                                        KC.PSLS,   KC.P1,   KC.P2,   KC.P3, KC.PENT, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,          KC.TRNS,   KC.NO, KC.NO,      KC.LALT, KC.RSFT,  SFTGUI,            KC.P0, KC.PDOT, KC.TRNS, KC.TRNS,
+                                                       KC.NO,   KC.NO, KC.NO,      KC.RGUI, KC.RCTL,  ALTCTL,
+    ],
+    [  #2
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,                      KC.TRNS, KC.TRNS,  KC.TRNS,  KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS,   KC.F1,   KC.F2,   KC.F3,   KC.F4, KC.TRNS, KC.TRNS,                      KC.TRNS, KC.TRNS,  KC.TRNS,  KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS,   KC.F1,   KC.F2,   KC.F3,   KC.F4, KC.PAUS, KC.TRNS,                      KC.TRNS, KC.TRNS, KC.RESET, KC.DEBUG, KC.TRNS,  KC.RLD, KC.TRNS,
+        KC.TRNS,   KC.F9,  KC.F10,  KC.F11,  KC.F12, KC.TRNS,                                        KC.TRNS,  KC.TRNS,  KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+                          KC.TRNS, KC.TRNS,           SFTGUI, KC.LSFT, KC.LALT,      KC.NO,   KC.NO, KC.TRNS,            KC.TRNS, KC.SLCK,
+                                                      ALTCTL, KC.LCTL, KC.LGUI,      KC.NO,   KC.NO,   KC.NO,
+    ],
+]

--- a/boards/dactyl_manuform_carbonfet/6x6/kb.py
+++ b/boards/dactyl_manuform_carbonfet/6x6/kb.py
@@ -1,0 +1,43 @@
+import board
+
+from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
+from kmk.quickpin.pro_micro.avr_promicro import translate as avr
+from kmk.quickpin.pro_micro.boardsource_blok import pinout as pins
+from kmk.scanners import DiodeOrientation
+
+
+class KMKKeyboard(_KMKKeyboard):
+    row_pins = (
+        pins[avr['D4']],
+        pins[avr['C6']],
+        pins[avr['D7']],
+        pins[avr['E6']],
+        pins[avr['B4']],
+        pins[avr['B5']],
+    )
+    col_pins = (
+        pins[avr['F5']],
+        pins[avr['F6']],
+        pins[avr['F7']],
+        pins[avr['B1']],
+        pins[avr['B3']],
+        pins[avr['B2']],
+        pins[avr['B6']],
+    )
+    diode_orientation = DiodeOrientation.COLUMNS
+    data_pin = pins[avr['D0']]
+    # data_pin2 =
+    # rgb_pixel_pin = pins[avr['D3']]
+    # num_pixels = 12
+    
+    # flake8: noqa
+    # fmt: off
+    coord_mapping = [
+        0,  1,  2,  3,  4,  5,  6,                      49, 50, 51, 52, 53, 54, 55,
+        7,  8,  9,  10, 11, 12, 13,                     56, 57, 58, 59, 60, 61, 62,
+        14, 15, 16, 17, 18, 19, 20,                     63, 64, 65, 66, 67, 68, 69,
+        21, 22, 23, 24, 25, 26, 27,                     70, 71, 72, 73, 74, 75, 76,
+        28, 29, 30, 31, 32, 33, 34,                     77, 78, 79, 80, 81, 82, 83,
+                    38, 39,     46, 40, 41,     84, 85, 93,     86, 87,
+                                45, 47, 48,     91, 92, 94
+    ]

--- a/boards/dactyl_manuform_carbonfet/6x6/main.py
+++ b/boards/dactyl_manuform_carbonfet/6x6/main.py
@@ -1,0 +1,53 @@
+from kb import KMKKeyboard
+
+from kmk.keys import KC
+from kmk.modules.holdtap import HoldTap
+from kmk.modules.layers import Layers
+from kmk.modules.split import Split
+
+keyboard = KMKKeyboard()
+
+keyboard.modules.append(Layers())
+keyboard.modules.append(HoldTap())
+
+split = Split(
+    data_pin=keyboard.data_pin
+    # data_pin2=
+)
+keyboard.modules.append(split)
+
+M_DEL = KC.HT(KC.DEL, KC.MEH)
+H_BSPC = KC.HT(KC.BSPC, KC.HYPR)
+A_TAB = KC.HT(KC.TAB, KC.LALT)
+ALTCTL = KC.LALT(KC.LCTL)
+SFTGUI = KC.LSFT(KC.LGUI)
+
+keyboard.keymap = [
+    [   # 0
+        KC.F1,   KC.F2,   KC.F3,   KC.F4, KC.F5,   KC.F6,                                         KC.F7, KC.F8,   KC.F9,  KC.F10,  KC.F11,  KC.F12,
+        KC.ESC,  KC.N1,   KC.N2,   KC.N3, KC.N4,   KC.N5,                                         KC.N6, KC.N7,   KC.N8,   KC.N9,   KC.N0,  KC.GRV,
+        KC.CAPS,  KC.Q,    KC.W,    KC.E,  KC.R,    KC.T,                                          KC.Y,  KC.U,    KC.I,    KC.O,    KC.P, KC.BSLS,
+        KC.LSFT,  KC.A,    KC.S,    KC.D,  KC.F,    KC.G,                                          KC.H,  KC.J,    KC.K,    KC.L, KC.SCLN, KC.RSFT,
+        KC.LCTL,  KC.Z,    KC.X,    KC.C,  KC.V,    KC.B,                                          KC.N,  KC.M, KC.COMM,  KC.DOT, KC.SLSH, KC.RCTL,
+                        KC.LEFT, KC.RGHT,       KC.MO(1), KC.SPC, KC.LALT,      KC.LALT, KC.ENT, KC.MO(2),        KC.UP, KC.DOWN,
+                                                 KC.HOME,  M_DEL, KC.LGUI,       KC.RGUI, H_BSPC, KC.END,
+    ],
+    [  #1
+        KC.F13,   KC.F14,  KC.F15,  KC.F16,     KC.F17,     KC.F18,                                       KC.F19,  KC.F20,  KC.F21,  KC.F22,  KC.F23,  KC.F24,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,    KC.TRNS,    KC.TRNS,                                      KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,    KC.TRNS,    KC.TRNS,                                      KC.NLCK,   KC.P7,   KC.P8,   KC.P9, KC.PMNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.UNDS, KC.MINS, KC.KC.LBRC, KC.KC.RBRC,                                      KC.PAST,   KC.P4,   KC.P5,   KC.P6, KC.PPLS, KC.TRNS,
+        KC.TRNS, KC.TRNS,  KC.EQL, KC.PLUS, KC.KC.LCBR, KC.KC.RCBR,                                      KC.PSLS,   KC.P1,   KC.P2,   KC.P3, KC.PENT, KC.TRNS,
+                          KC.TRNS, KC.TRNS,                KC.TRNS, KC.NO, KC.NO,      KC.LALT, KC.RSFT,  SFTGUI,            KC.P0, KC.PDOT,
+                                                             KC.NO, KC.NO, KC.NO,      KC.RGUI, KC.RCTL,  ALTCTL,
+    ],
+    [  #2
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,                                      KC.TRNS,  KC.TRNS,  KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,                                      KC.TRNS,  KC.TRNS,  KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.PGUP,  KC.INS,                                      KC.TRNS,  KC.TRNS,  KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.PSCR,                                      KC.TRNS, KC.RESET, KC.DEBUG, KC.TRNS,  KC.RLD, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.PGDN, KC.PAUS,                                      KC.TRNS,  KC.TRNS,  KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+                          KC.TRNS, KC.TRNS,           SFTGUI, KC.LSFT, KC.LALT,      KC.NO, KC.NO, KC.TRNS,            KC.TRNS, KC.SLCK,
+                                                      ALTCTL, KC.LCTL, KC.LGUI,      KC.NO, KC.NO,   KC.NO,
+    ],
+]

--- a/boards/dactyl_manuform_carbonfet/6x7/kb.py
+++ b/boards/dactyl_manuform_carbonfet/6x7/kb.py
@@ -1,0 +1,44 @@
+import board
+
+from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
+from kmk.quickpin.pro_micro.avr_promicro import translate as avr
+from kmk.quickpin.pro_micro.boardsource_blok import pinout as pins
+from kmk.scanners import DiodeOrientation
+
+
+class KMKKeyboard(_KMKKeyboard):
+    row_pins = (
+        pins[avr['D4']],
+        pins[avr['C6']],
+        pins[avr['D7']],
+        pins[avr['E6']],
+        pins[avr['B4']],
+        pins[avr['B5']],
+        pins[avr['B7']],
+    )
+    col_pins = (
+        pins[avr['F5']],
+        pins[avr['F6']],
+        pins[avr['F7']],
+        pins[avr['B1']],
+        pins[avr['B3']],
+        pins[avr['B2']],
+        pins[avr['B6']],
+    )
+    diode_orientation = DiodeOrientation.COLUMNS
+    data_pin = pins[avr['D0']]
+    # data_pin2 =
+    # rgb_pixel_pin = pins[avr['D3']]
+    # num_pixels = 12
+
+    # flake8: noqa
+    # fmt: off
+    coord_mapping = [
+        0,  1,  2,  3,  4,  5,  6,                      49, 50, 51, 52, 53, 54, 55,
+        7,  8,  9,  10, 11, 12, 13,                     56, 57, 58, 59, 60, 61, 62,
+        14, 15, 16, 17, 18, 19, 20,                     63, 64, 65, 66, 67, 68, 69,
+        21, 22, 23, 24, 25, 26, 27,                     70, 71, 72, 73, 74, 75, 76,
+        28, 29, 30, 31, 32, 33, 34,                     77, 78, 79, 80, 81, 82, 83,
+                    38, 39,     46, 40, 41,     84, 85, 93,     86, 87,
+                                45, 47, 48,     91, 92, 94 
+    ]

--- a/boards/dactyl_manuform_carbonfet/6x7/main.py
+++ b/boards/dactyl_manuform_carbonfet/6x7/main.py
@@ -1,0 +1,55 @@
+from kb import KMKKeyboard
+
+from kmk.keys import KC
+from kmk.modules.holdtap import HoldTap
+from kmk.modules.layers import Layers
+from kmk.modules.split import Split
+
+keyboard = KMKKeyboard()
+
+keyboard.modules.append(Layers())
+keyboard.modules.append(HoldTap())
+
+split = Split(
+    data_pin=keyboard.data_pin
+    # data_pin2=
+)
+keyboard.modules.append(split)
+
+L1_HOME = KC.LT(1, KC.HOME)
+L2_END = KC.LT(2, KC.END)
+M_DEL = KC.HT(KC.DEL, KC.MEH)
+H_BSPC = KC.HT(KC.BSPC, KC.HYPR)
+A_TAB = KC.HT(KC.TAB, KC.LALT)
+ALTCTL = KC.LALT(KC.LCTL)
+SFTGUI = KC.LSFT(KC.LGUI)
+
+keyboard.keymap = [
+    [   # 0
+        KC.TRNS,  KC.F1,  KC.F2,   KC.F3,   KC.F4, KC.F5,   KC.F6,                                         KC.F7, KC.F8,   KC.F9,  KC.F10,  KC.F11,  KC.F12, KC.TRNS,
+        KC.TRNS,  KC.ESC, KC.N1,   KC.N2,   KC.N3, KC.N4,   KC.N5,                                         KC.N6, KC.N7,   KC.N8,   KC.N9,   KC.N0,  KC.GRV, KC.TRNS,
+        KC.TRNS, KC.CAPS,  KC.Q,    KC.W,    KC.E,  KC.R,    KC.T,                                          KC.Y,  KC.U,    KC.I,    KC.O,    KC.P, KC.BSLS, KC.TRNS,
+        KC.TRNS, KC.LSFT,  KC.A,    KC.S,    KC.D,  KC.F,    KC.G,                                          KC.H,  KC.J,    KC.K,    KC.L, KC.SCLN, KC.RSFT, KC.TRNS,
+        KC.TRNS, KC.LCTL,  KC.Z,    KC.X,    KC.C,  KC.V,    KC.B,                                          KC.N,  KC.M, KC.COMM,  KC.DOT, KC.SLSH, KC.RCTL, KC.TRNS,
+                                 KC.LEFT, KC.RGHT,       KC.MO(1), KC.SPC,   A_TAB,      KC.LALT, KC.ENT, KC.MO(2),        KC.UP, KC.DOWN,
+                                                          KC.HOME,  M_DEL, KC.LGUI,      KC.RGUI, H_BSPC, KC.END,
+    ],
+    [  #1
+        KC.TRNS,  KC.F13,  KC.F14,  KC.F15,  KC.F16,     KC.F17,     KC.F18,                                       KC.F19,  KC.F20,  KC.F21,  KC.F22,  KC.F23,  KC.F24, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,    KC.TRNS,    KC.TRNS,                                      KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,    KC.TRNS,    KC.TRNS,                                      KC.NLCK,   KC.P7,   KC.P8,   KC.P9, KC.PMNS, KC.TRNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.UNDS, KC.MINS, KC.KC.LBRC, KC.KC.RBRC,                                      KC.PAST,   KC.P4,   KC.P5,   KC.P6, KC.PPLS, KC.TRNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS,  KC.EQL, KC.PLUS, KC.KC.LCBR, KC.KC.RCBR,                                      KC.PSLS,   KC.P1,   KC.P2,   KC.P3, KC.PENT, KC.TRNS, KC.TRNS,
+                                   KC.TRNS, KC.TRNS,                KC.TRNS, KC.NO, KC.NO,      KC.LALT, KC.RSFT,  SFTGUI,            KC.P0, KC.PDOT,
+                                                                      KC.NO, KC.NO, KC.NO,      KC.RGUI, KC.RCTL,  ALTCTL,
+    ],
+    [  #2
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,                                      KC.TRNS,  KC.TRNS,  KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,                                      KC.TRNS,  KC.TRNS,  KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.PGUP,  KC.INS,                                      KC.TRNS,  KC.TRNS,  KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.PSCR,                                      KC.TRNS, KC.RESET, KC.DEBUG, KC.TRNS,  KC.RLD, KC.TRNS, KC.TRNS,
+        KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.PGDN, KC.PAUS,                                      KC.TRNS,  KC.TRNS,  KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS, KC.TRNS,
+                                   KC.TRNS, KC.TRNS,           SFTGUI, KC.LSFT, KC.LALT,      KC.NO, KC.NO, KC.TRNS,            KC.TRNS, KC.SLCK,
+                                                               ALTCTL, KC.LCTL, KC.LGUI,      KC.NO, KC.NO,   KC.NO,
+    ],
+]

--- a/boards/dactyl_manuform_carbonfet/README.md
+++ b/boards/dactyl_manuform_carbonfet/README.md
@@ -11,7 +11,7 @@ Forked from the [Dactyl ManuForm Mini](/boards/dactyl_manuform_mini), the Dactyl
 Dactyl Manuform Carbonfets are built in variations that cater for different row and column counts.  
 Variants are denoted as `RowCount`*x*`ColumnCount` and share the common configuration of:
 - The finger key-well bottom row has 2 keys; 1 each in ring and middle columns.
-    - Exception to this rule is the `5x7` variant that has two additional keys in this row.
+   Exception to this rule is the `5x7` variant that has two additional keys in this row.
 - The thumb cluster has 5 keys: 2 (row) x 3 (column) arrangement with bottom left position ommited for left half, this arrangment mirrored for right half.
 
 ### Row

--- a/boards/dactyl_manuform_carbonfet/README.md
+++ b/boards/dactyl_manuform_carbonfet/README.md
@@ -1,5 +1,4 @@
 # Dactyl ManuForm Carbonfet
-
 The [Dactyl ManuForm Carbonfet](https://github.com/carbonfet/dactyl-manuform) is a handwired, split bodied, tented, curved key-well keyboard.  
 Forked from the [Dactyl ManuForm Mini](/boards/dactyl_manuform_mini), the Dactyl ManuForm Carbonfet appends the 5 key thumb cluster of the former with an additional key into a 2 row by 3 column arrangement.
 
@@ -7,7 +6,6 @@ Forked from the [Dactyl ManuForm Mini](/boards/dactyl_manuform_mini), the Dactyl
 *Dactyl Manuform Carbonfet 5x6 variant*
 
 ## Variants
-
 Dactyl Manuform Carbonfets are built in variations that cater for different row and column counts.  
 Variants are denoted as `RowCount`*x*`ColumnCount` and share the common configuration of:
 - The finger key-well bottom row has 2 keys; 1 each in ring and middle columns.
@@ -15,27 +13,27 @@ Variants are denoted as `RowCount`*x*`ColumnCount` and share the common configur
 - The thumb cluster has 5 keys: 2 (row) x 3 (column) arrangement with bottom left position ommited for left half, this arrangment mirrored for right half.
 
 ### Row
-| Count | Description |
-| :---: | :--- |
-| 4 | Three rows, typically for alphabet and some punctuation characters, with two keys in bottom row of finger key-well section |
-| 5 | As *4 rows* with number row above |
-| 6 | As *5 rows* with function row above |
+| Count | Description                                                                                                                |
+| ----- | -------------------------------------------------------------------------------------------------------------------------- |
+|     4 | Three rows, typically for alphabet and some punctuation characters, with two keys in bottom row of finger key-well section |
+|     5 | As *4 rows* with number row above                                                                                          |
+|     6 | As *5 rows* with function row above                                                                                        |
 
 ### Column
-| Count | Description |
-| :---: | :--- |
-| 5 | A column for each finger with additional index finger column |  
-| 6 | As *5 columns* with additional pinky finger column |
-| 7 | As *6 columns* with either an additional index finger column (`5x7`) or additional pinky column (`6x7`) |
+| Count | Description                                                                                             |
+| ----- | ------------------------------------------------------------------------------------------------------- |
+|     5 | A column for each finger with additional index finger column                                            |
+|     6 | As *5 columns* with additional pinky finger column                                                      |
+|     7 | As *6 columns* with either an additional index finger column (`5x7`) or additional pinky column (`6x7`) |
 
 ## Extended Bottom Row
-
 Further to this board's customisable ethos, the bottom row of the finger key-well can be extended, outward, from the default two keys.
 
 *Note: This does not apply to the `5x7` variant, as its bottom row is already extended*
 
 To accomodate this, in files of chosen variant:
-### `kb.py`  
+
+### `kb.py`
 `coord_mapping` element: Populate the extended row positions with numbers that continue numerical pattern of each half.  
 e.g. in the case of `4x6` variant:
 - `18, 19,` positions would be placed left of `20,` position.
@@ -45,13 +43,11 @@ e.g. in the case of `4x6` variant:
 `keyboard.keymap` element: For each layer, append with keycodes in the respective extended bottom row positions.
 
 ## KMk Specifics
-
 Extentions enabled by default:  
 - [Layers](/docs/en/layers.md)
 - [Split](/docs/en/split_keyboards.md): Configured to 1-wire UART to match legacy configuration. Please see documentation for enabling 2-wire UART or, for capable controllers, Bluetooth.
 
 ## Microcontroller support
-
 Replace `boardsource_blok` in variant's `kb.py` to a supported microcontroller in `kmk/quickpin/pro_micro`:
 
 ```python

--- a/boards/dactyl_manuform_carbonfet/README.md
+++ b/boards/dactyl_manuform_carbonfet/README.md
@@ -16,14 +16,14 @@ Variants are denoted as `RowCount`*x*`ColumnCount` and share the common configur
 
 ### Row
 | Count | Description |
-| --- | --- |
+| :---: | :--- |
 | 4 | Three rows, typically for alphabet and some punctuation characters, with two keys in bottom row of finger key-well section |
 | 5 | As *4 rows* with number row above |
 | 6 | As *5 rows* with function row above |
 
 ### Column
 | Count | Description |
-| --- | --- |
+| :---: | :--- |
 | 5 | A column for each finger with additional index finger column |  
 | 6 | As *5 columns* with additional pinky finger column |
 | 7 | As *6 columns* with either an additional index finger column (`5x7`) or additional pinky column (`6x7`) |

--- a/boards/dactyl_manuform_carbonfet/README.md
+++ b/boards/dactyl_manuform_carbonfet/README.md
@@ -8,7 +8,7 @@ Forked from the [Dactyl ManuForm Mini](/boards/dactyl_manuform_mini), the Dactyl
 
 ## Variants
 
-Dactyl Manuform Carbonfet's are built in variations that cater for different row and column counts.  
+Dactyl Manuform Carbonfets are built in variations that cater for different row and column counts.  
 Variants are denoted as `RowCount`*x*`ColumnCount` and share the common configuration of:
 - The finger key-well bottom row has 2 keys; 1 each in ring and middle columns.
     - Exception to this rule is the `5x7` variant that has two additional keys in this row.

--- a/boards/dactyl_manuform_carbonfet/README.md
+++ b/boards/dactyl_manuform_carbonfet/README.md
@@ -1,14 +1,14 @@
-# Dactyl ManuForm Mini
+# Dactyl ManuForm Carbonfet
 
 The [Dactyl ManuForm Carbonfet](https://github.com/carbonfet/dactyl-manuform) is a handwired, split bodied, tented, curved key-well keyboard.  
-Forked from the [Dactyl ManuForm](/boards/dactyl_manuform), the Dactyl ManuForm Carbonfet rearranges the 6 key thumb cluster of the former into a 2 row by 3 column arrangement.
+Forked from the [Dactyl ManuForm Mini](/boards/dactyl_manuform_mini), the Dactyl ManuForm Carbonfet appends the 5 key thumb cluster of the former with an additional key into a 2 row by 3 column arrangement.
 
-![White](![GlamShot](https://i.imgur.com/0ugz1C9.jpg))  
+![White](https://i.imgur.com/0ugz1C9.jpg)  
 *Dactyl Manuform Carbonfet 5x6 variant*
 
 ## Variants
 
-Dactyl Manuform Mini's are built in variations that cater for different row and column counts.  
+Dactyl Manuform Carbonfet's are built in variations that cater for different row and column counts.  
 Variants are denoted as `RowCount`*x*`ColumnCount` and share the common configuration of:
 - The finger key-well bottom row has 2 keys; 1 each in ring and middle columns.
     - Exception to this rule is the `5x7` variant that has two additional keys in this row.
@@ -39,7 +39,7 @@ To accomodate this, in files of chosen variant:
 `coord_mapping` element: Populate the extended row positions with numbers that continue numerical pattern of each half.  
 e.g. in the case of `4x6` variant:
 - `18, 19,` positions would be placed left of `20,` position.
-- `49, 48,` positions would be placed right of `50,` position.
+- `52, 53,` positions would be placed right of `51,` position.
 
 ### `main.py`  
 `keyboard.keymap` element: For each layer, append with keycodes in the respective extended bottom row positions.

--- a/boards/dactyl_manuform_carbonfet/README.md
+++ b/boards/dactyl_manuform_carbonfet/README.md
@@ -1,0 +1,59 @@
+# Dactyl ManuForm Mini
+
+The [Dactyl ManuForm Carbonfet](https://github.com/carbonfet/dactyl-manuform) is a handwired, split bodied, tented, curved key-well keyboard.  
+Forked from the [Dactyl ManuForm](/boards/dactyl_manuform), the Dactyl ManuForm Carbonfet rearranges the 6 key thumb cluster of the former into a 2 row by 3 column arrangement.
+
+![White](![GlamShot](https://i.imgur.com/0ugz1C9.jpg))  
+*Dactyl Manuform Carbonfet 5x6 variant*
+
+## Variants
+
+Dactyl Manuform Mini's are built in variations that cater for different row and column counts.  
+Variants are denoted as `RowCount`*x*`ColumnCount` and share the common configuration of:
+- The finger key-well bottom row has 2 keys; 1 each in ring and middle columns.
+    - Exception to this rule is the `5x7` variant that has two additional keys in this row.
+- The thumb cluster has 5 keys: 2 (row) x 3 (column) arrangement with bottom left position ommited for left half, this arrangment mirrored for right half.
+
+### Row
+| Count | Description |
+| --- | --- |
+| 4 | Three rows, typically for alphabet and some punctuation characters, with two keys in bottom row of finger key-well section |
+| 5 | As *4 rows* with number row above |
+| 6 | As *5 rows* with function row above |
+
+### Column
+| Count | Description |
+| --- | --- |
+| 5 | A column for each finger with additional index finger column |  
+| 6 | As *5 columns* with additional pinky finger column |
+| 7 | As *6 columns* with either an additional index finger column (`5x7`) or additional pinky column (`6x7`) |
+
+## Extended Bottom Row
+
+Further to this board's customisable ethos, the bottom row of the finger key-well can be extended, outward, from the default two keys.
+
+*Note: This does not apply to the `5x7` variant, as its bottom row is already extended*
+
+To accomodate this, in files of chosen variant:
+### `kb.py`  
+`coord_mapping` element: Populate the extended row positions with numbers that continue numerical pattern of each half.  
+e.g. in the case of `4x6` variant:
+- `18, 19,` positions would be placed left of `20,` position.
+- `49, 48,` positions would be placed right of `50,` position.
+
+### `main.py`  
+`keyboard.keymap` element: For each layer, append with keycodes in the respective extended bottom row positions.
+
+## KMk Specifics
+
+Extentions enabled by default:  
+- [Layers](/docs/en/layers.md)
+- [Split](/docs/en/split_keyboards.md): Configured to 1-wire UART to match legacy configuration. Please see documentation for enabling 2-wire UART or, for capable controllers, Bluetooth.
+
+## Microcontroller support
+
+Replace `boardsource_blok` in variant's `kb.py` to a supported microcontroller in `kmk/quickpin/pro_micro`:
+
+```python
+from kmk.quickpin.pro_micro.boardsource_blok import pinout as pins
+```


### PR DESCRIPTION
Addition of the [carbonfet](https://github.com/carbonfet) thumb cluster variation of the dactyl_manuform to KMK