### PR TITLE
Remove _ext suffix from variable names

### DIFF
--- a/boards/anavi/anavi-arrows/code.py
+++ b/boards/anavi/anavi-arrows/code.py
@@ -28,7 +28,7 @@ keyboard.keymap = [
 ]
 # fmt: on
 
-oled_ext = Oled(
+oled = Oled(
     OledData(
         corner_one={0: OledReactionType.STATIC, 1: ['ANAVI Arrows']},
         corner_two={0: OledReactionType.STATIC, 1: [' ']},
@@ -40,9 +40,9 @@ oled_ext = Oled(
     toDisplay=OledDisplayMode.TXT,
     flip=False,
 )
-keyboard.extensions.append(oled_ext)
+keyboard.extensions.append(oled)
 
-led_ext = LED(
+led = LED(
     led_pin=[
         board.D0,
     ],
@@ -55,7 +55,7 @@ led_ext = LED(
     user_animation=None,
     val=100,
 )
-keyboard.extensions.append(led_ext)
+keyboard.extensions.append(led)
 
 # WS2812B LED strips on the back
 underglow = RGB(

--- a/boards/anavi/knob1/code.py
+++ b/boards/anavi/knob1/code.py
@@ -20,14 +20,14 @@ encoder_handler.pins = ((board.D1, board.D2, board.D0),)
 encoder_handler.map = (((KC.VOLD, KC.VOLU, KC.MUTE),),)
 knob.modules.append(encoder_handler)
 
-rgb_ext = RGB(
+rgb = RGB(
     pixel_pin=board.NEOPIXEL,
     num_pixels=1,
     val_limit=100,
     val_default=25,
     animation_mode=AnimationModes.RAINBOW,
 )
-knob.extensions.append(rgb_ext)
+knob.extensions.append(rgb)
 
 knob.keymap = [[KC.MUTE]]
 

--- a/boards/anavi/knobs3/code.py
+++ b/boards/anavi/knobs3/code.py
@@ -28,14 +28,14 @@ knob.modules.append(encoder_handler)
 
 print('ANAVI Knobs 3')
 
-rgb_ext = RGB(
+rgb = RGB(
     pixel_pin=board.NEOPIXEL,
     num_pixels=1,
     val_limit=100,
     val_default=25,
     animation_mode=AnimationModes.RAINBOW,
 )
-knob.extensions.append(rgb_ext)
+knob.extensions.append(rgb)
 
 knob.keymap = [[KC.MUTE]]
 

--- a/boards/anavi/macro-pad-10/code.py
+++ b/boards/anavi/macro-pad-10/code.py
@@ -11,7 +11,7 @@ from kmk.scanners import DiodeOrientation
 print('ANAVI Macro Pad 10')
 
 keyboard = KMKKeyboard()
-led_ext = LED(
+led = LED(
     led_pin=[
         board.D0,
     ],
@@ -24,7 +24,7 @@ led_ext = LED(
     user_animation=None,
     val=100,
 )
-keyboard.extensions.append(led_ext)
+keyboard.extensions.append(led)
 
 # WS2812B LED strips on the back
 underglow = RGB(

--- a/boards/anavi/macro-pad-12/code.py
+++ b/boards/anavi/macro-pad-12/code.py
@@ -19,7 +19,7 @@ keyboard = KMKKeyboard()
 keyboard.SCL = board.D5
 keyboard.SDA = board.D4
 
-oled_ext = Oled(
+oled = Oled(
     OledData(
         corner_one={0: OledReactionType.STATIC, 1: ['ANAVI Macro Pad 12']},
         corner_two={0: OledReactionType.STATIC, 1: [' ']},
@@ -31,9 +31,9 @@ oled_ext = Oled(
     toDisplay=OledDisplayMode.TXT,
     flip=False,
 )
-keyboard.extensions.append(oled_ext)
+keyboard.extensions.append(oled)
 
-led_ext = LED(
+led = LED(
     led_pin=[
         board.D0,
     ],
@@ -46,7 +46,7 @@ led_ext = LED(
     user_animation=None,
     val=100,
 )
-keyboard.extensions.append(led_ext)
+keyboard.extensions.append(led)
 
 # WS2812B LED strips on the back
 underglow = RGB(

--- a/boards/atreus62/main.py
+++ b/boards/atreus62/main.py
@@ -24,10 +24,10 @@ XXXXXXX = KC.NO
 layers = Layers()
 
 # 1 encoder, no button, inversed = True
-encoder_ext = EncoderHandler(
+encoder = EncoderHandler(
     (board.D40, board.D41, None, True),
 )
-keyboard.modules = [layers, encoder_ext]
+keyboard.modules = [layers, encoder]
 
 keyboard.tap_time = 250
 keyboard.debug_enabled = False

--- a/boards/boardsource/Lulu/main.py
+++ b/boards/boardsource/Lulu/main.py
@@ -22,7 +22,7 @@ layers = Layers()
 keyboard.modules.append(layers)
 keyboard.modules.append(holdtap)
 
-oled_ext = Oled(
+oled = Oled(
     OledData(
         corner_one={0: OledReactionType.STATIC, 1: ['qwertyzzzz']},
         corner_two={
@@ -41,10 +41,10 @@ oled_ext = Oled(
     toDisplay=OledDisplayMode.TXT,
     flip=False,
 )
-keyboard.extensions.append(oled_ext)
+keyboard.extensions.append(oled)
 
 # Default RGB matrix colours
-rgb_ext = Rgb_matrix(
+rgb = Rgb_matrix(
     ledDisplay=[
         [85, 0, 255],
         [0, 255, 234],
@@ -121,7 +121,7 @@ rgb_ext = Rgb_matrix(
     rightSide=False,
     disable_auto_write=True,
 )
-keyboard.extensions.append(rgb_ext)
+keyboard.extensions.append(rgb)
 
 # TODO Comment one of these on each side
 split_side = SplitSide.LEFT

--- a/boards/fourtypercentclub/luddite/main.py
+++ b/boards/fourtypercentclub/luddite/main.py
@@ -10,10 +10,10 @@ keyboard = KMKKeyboard()
 _______ = KC.TRNS
 XXXXXXX = KC.NO
 
-rgb_ext = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels)
+rgb = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels)
 led = LED()
 layers = Layers()
-keyboard.extensions = [rgb_ext, led]
+keyboard.extensions = [rgb, led]
 keyboard.modules = [layers]
 
 BASE = 0

--- a/boards/keebio/iris/main.py
+++ b/boards/keebio/iris/main.py
@@ -56,7 +56,7 @@ HELLA_TD = KC.TD(
     KC.TG(1),
 )
 
-rgb_ext = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels)
+rgb = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels)
 layers = Layers()
 
 # TODO Comment one of these on each side
@@ -64,7 +64,7 @@ split_side = SplitSide.LEFT
 split_side = SplitSide.RIGHT
 split = Split(split_type=SplitType.BLE, split_side=split_side)
 
-keyboard.extensions = [rgb_ext]
+keyboard.extensions = [rgb]
 keyboard.modules = [split, layers]
 
 

--- a/boards/keebio/levinson/main.py
+++ b/boards/keebio/levinson/main.py
@@ -7,14 +7,14 @@ from kmk.modules.split import Split, SplitSide, SplitType
 
 keyboard = KMKKeyboard()
 
-rgb_ext = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels)
+rgb = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels)
 layers = Layers()
 # TODO Comment one of these on each side
 split_side = SplitSide.LEFT
 split_side = SplitSide.RIGHT
 split = Split(split_type=SplitType.BLE, split_side=split_side)
 
-keyboard.extensions = [rgb_ext]
+keyboard.extensions = [rgb]
 keyboard.modules = [layers, split]
 
 _______ = KC.TRNS

--- a/boards/keebio/nyquist/main.py
+++ b/boards/keebio/nyquist/main.py
@@ -7,7 +7,7 @@ from kmk.modules.split import Split, SplitSide, SplitType
 
 keyboard = KMKKeyboard()
 
-rgb_ext = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels)
+rgb = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels)
 layers = Layers()
 
 # TODO Comment one of these on each side
@@ -16,7 +16,7 @@ split_side = SplitSide.RIGHT
 split = Split(split_type=SplitType.BLE, split_side=split_side)
 
 keyboard.modules = [layers, split]
-keyboard.extensions = [rgb_ext]
+keyboard.extensions = [rgb]
 
 _______ = KC.TRNS
 XXXXXXX = KC.NO

--- a/boards/kyria/main.py
+++ b/boards/kyria/main.py
@@ -24,12 +24,12 @@ encoder_handler = EncoderHandler()
 encoder_handler.pins = ((keyboard.encoder_pin_0, keyboard.encoder_pin_1, None, False),)
 
 # Uncomment below if you're having RGB
-rgb_ext = RGB(
+rgb = RGB(
     pixel_pin=keyboard.rgb_pixel_pin,
     num_pixels=10,
     animation_mode=AnimationModes.BREATHING_RAINBOW,
 )
-keyboard.extensions.append(rgb_ext)
+keyboard.extensions.append(rgb)
 
 # Edit your layout below
 # Currently, that's a default QMK Kyria Layout - https://config.qmk.fm/#/splitkb/kyria/rev1/LAYOUT

--- a/boards/lunakey_pico/main.py
+++ b/boards/lunakey_pico/main.py
@@ -20,7 +20,7 @@ keyboard = KMKKeyboard()
 keyboard.tap_time = 100
 
 layers = Layers()
-holdtap_ext = HoldTap()
+holdtap = HoldTap()
 
 # TODO Comment one of these on each side
 split_side = SplitSide.LEFT
@@ -37,15 +37,15 @@ split = Split(
     data_pin2=data_pin2
 )
 
-rgb_ext = RGB(
+rgb = RGB(
     pixel_pin=board.GP6,
     num_pixels=6,
     animation_mode=AnimationModes.BREATHING_RAINBOW
 )
 
-keyboard.modules = [layers, holdtap_ext, split]
+keyboard.modules = [layers, holdtap, split]
 keyboard.extensions.append(MediaKeys())
-keyboard.extensions.append(rgb_ext)
+keyboard.extensions.append(rgb)
 
 if split_side == SplitSide.LEFT:
     buzzer = pwmio.PWMOut(board.GP8, variable_frequency=True)

--- a/boards/pimoroni/keybow/keybow.py
+++ b/boards/pimoroni/keybow/keybow.py
@@ -94,7 +94,7 @@ else:
 
 
 led_strip = adafruit_dotstar.DotStar(_LED_PINS[0], _LED_PINS[1], 12)
-rgb_ext = RGB(
+rgb = RGB(
     pixel_pin=0,
     pixels=led_strip,
     num_pixels=12,
@@ -107,7 +107,7 @@ class Keybow(KMKKeyboard):
     Default keyboard config for the Keybow.
     '''
 
-    extensions = [rgb_ext]
+    extensions = [rgb]
 
     def __init__(self):
         self.matrix = KeysScanner(_KEY_CFG)

--- a/boards/pimoroni/keybow_2040/code.py
+++ b/boards/pimoroni/keybow_2040/code.py
@@ -4,7 +4,7 @@ from keybow_2040 import Keybow2040
 from kmk.extensions.rgb import RGB, AnimationModes
 from kmk.keys import KC
 
-rgb_ext = RGB(
+rgb = RGB(
     pixel_pin=0,
     pixels=Keybow2040Leds(16),
     num_pixels=16,
@@ -12,7 +12,7 @@ rgb_ext = RGB(
 )
 
 keybow = Keybow2040()
-keybow.extensions = [rgb_ext]
+keybow.extensions = [rgb]
 
 # fmt: off
 keybow.keymap = [

--- a/boards/zodiark/main.py
+++ b/boards/zodiark/main.py
@@ -22,7 +22,7 @@ layers = Layers()
 keyboard.modules.append(layers)
 keyboard.modules.append(holdtap)
 
-oled_ext = Oled(
+oled = Oled(
     OledData(
         corner_one={0: OledReactionType.STATIC, 1: ['qwertyzzzz']},
         corner_two={
@@ -41,10 +41,10 @@ oled_ext = Oled(
     toDisplay=OledDisplayMode.TXT,
     flip=False,
 )
-keyboard.extensions.append(oled_ext)
+keyboard.extensions.append(oled)
 
 # Default RGB matrix colours
-rgb_ext = Rgb_matrix(
+rgb = Rgb_matrix(
     ledDisplay=[
         [80, 0, 80],
         [80, 0, 80],
@@ -113,7 +113,7 @@ rgb_ext = Rgb_matrix(
     rightSide=False,
     disable_auto_write=True,
 )
-keyboard.extensions.append(rgb_ext)
+keyboard.extensions.append(rgb)
 
 # TODO Comment one of these on each side
 split_side = SplitSide.LEFT

--- a/docs/en/Display.md
+++ b/docs/en/Display.md
@@ -172,7 +172,7 @@ keyboard.extensions.append(display)
 Inverts colours of your text. Comes in handy, for example, as a good layer indicator.
 
 ```python
-display_ext = Display(
+display = Display(
     entries=[
         TextEntry(text='0 1 2 4', x=0, y=0),
         TextEntry(text='0', x=0, y=0, inverted=True, layer=0),

--- a/docs/en/led.md
+++ b/docs/en/led.md
@@ -9,8 +9,8 @@ LED's.
 from kmk.extensions.LED import LED
 import board
 
-led_ext = LED(led_pin=[board.GP0, board.GP1])
-keyboard.extensions.append(led_ext)
+led = LED(led_pin=[board.GP0, board.GP1])
+keyboard.extensions.append(led)
 ```
 
 ## [Keycodes]
@@ -43,7 +43,7 @@ LED_DEC_1_2 = KC.LED_DEC(1,2)
 All of these values can be set by default for when the keyboard boots.
 ```python
 from kmk.extensions.led import AnimationModes
-led_ext = LED(
+led = LED(
     led_pin=led_pin,
     brightness=50,
     brightness_step=5,

--- a/docs/en/peg_oled_display.md
+++ b/docs/en/peg_oled_display.md
@@ -40,7 +40,7 @@ No matter how you are going to use the oled you need this part (in `main.py`):
     from kmk.extensions.peg_oled_Display import Oled,OledDisplayMode,OledReactionType,OledData
     keyboard = KMKKeyboard()
     # ... Other oled code
-    keyboard.extensions.append(oled_ext) 
+    keyboard.extensions.append(oled) 
 
 ```
 ### Photos
@@ -59,7 +59,7 @@ Oled takes 2-3 arguments
 
 
 ```python
-oled_ext = Oled(OledData(image={0:OledReactionType.LAYER,1:["1.bmp","2.bmp","1.bmp","2.bmp"]}),toDisplay=OledDisplayMode.IMG,flip=False)
+oled = Oled(OledData(image={0:OledReactionType.LAYER,1:["1.bmp","2.bmp","1.bmp","2.bmp"]}),toDisplay=OledDisplayMode.IMG,flip=False)
 ```
 In this code example we are saying to react to the layer change and load a image filed named "1.bmp" for layer one and "2.bmp" for layer two and so on.
 
@@ -85,7 +85,7 @@ In this code we will always display the word "layer" in the top left corner of t
 
 
 ```python
-oled_ext = Oled(
+oled = Oled(
     OledData(
         corner_one={0:OledReactionType.STATIC,1:["layer"]},
         corner_two={0:OledReactionType.LAYER,1:["1","2","3","4"]},
@@ -101,7 +101,7 @@ Your oled data can be a variable as shown below with images.
 ```python
 oled_display_data=OledData(image={0:OledReactionType.LAYER,1:["1.bmp","2.bmp","1.bmp","2.bmp"]})
 
-oled_ext = Oled(oled_display_data,toDisplay=OledDisplayMode.IMG,flip=False)
+oled = Oled(oled_display_data,toDisplay=OledDisplayMode.IMG,flip=False)
 ```
 
 ### Text example

--- a/docs/en/peg_rgb_matrix.md
+++ b/docs/en/peg_rgb_matrix.md
@@ -112,8 +112,8 @@ It is possible your chosen board may already have these changes made, if not you
 ```python
 from kmk.extensions.peg_rgb_matrix import Rgb_matrix,Rgb_matrix_data,Color
 # ... Other code
-rgb_ext = Rgb_matrix(...per key color data)
-keyboard.extensions.append(rgb_ext)
+rgb = Rgb_matrix(...per key color data)
+keyboard.extensions.append(rgb)
 ```
 
 Rgb_matrix extension requires one argument (`Rgb_matrix_data`), although additional arguments can be passed, here are all arguments that can be passed to 
@@ -160,7 +160,7 @@ Rgb_matrix_data(
 ### Full Examples
 
 ```python
-rgb_ext = Rgb_matrix(ledDisplay=Rgb_matrix_data(
+rgb = Rgb_matrix(ledDisplay=Rgb_matrix_data(
     keys=[
     [255,55,55],[55,55,55],[55,55,55],[55,55,55],[55,55,55],[55,55,55],                        [55,55,55],[55,55,55],[55,55,55],[55,55,55],[55,55,55],[255,55,55],
     [255,55,55],[55,55,55],[55,55,55],[55,55,55],[55,55,55],[55,55,55],                        [55,55,55],[55,55,55],[55,55,55],[55,55,55],[55,55,55],[255,55,55],

--- a/docs/ptBR/encoder.md
+++ b/docs/ptBR/encoder.md
@@ -51,14 +51,14 @@ encoder_map = [
 
 # create the encoder instance, and pass in a list of pad a pins, a lsit of pad b
 # pins, and the encoder map created above
-encoder_ext = EncoderHandler([board.D40],[board.D41], encoder_map)
+encoder = EncoderHandler([board.D40],[board.D41], encoder_map)
 
 # if desired, you can flip the incrfement/decrement direction of the knob by
 # setting the is_inerted flag to True.  If you turn the knob to the right and
 # the volume goes down, setting this flag will make it go up.  It's default
 # setting is False
-encoder_ext.encoders[0].is_inverted = True
+encoder.encoders[0].is_inverted = True
 
-# Make sure to add the encoder_ext to the modules list
-keyboard.modules = [encoder_ext]
+# Make sure to add the encoder to the modules list
+keyboard.modules = [encoder]
 ```

--- a/docs/ptBR/led.md
+++ b/docs/ptBR/led.md
@@ -12,8 +12,8 @@ não ao total dos dois juntos.
 from kmk.extensions.RGB import RGB
 from kb import led_pin  # This can be imported or defined manually
 
-led_ext = LED(led_pin=led_pin)
-keyboard.extensions.append(led_ext)
+led = LED(led_pin=led_pin)
+keyboard.extensions.append(led)
 ```
 
 ## [Keycodes]
@@ -35,7 +35,7 @@ Todos esses valores podem ser atribuídos por padrão quando o teclado inicia.
 
 ```python
 from kmk.extensions.led import AnimationModes
-led_ext = LED(
+led = LED(
     led_pin=led_pin,
     brightness_step=5,
     brightness_limit=100,

--- a/docs/ptBR/rgb.md
+++ b/docs/ptBR/rgb.md
@@ -39,8 +39,8 @@ parte, não pelo total das duas.
 from kmk.extensions.RGB import RGB
 from kb import rgb_pixel_pin  # This can be imported or defined manually
 
-rgb_ext = RGB(pixel_pin=rgb_pixel_pin, num_pixels=27)
-keyboard.extensions.append(rgb_ext)
+rgb = RGB(pixel_pin=rgb_pixel_pin, num_pixels=27)
+keyboard.extensions.append(rgb)
 ```
 
 ## [Keycodes]
@@ -123,7 +123,7 @@ numa macro, ou numa troca de camadas, eis  algumas funções disponíveis:
 
 ```python
 from kmk.extensions.rgb import AnimationModes
-rgb_ext = RGB(pixel_pin=rgb_pixel_pin,
+rgb = RGB(pixel_pin=rgb_pixel_pin,
         num_pixels=27
         num_pixels=0,
         val_limit=100,

--- a/user_keymaps/ZFR_KBD/RP2.65-F.py
+++ b/user_keymaps/ZFR_KBD/RP2.65-F.py
@@ -16,7 +16,7 @@ keyboard.modules.append(Layers())
 keyboard.modules.append(MidiKeys())
 
 
-rgb_ext = RGB(
+rgb = RGB(
     val_default=10,
     val_limit=100,  # out of 255
     pixel_pin=keyboard.rgb_pixel_pin,
@@ -25,7 +25,7 @@ rgb_ext = RGB(
     animation_speed=3,
     animation_mode=AnimationModes.STATIC,
 )
-keyboard.extensions.append(rgb_ext)
+keyboard.extensions.append(rgb)
 keyboard.extensions.append(MediaKeys())
 
 _______ = KC.TRNS

--- a/user_keymaps/dgriswo/pyKey60.py
+++ b/user_keymaps/dgriswo/pyKey60.py
@@ -13,10 +13,10 @@ from kmk.scanners import DiodeOrientation
 keyboard = _KMKKeyboard()
 keyboard.modules.append(Layers())
 
-rgb_ext = RGB(
+rgb = RGB(
     pixel_pin=board.NEOPIXEL, num_pixels=61, animation_mode=AnimationModes.STATIC
 )
-keyboard.extensions.append(rgb_ext)
+keyboard.extensions.append(rgb)
 
 keyboard.col_pins = (
     board.COL1, board.COL2, board.COL3, board.COL4, board.COL5, board.COL6, board.COL7,

--- a/user_keymaps/dzervas/lab68.py
+++ b/user_keymaps/dzervas/lab68.py
@@ -15,8 +15,8 @@ from kmk.scanners import DiodeOrientation
 i2c = busio.I2C(scl=board.SCL, sda=board.SDA, frequency=100000)
 mcp = MCP23017(i2c, address=0x20)
 keyboard = KMKKeyboard()
-layer_ext = Layers
-keyboard.modules = [layer_ext]
+layer = Layers
+keyboard.modules = [layer]
 
 _______ = KC.TRNS
 XXXXXXX = KC.NO

--- a/user_keymaps/jpconstantineau/gridmx47.py
+++ b/user_keymaps/jpconstantineau/gridmx47.py
@@ -12,8 +12,8 @@ from kmk.modules.layers import Layers
 keyboard = KMKKeyboard()
 keyboard.modules.append(Layers())
 
-rgb_ext = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels, animation_mode=AnimationModes.STATIC)
-keyboard.extensions.append(rgb_ext)
+rgb = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels, animation_mode=AnimationModes.STATIC)
+keyboard.extensions.append(rgb)
 
 FUN = KC.MO(1)
 UPPER = KC.MO(2)

--- a/user_keymaps/jpconstantineau/offsetmx43.py
+++ b/user_keymaps/jpconstantineau/offsetmx43.py
@@ -12,8 +12,8 @@ from kmk.modules.layers import Layers
 keyboard = KMKKeyboard()
 keyboard.modules.append(Layers())
 
-rgb_ext = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels, animation_mode=AnimationModes.STATIC)
-keyboard.extensions.append(rgb_ext)
+rgb = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels, animation_mode=AnimationModes.STATIC)
+keyboard.extensions.append(rgb)
 
 FUN = KC.MO(1)
 UPPER = KC.MO(2)

--- a/user_keymaps/jpconstantineau/pyKey60.py
+++ b/user_keymaps/jpconstantineau/pyKey60.py
@@ -11,8 +11,8 @@ from kmk.modules.layers import Layers
 keyboard = KMKKeyboard()
 keyboard.modules.append(Layers())
 
-rgb_ext = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels, animation_mode=AnimationModes.STATIC)
-keyboard.extensions.append(rgb_ext)
+rgb = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels, animation_mode=AnimationModes.STATIC)
+keyboard.extensions.append(rgb)
 
 FN = KC.MO(1)
 FN2 = KC.MO(2)

--- a/user_keymaps/jpconstantineau/vcolchoc44_colemak_dh.py
+++ b/user_keymaps/jpconstantineau/vcolchoc44_colemak_dh.py
@@ -12,8 +12,8 @@ from kmk.modules.layers import Layers
 keyboard = KMKKeyboard()
 keyboard.modules.append(Layers())
 
-rgb_ext = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels, animation_mode=AnimationModes.STATIC)
-keyboard.extensions.append(rgb_ext)
+rgb = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels, animation_mode=AnimationModes.STATIC)
+keyboard.extensions.append(rgb)
 
 FUN = KC.MO(1)
 UPPER = KC.MO(2)

--- a/user_keymaps/jpconstantineau/vcolchoc44_qwerty.py
+++ b/user_keymaps/jpconstantineau/vcolchoc44_qwerty.py
@@ -12,8 +12,8 @@ from kmk.modules.layers import Layers
 keyboard = KMKKeyboard()
 keyboard.modules.append(Layers())
 
-rgb_ext = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels, animation_mode=AnimationModes.STATIC)
-keyboard.extensions.append(rgb_ext)
+rgb = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels, animation_mode=AnimationModes.STATIC)
+keyboard.extensions.append(rgb)
 
 FUN = KC.MO(1)
 UPPER = KC.MO(2)

--- a/user_keymaps/jpconstantineau/vcolmx44.py
+++ b/user_keymaps/jpconstantineau/vcolmx44.py
@@ -12,8 +12,8 @@ from kmk.modules.layers import Layers
 keyboard = KMKKeyboard()
 keyboard.modules.append(Layers())
 
-rgb_ext = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels, animation_mode=AnimationModes.STATIC)
-keyboard.extensions.append(rgb_ext)
+rgb = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixels, animation_mode=AnimationModes.STATIC)
+keyboard.extensions.append(rgb)
 
 FUN = KC.MO(1)
 UPPER = KC.MO(2)

--- a/user_keymaps/kdb424/luddite.py
+++ b/user_keymaps/kdb424/luddite.py
@@ -20,12 +20,12 @@ BASE = 0
 GAMING = 1
 FN1 = 2
 
-rgb_ext = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=16)
+rgb = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=16)
 layers = Layers()
 holdtap = HoldTap()
 
 keyboard.modules = [layers, holdtap]
-keyboard.extensions = [rgb_ext]
+keyboard.extensions = [rgb]
 
 _______ = KC.TRNS
 XXXXXXX = KC.NO

--- a/user_keymaps/kdb424/nyquist_r2.py
+++ b/user_keymaps/kdb424/nyquist_r2.py
@@ -16,11 +16,11 @@ keyboard.tap_time = 150
 
 layers = Layers()
 holdtap = HoldTap()
-rgb_ext = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=27, val_limit=100, hue_default=190, sat_default=100, val_default=5)
+rgb = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=27, val_limit=100, hue_default=190, sat_default=100, val_default=5)
 split = Split()
 
 keyboard.modules = [holdtap, layers, split]
-keyboard.extensions = [rgb_ext]
+keyboard.extensions = [rgb]
 
 _______ = KC.TRNS
 XXXXXXX = KC.NO

--- a/user_keymaps/rk463345/levinson_r2.py
+++ b/user_keymaps/rk463345/levinson_r2.py
@@ -12,9 +12,9 @@ keyboard = KMKKeyboard()
 layers = Layers()
 media_keys = MediaKeys()
 split = Split(split_type=SplitType.UART)
-rgb_ext = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=16, val_limit=150, hue_default=0, sat_default=100, val_default=20)
+rgb = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=16, val_limit=150, hue_default=0, sat_default=100, val_default=20)
 keyboard.modules = [layers, media_keys, split]
-keyboard.extensions = [rgb_ext]
+keyboard.extensions = [rgb]
 
 
 # ------------------User level config variables ---------------------------------------


### PR DESCRIPTION
Just a bit of coding style improvement. Or semantic pedantry.