### PR TITLE
Fix aspell dependency in spellcheck action

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -9,4 +9,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: sudo apt-get install aspell
       - run: make spellcheck


### PR DESCRIPTION
Quick & dirty fix for the spellcheck action.
Not a very nice or efficient solution. While searching for ready-to-use aspell actions I stumbled across `pyspelling`, which could be worth a consideration as a replacement for our janky shell script.