### PR TITLE
Added extra construction support to Encoder.py to support pullup direction from Code.py

### DIFF
--- a/docs/en/encoder.md
+++ b/docs/en/encoder.md
@@ -26,8 +26,8 @@ encoder_handler = EncoderHandler()
 keyboard.modules = [layers, holdtap, encoder_handler]
 ```
 
-2. Define the pins for each encoder: `pin_a`, `pin_b` for rotations, `pin_button` for the switch in the encoder. Set switch to `None` if the encoder's button is handled differently (as a part of matrix for example) or not at all. If you want to invert the direction of the encoder, set the 4th (optional) parameter `is_inverted` to `True`. 5th parameter is [encoder divisor](#encoder-resolution) (optional), it can be either `2` or `4`.
- 
+2. Define the pins for each encoder: `pin_a`, `pin_b` for rotations, `pin_button` for the switch in the encoder. Set switch to `None` if the encoder's button is handled differently (as a part of matrix for example) or not at all. If you want to invert the direction of the encoder, set the 4th (optional) parameter `is_inverted` to `True`. 5th parameter is [encoder divisor](#encoder-resolution) (optional), it can be either `2` or `4`. If your encoder button pull direction is not the default of `digitalio.Pull.UP`, you may specify the 6th (optional) parameter `button_pull` as `digitalio.Pull.DOWN`.
+
 ```python
 # Regular GPIO Encoder
 encoder_handler.pins = (

--- a/kmk/modules/encoder.py
+++ b/kmk/modules/encoder.py
@@ -112,7 +112,15 @@ class BaseEncoder:
 
 
 class GPIOEncoder(BaseEncoder):
-    def __init__(self, pin_a, pin_b, pin_button=None, is_inverted=False, divisor=None, button_pull=digitalio.Pull.UP):
+    def __init__(
+        self,
+        pin_a,
+        pin_b,
+        pin_button=None,
+        is_inverted=False,
+        divisor=None,
+        button_pull=digitalio.Pull.UP,
+    ):
         super().__init__(is_inverted)
 
         # Divisor can be 4 or 2 depending on whether the detent
@@ -162,6 +170,7 @@ class EncoderPin:
         if digitalio.Pull.UP != io.pull:
             result = not result
         return result
+
 
 class I2CEncoder(BaseEncoder):
     def __init__(self, i2c, address, is_inverted=False):

--- a/kmk/modules/encoder.py
+++ b/kmk/modules/encoder.py
@@ -112,7 +112,7 @@ class BaseEncoder:
 
 
 class GPIOEncoder(BaseEncoder):
-    def __init__(self, pin_a, pin_b, pin_button=None, is_inverted=False, divisor=None):
+    def __init__(self, pin_a, pin_b, pin_button=None, is_inverted=False, divisor=None, button_pull=digitalio.Pull.UP):
         super().__init__(is_inverted)
 
         # Divisor can be 4 or 2 depending on whether the detent
@@ -121,10 +121,10 @@ class GPIOEncoder(BaseEncoder):
 
         self.pin_a = EncoderPin(pin_a)
         self.pin_b = EncoderPin(pin_b)
-        self.pin_button = (
-            EncoderPin(*pin_button) if isinstance(pin_button, tuple) else
-            EncoderPin(pin_button, button_type=True) if pin_button is not None else None
-        )
+        if pin_button:
+            self.pin_button = EncoderPin(pin_button, button_type=True, pull=button_pull)
+        else:
+            self.pin_button = None
 
         self._state = (self.pin_a.get_value(), self.pin_b.get_value())
         self._start_state = self._state

--- a/kmk/modules/encoder.py
+++ b/kmk/modules/encoder.py
@@ -157,10 +157,11 @@ class EncoderPin:
             self.io = None
 
     def get_value(self):
-        return (
-            self.io.value if digitalio.Pull.UP == self.io.pull else not self.io.value
-        )
-
+        io = self.io
+        result = io.value
+        if digitalio.Pull.UP == io.pull:
+            result = not result
+        return result
 
 class I2CEncoder(BaseEncoder):
     def __init__(self, i2c, address, is_inverted=False):

--- a/kmk/modules/encoder.py
+++ b/kmk/modules/encoder.py
@@ -159,7 +159,7 @@ class EncoderPin:
     def get_value(self):
         io = self.io
         result = io.value
-        if digitalio.Pull.UP == io.pull:
+        if digitalio.Pull.UP != io.pull:
             result = not result
         return result
 

--- a/kmk/modules/encoder.py
+++ b/kmk/modules/encoder.py
@@ -122,6 +122,7 @@ class GPIOEncoder(BaseEncoder):
         self.pin_a = EncoderPin(pin_a)
         self.pin_b = EncoderPin(pin_b)
         self.pin_button = (
+            EncoderPin(*pin_button) if isinstance(pin_button, tuple) else
             EncoderPin(pin_button, button_type=True) if pin_button is not None else None
         )
 
@@ -138,9 +139,10 @@ class GPIOEncoder(BaseEncoder):
 
 
 class EncoderPin:
-    def __init__(self, pin, button_type=False):
+    def __init__(self, pin, button_type=False, pull=digitalio.Pull.UP):
         self.pin = pin
         self.button_type = button_type
+        self.pull = pull
         self.prepare_pin()
 
     def prepare_pin(self):
@@ -150,12 +152,14 @@ class EncoderPin:
             else:
                 self.io = digitalio.DigitalInOut(self.pin)
             self.io.direction = digitalio.Direction.INPUT
-            self.io.pull = digitalio.Pull.UP
+            self.io.pull = self.pull
         else:
             self.io = None
 
     def get_value(self):
-        return self.io.value
+        return (
+            self.io.value if digitalio.Pull.UP == self.io.pull else not self.io.value
+        )
 
 
 class I2CEncoder(BaseEncoder):


### PR DESCRIPTION
Added support to Encoder.py to allow GPIOEncoder to accept tuple for pin_button construction.  This includes allowance for pull resistor (pullup/pulldown) customisation directly from code.py.  Additionally the change preserves state generation semantics for pin_button.get_value(self) and depends upon the pull direction.  The default pull direction remains as digitalio.Pull.UP

An example config from code.py to customise the pin button pull up direction:
encoder_handler.pins = ((board.VOLC_A, board.VOLC_B, (board.VOLC_PUSH, True, digitalio.Pull.DOWN), False, 2),)

Tested this out on my own code.py.