### PR TITLE
Fix off() method in RGB

### DIFF
--- a/kmk/extensions/rgb.py
+++ b/kmk/extensions/rgb.py
@@ -415,6 +415,7 @@ class RGB(Extension):
         self.set_hsv_fill(0, 0, 0)
 
         self.show()
+
     def show(self):
         '''
         Turns on all LEDs/Neopixels without changing stored values

--- a/kmk/extensions/rgb.py
+++ b/kmk/extensions/rgb.py
@@ -414,6 +414,7 @@ class RGB(Extension):
         '''
         self.set_hsv_fill(0, 0, 0)
 
+        self.show()
     def show(self):
         '''
         Turns on all LEDs/Neopixels without changing stored values


### PR DESCRIPTION
Since the animate() method doesn't call `self.show()` when RGB is toggled off, it has to be called in `self.off()` for the latter to produce desired effect.