### PR TITLE
Minor tweaks to the example in the Display extension doc

### DIFF
--- a/docs/en/Display.md
+++ b/docs/en/Display.md
@@ -197,10 +197,10 @@ layers = Layers()
 keyboard.modules.append(layers)
 
 i2c_bus = busio.I2C(board.GP21, board.GP20)
-display_driver = SSD1306(i2c=i2c_bus)
+display_driver = SSD1306(i2c=i2c_bus, device_address=0x3C)
 
 display = Display(
-    display=display_driver
+    display=display_driver,
     entries=[
         TextEntry(text='Layer: ', x=0, y=32, y_anchor='B'),
         TextEntry(text='BASE', x=40, y=32, y_anchor='B', layer=0),
@@ -211,7 +211,6 @@ display = Display(
         TextEntry(text='1', x=12, y=4, inverted=True, layer=1),
         TextEntry(text='2', x=24, y=4, inverted=True, layer=2),
     ],
-    device_address=0x3C,
     width=128,
     height=64,
     dim_time=10,

--- a/docs/en/Display.md
+++ b/docs/en/Display.md
@@ -197,7 +197,11 @@ layers = Layers()
 keyboard.modules.append(layers)
 
 i2c_bus = busio.I2C(board.GP21, board.GP20)
-display_driver = SSD1306(i2c=i2c_bus, device_address=0x3C)
+display_driver = SSD1306(
+    i2c=i2c_bus,
+    # Optional device_addres argument. Default is 0x3C.
+    # device_address=0x3C,
+)
 
 display = Display(
     display=display_driver,
@@ -211,10 +215,11 @@ display = Display(
         TextEntry(text='1', x=12, y=4, inverted=True, layer=1),
         TextEntry(text='2', x=24, y=4, inverted=True, layer=2),
     ],
-    width=128,
+    # Optional width argument. Default is 128.
+    # width=128,
     height=64,
     dim_time=10,
-    dim_target=0.1,
+    dim_target=0.2,
     off_time=1200,
     brightness=1,
 )


### PR DESCRIPTION
A few tweaks to the example mentioned in the Display extension documentation.

- Moved the `device_address` argument from the `Display` instantiation to the `SSD1306` instantiation.  `Display` doesn't currently support this argument, but `SSD1306` does (https://github.com/KMKfw/kmk_firmware/blob/master/kmk/extensions/display.py#L137)
- Added missing comma to the arguments for the `Display` instantiation.