### PR TITLE
Removed intify_coordinate from code, boards, docs

### DIFF
--- a/boards/fingerpunch/ffkb/other_pro_micro/kb.py
+++ b/boards/fingerpunch/ffkb/other_pro_micro/kb.py
@@ -3,7 +3,6 @@ import board
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
 from kmk.quickpin.pro_micro.boardsource_blok import pinout as pins
 from kmk.scanners import DiodeOrientation
-from kmk.scanners import intify_coordinate as ic
 
 
 class KMKKeyboard(_KMKKeyboard):
@@ -33,8 +32,8 @@ class KMKKeyboard(_KMKKeyboard):
     # flake8: noqa
     # fmt: off
     coord_mapping = [
-            ic(0, 0), ic(0, 1), ic(0, 2), ic(0, 3), ic(0, 4), ic(0, 5),           ic(0, 6), ic(0, 7), ic(4, 3), ic(3, 4), ic(4, 5), ic(3, 7),
-            ic(1, 0), ic(1, 1), ic(1, 2), ic(1, 3), ic(1, 4), ic(1, 5), ic(4, 1), ic(1, 6), ic(1, 7), ic(3, 2), ic(4, 4), ic(3, 5), ic(4, 7),
-            ic(2, 0), ic(2, 1), ic(2, 2), ic(2, 3), ic(2, 4), ic(2, 5),           ic(2, 6), ic(2, 7), ic(4, 2), ic(3, 3), ic(3, 6), ic(4, 6),
-            ic(5, 1),                     ic(5, 3), ic(5, 4), ic(5, 5),           ic(5, 6), ic(5, 7), ic(5, 2),                     ic(5, 0)
+       0,   1,  2,  3,  4,  5,      6,  7, 35, 28, 37, 31,
+       8,   9, 10, 11, 12, 13, 33, 14, 15, 26, 36, 29, 39,
+       16, 17, 18, 19, 20, 21,     22, 23, 34, 27, 30, 38,
+       41,         43, 44, 45,     46, 47, 42,         40,
     ]

--- a/boards/gtips/reviung41/kb.py
+++ b/boards/gtips/reviung41/kb.py
@@ -3,7 +3,6 @@ import board
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
 from kmk.quickpin.pro_micro.boardsource_blok import pinout as pins
 from kmk.scanners import DiodeOrientation
-from kmk.scanners import intify_coordinate as ic
 
 
 class KMKKeyboard(_KMKKeyboard):
@@ -28,11 +27,13 @@ class KMKKeyboard(_KMKKeyboard):
     rgb_pixel_pin = pins[0]
     rgb_num_pixels = 11
     i2c = board.I2C
-
-    coord_mapping = []
-    coord_mapping.extend(ic(0, x, 12) for x in range(12))
-    coord_mapping.extend(ic(1, x, 12) for x in range(12))
-    coord_mapping.extend(ic(2, x, 12) for x in range(12))
-
-    # And now, to handle R3, which at this point is down to just five keys
-    coord_mapping.extend(ic(3, x, 12) for x in range(5))
+    
+    #flake8: noqa
+    #fmt: off
+    coord_mapping = [
+              0,  1,  2,  3,  4,  5,   6,  7,  8,  9, 10, 11, 
+            12, 13, 14, 15, 16, 17,     18, 19, 20, 21, 22, 23,
+           24, 25, 26, 27, 28, 29,       30, 31, 32, 33, 34, 35,
+                         36,   37,  38,  39,   40,  
+    ]
+    

--- a/boards/gtips/reviung41/kb.py
+++ b/boards/gtips/reviung41/kb.py
@@ -28,8 +28,8 @@ class KMKKeyboard(_KMKKeyboard):
     rgb_num_pixels = 11
     i2c = board.I2C
     
-    #flake8: noqa
-    #fmt: off
+    # flake8: noqa
+    # fmt: off
     coord_mapping = [
               0,  1,  2,  3,  4,  5,   6,  7,  8,  9, 10, 11, 
             12, 13, 14, 15, 16, 17,     18, 19, 20, 21, 22, 23,

--- a/boards/kyria/kb_v1.py
+++ b/boards/kyria/kb_v1.py
@@ -21,8 +21,8 @@ class KMKKeyboard(_KMKKeyboard):
     encoder_pin_0 = pins[11]
     encoder_pin_1 = pins[7]
     
-    #flake8 :noqa
-    #fmt: off
+    # flake8: noqa
+    # fmt: off
     coord_mapping = [             
          0,  1,  2,  3,  4,  5,                 37, 36, 35, 34, 33, 32, 
          8,  9, 10, 11, 12, 13,                 45, 44, 43, 42, 41, 40,

--- a/boards/kyria/kb_v1.py
+++ b/boards/kyria/kb_v1.py
@@ -1,7 +1,6 @@
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
 from kmk.quickpin.pro_micro.boardsource_blok import pinout as pins
 from kmk.scanners import DiodeOrientation
-from kmk.scanners import intify_coordinate as ic
 
 
 class KMKKeyboard(_KMKKeyboard):
@@ -21,13 +20,12 @@ class KMKKeyboard(_KMKKeyboard):
     rgb_pixel_pin = pins[0]
     encoder_pin_0 = pins[11]
     encoder_pin_1 = pins[7]
-
-    coord_mapping = []
-    coord_mapping.extend(ic(0, x, 8) for x in range(6))
-    coord_mapping.extend(ic(4, x, 8) for x in range(5, -1, -1))
-    coord_mapping.extend(ic(1, x, 8) for x in range(6))
-    coord_mapping.extend(ic(5, x, 8) for x in range(5, -1, -1))
-    coord_mapping.extend(ic(2, x, 8) for x in range(8))
-    coord_mapping.extend(ic(6, x, 8) for x in range(7, -1, -1))
-    coord_mapping.extend(ic(3, x, 8) for x in range(3, 8))
-    coord_mapping.extend(ic(7, x, 8) for x in range(7, 2, -1))
+    
+    #flake8 :noqa
+    #fmt: off
+    coord_mapping = [             
+         0,  1,  2,  3,  4,  5,                 37, 36, 35, 34, 33, 32, 
+         8,  9, 10, 11, 12, 13,                 45, 44, 43, 42, 41, 40,
+        16, 17, 18, 19, 20, 21, 22, 23, 55, 54, 53, 52, 51, 50, 49, 48,
+              27, 28, 29, 30, 31,             63, 62, 61, 60, 59, 
+    ]    

--- a/docs/en/porting_to_kmk.md
+++ b/docs/en/porting_to_kmk.md
@@ -36,24 +36,7 @@ provide a mapping directly. An example of this is the
 columns for the bottom row. Split keyboards count as the total keyboard, not per 
 side, the right side being offset by the number of keys on the left side, as if
 the rows were stacked.
-That would look like this
-```python
-from kmk.scanners import intify_coordinate as ic
-
-    coord_mapping = []
-    coord_mapping.extend(ic(0, x, 6) for x in range(6))
-    coord_mapping.extend(ic(4, x, 6) for x in range(6))
-    coord_mapping.extend(ic(1, x, 6) for x in range(6))
-    coord_mapping.extend(ic(5, x, 6) for x in range(6))
-    coord_mapping.extend(ic(2, x, 6) for x in range(6))
-    coord_mapping.extend(ic(6, x, 6) for x in range(6))
-    # And now, to handle R3, which at this point is down to just six keys
-    coord_mapping.extend(ic(3, x, 6) for x in range(3, 6))
-    coord_mapping.extend(ic(7, x, 6) for x in range(0, 3))
-```
-
-`intify_coordinate` is the traditional way to generate key positions.
-Here's an equivalent, maybe visually more explanatory version:
+That would look like this:
 ```python
 coord_mapping = [
  0,  1,  2,  3,  4,  5,  24, 25, 26, 27, 28, 29,

--- a/docs/ptBR/porting_to_kmk.md
+++ b/docs/ptBR/porting_to_kmk.md
@@ -44,23 +44,6 @@ linhas, e 6 colunas para a linha inferior. Teclados repartidos são contados pel
 total, não por parte separada. Isto seria mais ou menos assim:
 
 ```python
-from kmk.scanners import intify_coordinate as ic
-
-    coord_mapping = []
-    coord_mapping.extend(ic(0, x, 6) for x in range(6))
-    coord_mapping.extend(ic(4, x, 6) for x in range(6))
-    coord_mapping.extend(ic(1, x, 6) for x in range(6))
-    coord_mapping.extend(ic(5, x, 6) for x in range(6))
-    coord_mapping.extend(ic(2, x, 6) for x in range(6))
-    coord_mapping.extend(ic(6, x, 6) for x in range(6))
-    # And now, to handle R3, which at this point is down to just six keys
-    coord_mapping.extend(ic(3, x, 6) for x in range(3, 6))
-    coord_mapping.extend(ic(7, x, 6) for x in range(0, 3))
-```
-
-`intify_coordinate` é a maneira tradicional de gerar posições-chave.
-Aqui está uma versão equivalente, talvez visualmente mais explicativa:
-```python
 coord_mapping = [
  0,  1,  2,  3,  4,  5,  24, 25, 26, 27, 28, 29,
  6,  7,  8,  9, 10, 11,  30, 31, 32, 33, 34, 35,

--- a/kmk/scanners/__init__.py
+++ b/kmk/scanners/__init__.py
@@ -1,7 +1,3 @@
-def intify_coordinate(row, col, len_cols):
-    return len_cols * row + col
-
-
 class DiodeOrientation:
     '''
     Orientation of diodes on handwired boards. You can think of:


### PR DESCRIPTION
Modified the board code that used intify_coordinates to use the same method as other boards to the best of my ability, removed the references to intify_coordinate in the "porting to kmk" documentation, and then removed the intify_coordinate method itself.
Resolves #922 