### PR TITLE
determine breath val on selected val

### DIFF
--- a/kmk/extensions/rgb.py
+++ b/kmk/extensions/rgb.py
@@ -485,7 +485,7 @@ class RGB(Extension):
         multip_1 = exp(sined) - self.breathe_center / e
         multip_2 = self.val / (e - 1 / e)
 
-        self._animate_val = int(multip_1 * multip_2)
+        val = int(multip_1 * multip_2)
         self.pos = (self.pos + self._step) % 256
         self.set_hsv_fill(self.hue, self.sat, self._animate_val)
 

--- a/kmk/extensions/rgb.py
+++ b/kmk/extensions/rgb.py
@@ -487,7 +487,7 @@ class RGB(Extension):
 
         val = int(multip_1 * multip_2)
         self.pos = (self.pos + self._step) % 256
-        self.set_hsv_fill(self.hue, self.sat, self._animate_val)
+        self.set_hsv_fill(self.hue, self.sat, val)
 
     def effect_breathing_rainbow(self):
         self.increase_hue(self._step)

--- a/kmk/extensions/rgb.py
+++ b/kmk/extensions/rgb.py
@@ -132,6 +132,7 @@ class RGB(Extension):
         self.disable_auto_write = disable_auto_write
         self.pixels = pixels
         self.refresh_rate = refresh_rate
+        self._animate_val = val_default
 
         self.rgbw = bool(len(rgb_order) == 4)
 
@@ -482,11 +483,11 @@ class RGB(Extension):
         # https://github.com/qmk/qmk_firmware/blob/9f1d781fcb7129a07e671a46461e501e3f1ae59d/quantum/rgblight.c#L806
         sined = sin((self.pos / 255.0) * pi)
         multip_1 = exp(sined) - self.breathe_center / e
-        multip_2 = self.val_limit / (e - 1 / e)
+        multip_2 = self.val / (e - 1 / e)
 
-        self.val = int(multip_1 * multip_2)
+        self._animate_val = int(multip_1 * multip_2)
         self.pos = (self.pos + self._step) % 256
-        self.set_hsv_fill(self.hue, self.sat, self.val)
+        self.set_hsv_fill(self.hue, self.sat, self._animate_val)
 
     def effect_breathing_rainbow(self):
         self.increase_hue(self._step)

--- a/kmk/extensions/rgb.py
+++ b/kmk/extensions/rgb.py
@@ -132,7 +132,6 @@ class RGB(Extension):
         self.disable_auto_write = disable_auto_write
         self.pixels = pixels
         self.refresh_rate = refresh_rate
-        self._animate_val = val_default
 
         self.rgbw = bool(len(rgb_order) == 4)
 


### PR DESCRIPTION
Use the selected Brightness (val) to determine the max brightness for breathing animations, rather than the max. 

Prevents me being blinded at night when I change animations.