### PR TITLE
[do not merge] Tidbit hexpad with keyboard-side hex character composition

### DIFF
--- a/boards/nullbitsco/README.md
+++ b/boards/nullbitsco/README.md
@@ -1,1 +1,2 @@
-https://nullbits.co/
+Mappings for [nullbits](https://nullbits.co/) keyboards,
+often based on the [BIT-C pro micro MCU](https://nullbits.co/bit-c/).

--- a/boards/nullbitsco/README.md
+++ b/boards/nullbitsco/README.md
@@ -1,0 +1,1 @@
+https://nullbits.co/

--- a/boards/nullbitsco/tidbit/README.md
+++ b/boards/nullbitsco/tidbit/README.md
@@ -1,1 +1,38 @@
-https://nullbits.co/tidbit/
+Keyboard mapping for the [nullbits tidbit](https://nullbits.co/tidbit/).
+
+Copy `kb.py` and `main.py` to your top level circuitpython folder beside the kmk folder.
+Edit the key mapping in `main.py` to match your build,
+for example the number and location of encoders and double-size keys.
+
+The Keyboard constructor supports a couple of optional arguments (see `kb.py`).
+
+If you're setting your tidbit up in landscape mode, 
+with the USB connector at top right instead of top left, pass 
+`landscape_layout=True`.
+
+You can specify the active encoder positions by passing a list like
+`active_encoders=[0, 2]` which corresponds to the 1st and 3rd positions shown
+in [step 6](https://github.com/nullbitsco/docs/blob/main/tidbit/build_guide_en.md#6-optional-solder-rotary-encoder-led-matrix-andor-oled-display) of the build guide.
+The default is for a single encoder in either of the top two locations labeled 1 
+in the build diagram, i.e. `active_encoders=[0]`.  Pass an empty list if you skipped
+adding any encoders.
+
+You can control the RGB backlights with the [RGB extension](http://kmkfw.io/docs/rgb).
+Here's an example:
+
+```python
+from kb import KMKKeyboard
+from kmk.extensions.rgb import RGB, AnimationModes
+
+keyboard = KMKKeyboard(active_encoders=[0], landscape_layout=True)
+
+rgb = RGB(
+    pixel_pin=keyboard.pixel_pin, 
+    num_pixels=8,
+    animation_mode=AnimationModes.BREATHING,
+    animation_speed=3,
+    breathe_center=2,
+)
+keyboard.extensions.append(rgb)
+
+```

--- a/boards/nullbitsco/tidbit/README.md
+++ b/boards/nullbitsco/tidbit/README.md
@@ -1,0 +1,1 @@
+https://nullbits.co/tidbit/

--- a/boards/nullbitsco/tidbit/kb.py
+++ b/boards/nullbitsco/tidbit/kb.py
@@ -22,7 +22,6 @@ class KMKKeyboard(_KMKKeyboard):
 
     active_encoders=[0, 2] to list installed encoder positions (first=0)
         then declare keyboard.encoders.map = [(KC.<left> , KC.<right>, None), (...)]
-    enable_rgb=False (default True) to add rgb module (requires neopixel.py)
     landscape_layout=True to orient USB port top right rather than left (default)
     """
 #    led = digitalio.DigitalInOut(board.D21)
@@ -45,7 +44,7 @@ class KMKKeyboard(_KMKKeyboard):
     diode_orientation = DiodeOrientation.ROW2COL
     i2c = board.I2C  #TODO ??
 
-    def __init__(self, active_encoders=[], landscape_layout=False):
+    def __init__(self, active_encoders=[0], landscape_layout=False):
         super().__init__()
 
         if landscape_layout:

--- a/boards/nullbitsco/tidbit/kb.py
+++ b/boards/nullbitsco/tidbit/kb.py
@@ -1,0 +1,61 @@
+import board
+
+from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
+from kmk.quickpin.pro_micro.bitc_promicro import pinout as pins
+
+from kmk.scanners import DiodeOrientation
+from kmk.modules.encoder import EncoderHandler
+
+
+encoder_pinout = [
+    (pins[13],  pins[14],   None),      # enc 0, button mapped in matrix
+    (pins[10],  pins[11],   None),      # enc 1 (optional)
+    (pins[5],   pins[4],    None),      # enc 2 (optional)
+    (pins[0],   pins[1],    None),      # enc 3 (optional)
+]
+
+
+class KMKKeyboard(_KMKKeyboard):
+    """"
+    Create a nullbits tidbit keyboard.
+    optional constructor arguments:
+
+    active_encoders=[0, 2] to list installed encoder positions (first=0)
+        then declare keyboard.encoders.map = [(KC.<left> , KC.<right>, None), (...)]
+    enable_rgb=False (default True) to add rgb module (requires neopixel.py)
+    landscape_layout=True to orient USB port top right rather than left (default)
+    """
+#    led = digitalio.DigitalInOut(board.D21)
+#    led.direction = digitalio.Direction.OUTPUT
+#    led.value = False
+    row_pins = (
+        pins[15],
+        pins[9], 
+        pins[8], 
+        pins[7], 
+        pins[6],
+    )
+    col_pins = (
+        pins[19], 
+        pins[18], 
+        pins[17], 
+        pins[16],
+    )
+    pixel_pin = pins[12]
+    diode_orientation = DiodeOrientation.ROW2COL
+    i2c = board.I2C  #TODO ??
+
+    def __init__(self, active_encoders=[], landscape_layout=False):
+        super().__init__()
+
+        if landscape_layout:
+            self.coord_mapping = [
+                row * len(self.col_pins) + col 
+                for col in range(len(self.col_pins))
+                for row in reversed(range(len(self.row_pins)))
+            ]
+
+        if active_encoders:
+            self.encoders = EncoderHandler()
+            self.encoders.pins = tuple([encoder_pinout[i] for i in active_encoders])
+            self.modules.append(self.encoders)

--- a/boards/nullbitsco/tidbit/main.py
+++ b/boards/nullbitsco/tidbit/main.py
@@ -8,11 +8,11 @@ XXXXX = KC.NO
 
 keyboard.keymap = [
     [
-        XXXXX,  KC.PSLS, KC_PAST, KC_PMNS,
-        KC_P7,  KC_P8,   KC_P9,   KC_PPLS,
-        KC_P4,  KC_P5,   KC_P6,   KC_PPLS,
-        KC_P1,  KC_P2,   KC_P3,   KC_PENT,
-        KC_P0,  KC_P0,   KC_PDOT, KC_PENT,
+        XXXXX,  KC.PSLS, KC.PAST, KC.PMNS,
+        KC.P7,  KC.P8,   KC.P9,   KC.PPLS,
+        KC.P4,  KC.P5,   KC.P6,   KC.PPLS,
+        KC.P1,  KC.P2,   KC.P3,   KC.PENT,
+        KC.P0,  KC.P0,   KC.PDOT, KC.PENT,
     ]
 ]
 

--- a/boards/nullbitsco/tidbit/main.py
+++ b/boards/nullbitsco/tidbit/main.py
@@ -1,0 +1,20 @@
+from kb import KMKKeyboard
+from kmk.keys import KC
+
+# add active_encoders=[0, 2] to constructor if first and third encoders installed
+keyboard = KMKKeyboard()
+
+XXXXX = KC.NO
+
+keyboard.keymap = [
+    [
+        XXXXX,  KC.PSLS, KC_PAST, KC_PMNS,
+        KC_P7,  KC_P8,   KC_P9,   KC_PPLS,
+        KC_P4,  KC_P5,   KC_P6,   KC_PPLS,
+        KC_P1,  KC_P2,   KC_P3,   KC_PENT,
+        KC_P0,  KC_P0,   KC_PDOT, KC_PENT,
+    ]
+]
+
+if __name__ == '__main__':
+    keyboard.go()

--- a/boards/nullbitsco/tidbit/main_hexpad.py
+++ b/boards/nullbitsco/tidbit/main_hexpad.py
@@ -1,0 +1,135 @@
+from kb import KMKKeyboard
+from kmk.keys import KC, make_key
+from kmk.modules.holdtap import HoldTap
+from kmk.modules.layers import Layers
+from kmk.modules.hex_compose import HexCompose
+from kmk.modules.tapdance import TapDance
+from kmk.modules.oneshot import OneShot
+from kmk.extensions.rgb import RGB, AnimationModes
+from kmk.consts import UnicodeMode
+
+from kmk.handlers.sequences import unicode_string_sequence
+
+keyboard = KMKKeyboard(active_encoders=[0], landscape_layout=True)
+
+keyboard.unicode_mode = UnicodeMode.RALT
+
+keyboard.modules += [
+    Layers(), 
+    OneShot(), 
+    HoldTap(), 
+    TapDance(), 
+    HexCompose(encoding='utf8')
+]
+
+rgb = RGB(
+    pixel_pin=keyboard.pixel_pin, 
+    num_pixels=8,
+    animation_mode=AnimationModes.BREATHING,
+    animation_speed=3,
+    breathe_center=2,
+)
+keyboard.extensions.append(rgb)
+        
+
+def set_backlight(hsv):
+    rgb.hue, rgb.sat, rgb.val = hsv
+
+
+XXXXX = KC.NO
+_____ = KC.TRANSPARENT
+
+SPC_ENTER = KC.HT(KC.SPACE, KC.ENTER)
+SHFT_CTL = KC.TD(KC.LSHIFT, KC.LCTL)
+
+OS_NUM = KC.OS(KC.MO(2), tap_time=None)
+OS_ALPHA = KC.OS(KC.MO(4), tap_time=None)
+OS_SYM = KC.OS(KC.MO(6), tap_time=None)
+
+TO_HEX = KC.TO(0)
+TO_NUM = KC.TO(2)
+TO_ALPHA = KC.TO(4)
+
+colors = dict(
+    hex=(180,255,50), 
+    num=(265,255,50), 
+    alpha=(95,255,50)
+)
+set_backlight(colors['hex'])
+TO_HEX.after_press_handler(lambda *_: set_backlight(colors['hex']))
+TO_NUM.after_press_handler(lambda *_: set_backlight(colors['num']))
+TO_ALPHA.after_press_handler(lambda *_: set_backlight(colors['alpha']))
+
+# encoder direction does left/right or up/down with alt
+keyboard.encoders.map = [
+    [(KC.LEFT, KC.RIGHT, XXXXX)],
+    [(KC.UP, KC.DOWN, XXXXX)],
+] * 4
+
+# encoder button cycles modes (hex, numpad, alpha)
+keyboard.keymap = [
+    # -----------------------------------------------------------
+    # 0: hex
+    [
+        KC.HEX7,    KC.HEX8,    KC.HEX9,    TO_NUM,     XXXXX,
+        KC.HEX4,    KC.HEX5,    KC.HEX6,    KC.HEXA,    KC.HEXB,
+        KC.HEX1,    KC.HEX2,    KC.HEX3,    KC.HEXC,    KC.HEXD,
+KC.LT(1, OS_SYM),   KC.HEX0,    SPC_ENTER,  KC.HEXE,    KC.HEXF,
+    ],
+    # 1: hex alt
+    [
+        XXXXX,      XXXXX,      XXXXX,      XXXXX,      XXXXX,
+        XXXXX,      XXXXX,      XXXXX,      OS_ALPHA,   XXXXX,
+        XXXXX,      XXXXX,      XXXXX,      XXXXX,      XXXXX,
+        XXXXX,      OS_NUM,     XXXXX,      XXXXX,      KC.BSPC
+    ],
+    # -----------------------------------------------------------
+    # 2: numpad
+    [
+        KC.N7,      KC.N8,      KC.N9,      TO_ALPHA,   XXXXX,
+        KC.N4,      KC.N5,      KC.N6,      KC.SLSH,    KC.ASTR,
+        KC.N1,      KC.N2,      KC.N3,      KC.MINUS,   KC.PLUS,
+KC.LT(3, OS_SYM),   KC.N0,      SPC_ENTER,  KC.EQUAL,   KC.BSPC,
+    ],
+    # 3: numpad alt
+    [
+        KC.HOME,    KC.UP,      KC.PGUP,    XXXXX,      XXXXX,
+        KC.LEFT,    KC.COMMA,   KC.RIGHT,   OS_ALPHA,   XXXXX,
+        KC.END,     KC.DOWN,    KC.PGDN,    XXXXX,      XXXXX,
+        XXXXX,      KC.DOT,     KC.TAB,     XXXXX,      KC.ESC,
+    ],
+    # -----------------------------------------------------------
+    # 4: alpha
+    [
+        KC.S,       KC.T,       KC.U,       TO_HEX,     XXXXX,
+        KC.I,       KC.L,       KC.N,       KC.O,       KC.R,
+        KC.A,       KC.C,       KC.D,       KC.E,       KC.H,
+KC.LT(5, OS_SYM),   SHFT_CTL,   SPC_ENTER,  KC.COMM,    KC.BSPC,
+    ],
+    # 5: alpha alt 
+    [
+        KC.X,       KC.Y,       KC.Z,       XXXXX,      XXXXX,
+        KC.M,       KC.P,       KC.Q,       KC.V,       KC.W,
+        KC.B,       KC.F,       KC.G,       KC.J,       KC.K,
+        XXXXX,      OS_NUM,     KC.TAB,     KC.DOT,     KC.ESC,
+    ],
+    # -----------------------------------------------------------
+    # 6: symbols
+    [
+        KC.QUOT,    KC.LPRN,    KC.RPRN,    XXXXX,      XXXXX,
+        KC.DLR,     KC.PERC,    KC.AMPR,    KC.LBRC,    KC.RBRC,
+        KC.EXLM,    KC.DQT,     KC.HASH,    KC.SCLN,    KC.EQUAL,
+        KC.MO(7),   KC.SLSH,    SPC_ENTER,  KC.COMM,    KC.DOT,
+    ],
+    # 7: symbols alt
+    [
+        KC.GRV,     KC.ASTR,    KC.UNDS,    XXXXX,      XXXXX,
+        KC.BSLS,    KC.PIPE,    KC.CIRC,    KC.LCBR,    KC.RCBR,
+        KC.TILD,    KC.AT,      KC.MINUS,   KC.COLN,    KC.PLUS,
+        XXXXX,      KC.QUES,    KC.TAB,     KC.LABK,    KC.RABK,
+    ],
+]
+
+
+if __name__ == '__main__':
+    keyboard.go()

--- a/kmk/modules/hex_compose.py
+++ b/kmk/modules/hex_compose.py
@@ -1,0 +1,119 @@
+from kmk.modules import Module
+from kmk.keys import KC, make_key
+from kmk.handlers.sequences import unicode_string_sequence
+
+
+_ascii7_keys = []
+for c in range(64, 96):
+    _ascii7_keys.append(KC.LCTRL(KC.get(chr(c))))
+for c in range(32, 127):
+    k = KC.get(chr(c))
+    _ascii7_keys.append(KC.LSHIFT(k) if 65 <= c <= 90 else k)
+_ascii7_keys.append(KC.DEL)
+
+assert len(_ascii7_keys) == 128, "Failed to enumerate 7-bit ascii keys"
+
+
+def _utf8_length(first_byte):
+    # utf8 encodes length in first byte see https://en.wikipedia.org/wiki/UTF-8
+    length = 0
+    if first_byte & 0x80 == 0:        # 0xxx xxxx
+        length = 1
+    elif first_byte & 0xe0 == 0xc0:   # 110x xxxx
+        length = 2
+    elif first_byte & 0xf0 == 0xe0:   # 1110 xxxx
+        length = 3
+    elif first_byte & 0xf8 == 0xf0:   # 1111 0xxx
+        length = 4
+    return length or None
+
+
+class HexCompose(Module):
+    def __init__(self, encoding='utf8'):
+        self.encoding = encoding
+        self._hex_keys = [
+            make_key(
+                names=(f'HEX{digit:x}'.upper(), ),
+                meta=digit,
+            )
+            for digit in range(16)
+        ]
+        self.reset()
+
+    def reset(self):
+        self._bytes_needed = 1  # ascii always needs 1, uft8 sets dynamically
+        self._hi_nibble = None  # two hex digits => one byte
+        self._bytes = b''
+
+    def during_bootup(self, keyboard):
+        self.reset()
+
+    def before_matrix_scan(self, keyboard):
+        return
+
+    def after_matrix_scan(self, keyboard):
+        return
+
+    def before_hid_send(self, keyboard):
+        return
+
+    def after_hid_send(self, keyboard):
+        return
+
+    def on_powersave_enable(self, keyboard):
+        return
+
+    def on_powersave_disable(self, keyboard):
+        return
+
+    def process_key(self, keyboard, key, is_pressed, int_coord):
+        if key not in self._hex_keys:
+            self.reset()
+            return key
+        elif not is_pressed:
+            return None
+        
+        digit = key.meta
+        print("HexCompose: got hex key", digit)
+
+        # half way thru a byte?  
+        if self._hi_nibble is None:
+            self._hi_nibble = digit << 4
+            return None
+                
+        # otherwise add a byte
+        self._bytes += bytes([self._hi_nibble + digit])
+        self._hi_nibble = None
+
+        # validate length and continuation for utf-8
+        if self.encoding == 'utf8':
+            if len(self._bytes) == 1:
+                self._bytes_needed = _utf8_length(self._bytes[0])
+                # valid starting byte?
+                if not self._bytes_needed:
+                    print(f'HexCompose: invalid utf-8 length coding from {self._bytes}')
+                    self.reset()
+                    return None
+            else:
+                # valid continuation byte?
+                if self._bytes[-1] & 0xc0 != 0x80:
+                    print(f'HexCompose: invalid utf-8 continuation in {self._bytes}')
+                    self.reset()
+                    return None
+                
+        if len(self._bytes) != self._bytes_needed:
+            return None
+        
+        print('HexCompose: completed bytes', self._bytes)
+        character = self._bytes.decode(self.encoding)[0]
+        c = ord(character)
+        if c < 128:
+            composed_key = _ascii7_keys[c]
+            print('HexCompose: sending ascii7', composed_key)
+        else:
+            composed_key = unicode_string_sequence(character)
+            print('HexCompose: sending unicode for', character, composed_key)
+
+        self.reset()        
+
+        return composed_key

--- a/kmk/quickpin/pro_micro/bitc_promicro.py
+++ b/kmk/quickpin/pro_micro/bitc_promicro.py
@@ -1,0 +1,34 @@
+import board
+
+# Bit-C-Pro RP2040 pinout for reference, see https://nullbits.co/bit-c-pro/
+# (unused)
+pinout = [
+    board.D0,   # Enc 3
+    board.D1,   # Enc 3
+    None,  # GND
+    None,  # GND
+    board.D2,   # Enc 2
+    board.D3,   # Enc 2
+    board.D4,   # Row 4 + breakout SDA
+    board.D5,   # Row 3 + breakout SCL
+    board.D6,   # Row 2
+    board.D7,   # Row 1
+    board.D8,   # Enc 1
+    board.D9,   # Enc 1
+
+    # Unconnected breakout pins D11, D12, GND, D13, D14
+
+    board.D21,  # WS2812 LEDs labeled D10/GP21 but only board.D21 is defined
+    board.D23,  # MOSI - Enc 0
+    board.D20,  # MISO - Enc 0
+    board.D22,  # SCK - Row 0
+    board.D26,  # A0 - Col 3
+    board.D27,  # A1 - Col 2
+    board.D28,  # A2 - Col 1
+    board.D29,  # A3 - Col 0
+    None,  # 3.3v
+    None,  # RST
+    None,  # GND
+    None,  # RAW
+]
+# also defined: board.LED_RED, board.LED_GREEN, and board.LED_BLUE == board.LED


### PR DESCRIPTION
More complex tidbit hexpad build, with experimental keyboard-side ascii/unicode character composition module.
The idea is to eventually support a direct interface between keyboard and a retro-computer via SPI where it sends 8-bit ascii equivalents for keycodes.
 
Depends on https://github.com/KMKfw/kmk_firmware/pull/916