### PR TITLE
fix: exception when using combos with match_coord

### DIFF
--- a/kmk/modules/combos.py
+++ b/kmk/modules/combos.py
@@ -54,7 +54,10 @@ class Combo:
             self._match_coord = match_coord
 
     def __repr__(self):
-        return f'{self.__class__.__name__}({[k.code for k in self.match]})'
+        if self._match_coord:
+            return f'{self.__class__.__name__}({[k for k in self.match]})'
+        else:
+            return f'{self.__class__.__name__}({[k.code for k in self.match]})'
 
     def matches(self, key: Key, int_coord: int):
         raise NotImplementedError


### PR DESCRIPTION
when using combos with `match_coord = True` and debugging enabled `__repr__` would throw an exception.