### PR TITLE
Add automatic debug logs

### DIFF
--- a/docs/en/debugging.md
+++ b/docs/en/debugging.md
@@ -1,11 +1,13 @@
 # Debugging
-Debug will output most of the useful state to the console. This can be enable in your firmware
-by setting this in your keymap. NOTE that it will be slower, so only enable this when you
-need debugging.
+KMK's debug output is written to CircuitPython's serial console -- the one that's
+used for the REPL -- and is automatically enabled if it detects a connection to
+that console.
+It can also be enabled manually, though that shouldn't be necessary in
+general:
 ```python
 keyboard.debug_enabled = True
 ```
 
-The output can be viewed by connecting to the serial port of the keybord. Please refer to [THIS](https://learn.adafruit.com/welcome-to-circuitpython/kattni-connecting-to-the-serial-console) for
-more information when connecting to serial console. For Linux users, we recommend [picocom](https://github.com/npat-efault/picocom) or
-[screen](https://www.gnu.org/software/screen/manual/screen.html)
+Follow for example Adafruit's beginners guide on [how to connect to the serial console](https://learn.adafruit.com/welcome-to-circuitpython/kattni-connecting-to-the-serial-console).
+For Linux users, we recommend [picocom](https://github.com/npat-efault/picocom)
+or [screen](https://www.gnu.org/software/screen/manual/screen.html)

--- a/kmk/utils.py
+++ b/kmk/utils.py
@@ -5,12 +5,14 @@ except ImportError:
 
 from supervisor import ticks_ms
 
+from usb_cdc import console
+
 
 def clamp(x: int, bottom: int = 0, top: int = 100) -> int:
     return min(max(bottom, x), top)
 
 
-_debug_enabled = False
+_debug_enabled = None
 
 
 class Debug:
@@ -31,7 +33,14 @@ class Debug:
     @property
     def enabled(self) -> bool:
         global _debug_enabled
-        return _debug_enabled
+        if (
+            _debug_enabled is None
+            and console
+            and console.connected
+            and console.out_waiting == 0
+        ):
+            return True
+        return bool(_debug_enabled)
 
     @enabled.setter
     def enabled(self, enabled: bool):

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -31,6 +31,7 @@ def init_circuit_python_modules_mocks():
 
     sys.modules['supervisor'] = Mock()
     sys.modules['supervisor'].ticks_ms = ticks_ms
+    sys.modules['usb_cdc'] = Mock()
 
     from . import task
 

--- a/util/aspell.en.pws
+++ b/util/aspell.en.pws
@@ -1,10 +1,11 @@
-personal_ws-1.1 en 345 
+personal_ws-1.1 en 347 
 ADNS
 AMS
 ANAVI
 APA
 AVR
 Adafruit
+Adafruit's
 Affero
 BT
 BYO


### PR DESCRIPTION
Automatically enable debug output if a serial monitor is connected to the serial interface.