### PR TITLE
fix adns9800 module: add missing inputs to AX.X.move and AX.y.move

### DIFF
--- a/kmk/modules/adns9800.py
+++ b/kmk/modules/adns9800.py
@@ -203,10 +203,10 @@ class ADNS9800(Module):
                 delta_y *= -1
 
             if delta_x:
-                AX.X.move(delta_x)
+                AX.X.move(keyboard, delta_x)
 
             if delta_y:
-                AX.Y.move(delta_y)
+                AX.Y.move(keyboard, delta_y)
 
             if keyboard.debug_enabled:
                 print('Delta: ', delta_x, ' ', delta_y)

--- a/kmk/modules/adns9800.py
+++ b/kmk/modules/adns9800.py
@@ -187,7 +187,7 @@ class ADNS9800(Module):
             if self.adns_read(REG.Observation) & 0x20:
                 print('ADNS: Sensor is running SROM')
             else:
-                print('ADNS: Error! Sensor is not runnin SROM!')
+                print('ADNS: Error! Sensor is not running SROM!')
 
         return
 


### PR DESCRIPTION
Added missing keyboard input arguments to the AX.X.move and AX.Y.move function calls.

I have an adns9800 module running on a Pi Pico which I have tested with this fix on, and it's working in my local copy.

I had gotten the adns9800 module working with an older version of kmk, but the latest version of kmk was throwing errors when moving the trackball on the adns9800, and this change fixes the issue for me.