### PR TITLE
Fix DiodeOrientation imports from matrix module

### DIFF
--- a/boards/ZFR_KBD/RP2.65-F/kb.py
+++ b/boards/ZFR_KBD/RP2.65-F/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):

--- a/boards/sofle/sofleV2/kb.py
+++ b/boards/sofle/sofleV2/kb.py
@@ -1,7 +1,7 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 # change this to match your MCU board
 from kmk.quickpin.pro_micro.sparkfun_promicro_rp2040 import pinout as pins
 


### PR DESCRIPTION
`DiodeOrientation` was moved into `kmk.scanners` in #386. Ran into an import that wasn't updated in the Sofle config, and found one more instance of it in another board config.