### PR TITLE
Fix SSD1306

### DIFF
--- a/kmk/extensions/display.py
+++ b/kmk/extensions/display.py
@@ -14,6 +14,7 @@ from kmk.utils import clamp
 
 displayio.release_displays()
 
+
 class TextEntry:
     def __init__(
         self,

--- a/kmk/extensions/display.py
+++ b/kmk/extensions/display.py
@@ -12,6 +12,7 @@ from kmk.kmktime import PeriodicTimer, ticks_diff
 from kmk.modules.split import Split, SplitSide
 from kmk.utils import clamp
 
+displayio.release_displays()
 
 class TextEntry:
     def __init__(
@@ -132,8 +133,6 @@ class BuiltInDisplay(DisplayBackend):
 
 
 class SSD1306(DisplayBackend):
-    displayio.release_displays()
-
     def __init__(self, i2c=None, sda=None, scl=None, device_address=0x3C):
         self.device_address = device_address
         # i2c initialization

--- a/kmk/extensions/display.py
+++ b/kmk/extensions/display.py
@@ -133,6 +133,7 @@ class BuiltInDisplay(DisplayBackend):
 
 class SSD1306(DisplayBackend):
     displayio.release_displays()
+
     def __init__(self, i2c=None, sda=None, scl=None, device_address=0x3C):
         self.device_address = device_address
         # i2c initialization
@@ -302,7 +303,7 @@ class Display(Extension):
                 del self.entries[idx]
 
         self.display.during_bootup(self.width, self.height, 180 if self.flip else 0)
-        self.display.brightness=self.brightness
+        self.display.brightness = self.brightness
 
     def before_matrix_scan(self, sandbox):
         if self.dim_period.tick():

--- a/kmk/extensions/display.py
+++ b/kmk/extensions/display.py
@@ -132,8 +132,8 @@ class BuiltInDisplay(DisplayBackend):
 
 
 class SSD1306(DisplayBackend):
+    displayio.release_displays()
     def __init__(self, i2c=None, sda=None, scl=None, device_address=0x3C):
-        displayio.release_displays()
         self.device_address = device_address
         # i2c initialization
         self.i2c = i2c
@@ -148,7 +148,6 @@ class SSD1306(DisplayBackend):
             width=width,
             height=height,
             rotation=rotation,
-            brightness=self.brightness,
         )
 
         return self.display
@@ -303,6 +302,7 @@ class Display(Extension):
                 del self.entries[idx]
 
         self.display.during_bootup(self.width, self.height, 180 if self.flip else 0)
+        self.display.brightness=self.brightness
 
     def before_matrix_scan(self, sandbox):
         if self.dim_period.tick():


### PR DESCRIPTION
Simple fix to make SSD1306 work again.

Adding `displayio.release_displays()` might be needed for other backends if user is experiencing `ValueError: pin in use` on soft reboot.