### PR TITLE
Added Quickpin for Elite Pi

### DIFF
--- a/kmk/quickpin/pro_micro/elite_pi.py
+++ b/kmk/quickpin/pro_micro/elite_pi.py
@@ -1,0 +1,28 @@
+import board
+
+pins = [
+    board.D0,
+    board.D1,
+    None,  # GND
+    None,  # GND
+    board.D2,
+    board.D3,
+    board.D4,
+    board.D5,
+    board.D6,
+    board.D7,
+    board.D8,
+    board.D9,
+    board.D21,
+    board.D23,
+    board.D20,
+    board.D22,
+    board.D26,
+    board.D27,
+    board.D28,
+    board.D29,
+    None,  # VCC
+    None,  # RST
+    None,  # GND
+    None,  # RAW
+]

--- a/kmk/quickpin/pro_micro/elite_pi.py
+++ b/kmk/quickpin/pro_micro/elite_pi.py
@@ -1,6 +1,6 @@
 import board
 
-pins = [
+pinout = [
     board.D0,
     board.D1,
     None,  # GND
@@ -22,7 +22,7 @@ pins = [
     board.D28,
     board.D29,
     None,  # VCC
-    None,  # RST
+    None,  # RUN
     None,  # GND
     None,  # RAW
 ]


### PR DESCRIPTION
Add Quickpin Support for the [Elite Pi](https://splitkb.com/products/elite-pi) using [this](https://docs.keeb.io/elite-pi-guide) as a Reference.