### PR TITLE
Remove `RGB.disable_auto_write`

### DIFF
--- a/docs/en/rgb.md
+++ b/docs/en/rgb.md
@@ -78,7 +78,6 @@ If you want to create your own animations, or for example, change the lighting i
 |`rgb.set_hsv(hue, sat, val, index)`   |Sets a single LED with HSV value                                                            |
 |`rgb.set_rgb_fill((r, g, b))`         |Fills all LED's with RGB(W) values                                                          |
 |`rgb.set_rgb((r, g, b), index)`       |Set's a single LED with RGB(W) values                                                       |
-|`rgb.disable_auto_write(bool)`        |When True, disables showing changes. Good for setting multiple LED's before a visible update|
 |`rgb.increase_hue(step)`              |Increases hue by a given step                                                               |
 |`rgb.decrease_hue(step)`              |Decreases hue by a given step                                                               |
 |`rgb.increase_sat(step)`              |Increases saturation by a given step                                                        |
@@ -88,7 +87,7 @@ If you want to create your own animations, or for example, change the lighting i
 |`rgb.increase_ani()`                  |Increases animation speed by 1. Maximum 10                                                  |
 |`rgb.decrease_ani()`                  |Decreases animation speed by 1. Minimum 10                                                  |
 |`rgb.off()`                           |Turns all LED's off                                                                         |
-|`rgb.show()`                          |Displays all stored configuration for LED's. Useful with disable_auto_write explained above |
+|`rgb.show()`                          |Displays all stored configuration for LED's                                                 |
 
 ## Direct variable access
 |Define                             |Default    |Description                                                                                                |

--- a/kmk/extensions/rgb.py
+++ b/kmk/extensions/rgb.py
@@ -105,7 +105,6 @@ class RGB(Extension):
         effect_init=False,
         reverse_animation=False,
         user_animation=None,
-        disable_auto_write=False,
         pixels=None,
         refresh_rate=60,
     ):
@@ -129,7 +128,6 @@ class RGB(Extension):
         self.effect_init = effect_init
         self.reverse_animation = reverse_animation
         self.user_animation = user_animation
-        self.disable_auto_write = disable_auto_write
         self.pixels = pixels
         self.refresh_rate = refresh_rate
 
@@ -301,9 +299,6 @@ class RGB(Extension):
                     break
                 index -= len(pixels)
 
-            if not self.disable_auto_write:
-                pixels.show()
-
     def set_rgb_fill(self, rgb):
         '''
         Takes an RGB or RGBW and displays it on all LEDs/Neopixels
@@ -311,8 +306,6 @@ class RGB(Extension):
         '''
         for pixels in self.pixels:
             pixels.fill(rgb)
-            if not self.disable_auto_write:
-                pixels.show()
 
     def increase_hue(self, step=None):
         '''
@@ -439,26 +432,31 @@ class RGB(Extension):
         if self.animation_mode is AnimationModes.STATIC_STANDBY:
             return
 
-        if self.enable:
-            self._animation_step()
-            if self.animation_mode == AnimationModes.BREATHING:
-                self.effect_breathing()
-            elif self.animation_mode == AnimationModes.RAINBOW:
-                self.effect_rainbow()
-            elif self.animation_mode == AnimationModes.BREATHING_RAINBOW:
-                self.effect_breathing_rainbow()
-            elif self.animation_mode == AnimationModes.STATIC:
-                self.effect_static()
-            elif self.animation_mode == AnimationModes.KNIGHT:
-                self.effect_knight()
-            elif self.animation_mode == AnimationModes.SWIRL:
-                self.effect_swirl()
-            elif self.animation_mode == AnimationModes.USER:
-                self.user_animation(self)
-            elif self.animation_mode == AnimationModes.STATIC_STANDBY:
-                pass
-            else:
-                self.off()
+        if not self.enable:
+            return
+
+        self._animation_step()
+
+        if self.animation_mode == AnimationModes.STATIC_STANDBY:
+            return
+        elif self.animation_mode == AnimationModes.BREATHING:
+            self.effect_breathing()
+        elif self.animation_mode == AnimationModes.BREATHING_RAINBOW:
+            self.effect_breathing_rainbow()
+        elif self.animation_mode == AnimationModes.KNIGHT:
+            self.effect_knight()
+        elif self.animation_mode == AnimationModes.RAINBOW:
+            self.effect_rainbow()
+        elif self.animation_mode == AnimationModes.STATIC:
+            self.effect_static()
+        elif self.animation_mode == AnimationModes.SWIRL:
+            self.effect_swirl()
+        elif self.animation_mode == AnimationModes.USER:
+            self.user_animation(self)
+        else:
+            self.off()
+
+        self.show()
 
     def _animation_step(self):
         self._substep += self.animation_speed / 4
@@ -502,19 +500,13 @@ class RGB(Extension):
 
     def effect_swirl(self):
         self.increase_hue(self._step)
-        self.disable_auto_write = True  # Turn off instantly showing
         for i in range(0, self.num_pixels):
             self.set_hsv(
                 (self.hue - (i * self.num_pixels)) % 256, self.sat, self.val, i
             )
 
-        # Show final results
-        self.disable_auto_write = False  # Resume showing changes
-        self.show()
-
     def effect_knight(self):
         # Determine which LEDs should be lit up
-        self.disable_auto_write = True  # Turn off instantly showing
         self.off()  # Fill all off
         pos = int(self.pos)
 
@@ -532,10 +524,6 @@ class RGB(Extension):
             self.pos -= self._step / 2
         else:
             self.pos += self._step / 2
-
-        # Show final results
-        self.disable_auto_write = False  # Resume showing changes
-        self.show()
 
     def _rgb_tog(self, *args, **kwargs):
         if self.animation_mode == AnimationModes.STATIC:


### PR DESCRIPTION
There's no actual usecase for this.
Disable `auto_write` for every pixel buffer and call `show()` manually. Updating the pixel buffers all at once every refresh interval has no real-world downsides.
`disable_auto_write` only causes confusion and can lead to unexpected behavior.