### PR TITLE
Split display.py into files for each backend

### DIFF
--- a/docs/en/Display.md
+++ b/docs/en/Display.md
@@ -31,8 +31,10 @@ Here's how you may initialize the extension. Note that this includes examples of
 import board
 import busio
 
+from kmk.extensions.display import Display, TextEntry, ImageEntry
+
 # For SSD1306
-from kmk.extensions.display import Display, SSD1306, TextEntry, ImageEntry
+from kmk.extensions.display.ssd1306 import SSD1306
 
 # Replace SCL and SDA according to your hardware configuration.
 i2c_bus = busio.I2C(board.GP_SCL, board.GP_SDA)
@@ -45,7 +47,7 @@ driver = SSD1306(
 )
 
 # For SH1106
-from kmk.extensions.display import Display, SH1106, TextEntry, ImageEntry
+from kmk.extensions.display.sh1106 import SH1106
 
 # Replace SCK and MOSI according to your hardware configuration.
 spi_bus = busio.SPI(board.GP_SCK, board.GP_MOSI)
@@ -60,7 +62,8 @@ driver = SH1106(
 )
 
 # For displays initialized by CircuitPython by default
-from kmk.extensions.display import Display, BuiltInDisplay, TextEntry, ImageEntry
+# IMPORTANT: breaks if a display backend from kmk.extensions.display is also in use
+from kmk.extensions.display.builtin import BuiltInDisplay
 
 # Replace display, sleep_command, and wake_command according to your hardware configuration.
 driver = BuiltInDisplay(

--- a/kmk/extensions/display/__init__.py
+++ b/kmk/extensions/display/__init__.py
@@ -73,7 +73,7 @@ class ImageEntry:
             self.side = SplitSide.RIGHT
 
 
-class DisplayBackend:
+class DisplayBase:
     def __init__(self):
         raise NotImplementedError
 

--- a/kmk/extensions/display/__init__.py
+++ b/kmk/extensions/display/__init__.py
@@ -1,4 +1,3 @@
-import busio
 from supervisor import ticks_ms
 
 import displayio
@@ -11,8 +10,6 @@ from kmk.keys import make_key
 from kmk.kmktime import PeriodicTimer, ticks_diff
 from kmk.modules.split import Split, SplitSide
 from kmk.utils import clamp
-
-displayio.release_displays()
 
 
 class TextEntry:
@@ -108,96 +105,6 @@ class DisplayBackend:
     @root_group.setter
     def root_group(self, group):
         self.display.root_group = group
-
-
-# Intended for displays with drivers built into CircuitPython
-# that can be used directly without manual initialization
-class BuiltInDisplay(DisplayBackend):
-    def __init__(self, display=None, sleep_command=None, wake_command=None):
-        self.display = display
-        self.sleep_command = sleep_command
-        self.wake_command = wake_command
-        self.is_awake = True
-
-    def during_bootup(self, width, height, rotation):
-        self.display.rotation = rotation
-        return self.display
-
-    def deinit(self):
-        return
-
-    def sleep(self):
-        self.display.bus.send(self.sleep_command, b'')
-
-    def wake(self):
-        self.display.bus.send(self.wake_command, b'')
-
-
-class SSD1306(DisplayBackend):
-    def __init__(self, i2c=None, sda=None, scl=None, device_address=0x3C):
-        self.device_address = device_address
-        # i2c initialization
-        self.i2c = i2c
-        if self.i2c is None:
-            self.i2c = busio.I2C(scl, sda)
-
-    def during_bootup(self, width, height, rotation):
-        import adafruit_displayio_ssd1306
-
-        self.display = adafruit_displayio_ssd1306.SSD1306(
-            displayio.I2CDisplay(self.i2c, device_address=self.device_address),
-            width=width,
-            height=height,
-            rotation=rotation,
-        )
-
-        return self.display
-
-    def deinit(self):
-        self.i2c.deinit()
-
-
-class SH1106(DisplayBackend):
-    def __init__(
-        self,
-        spi=None,
-        sck=None,
-        mosi=None,
-        command=None,
-        chip_select=None,
-        reset=None,
-        baudrate=1000000,
-    ):
-        displayio.release_displays()
-        self.command = command
-        self.chip_select = chip_select
-        self.reset = reset
-        self.baudrate = baudrate
-        # spi initialization
-        self.spi = spi
-        if self.spi is None:
-            self.spi = busio.SPI(sck, mosi)
-
-    def during_bootup(self, width, height, rotation):
-        import adafruit_displayio_sh1106
-
-        self.display = adafruit_displayio_sh1106.SH1106(
-            displayio.FourWire(
-                self.spi,
-                command=self.command,
-                chip_select=self.chip_select,
-                reset=self.reset,
-                baudrate=self.baudrate,
-            ),
-            width=width,
-            height=height,
-            rotation=rotation,
-        )
-
-        return self.display
-
-    def deinit(self):
-        self.spi.deinit()
 
 
 class Display(Extension):

--- a/kmk/extensions/display/builtin.py
+++ b/kmk/extensions/display/builtin.py
@@ -1,0 +1,24 @@
+from kmk.extensions.display import DisplayBackend
+
+
+# Intended for displays with drivers built into CircuitPython
+# that can be used directly without manual initialization
+class BuiltInDisplay(DisplayBackend):
+    def __init__(self, display=None, sleep_command=None, wake_command=None):
+        self.display = display
+        self.sleep_command = sleep_command
+        self.wake_command = wake_command
+        self.is_awake = True
+
+    def during_bootup(self, width, height, rotation):
+        self.display.rotation = rotation
+        return self.display
+
+    def deinit(self):
+        return
+
+    def sleep(self):
+        self.display.bus.send(self.sleep_command, b'')
+
+    def wake(self):
+        self.display.bus.send(self.wake_command, b'')

--- a/kmk/extensions/display/builtin.py
+++ b/kmk/extensions/display/builtin.py
@@ -1,9 +1,9 @@
-from kmk.extensions.display import DisplayBackend
+from kmk.extensions.display import DisplayBase
 
 
 # Intended for displays with drivers built into CircuitPython
 # that can be used directly without manual initialization
-class BuiltInDisplay(DisplayBackend):
+class BuiltInDisplay(DisplayBase):
     def __init__(self, display=None, sleep_command=None, wake_command=None):
         self.display = display
         self.sleep_command = sleep_command

--- a/kmk/extensions/display/builtin.py
+++ b/kmk/extensions/display/builtin.py
@@ -1,4 +1,4 @@
-from kmk.extensions.display import DisplayBase
+from . import DisplayBase
 
 
 # Intended for displays with drivers built into CircuitPython

--- a/kmk/extensions/display/sh1106.py
+++ b/kmk/extensions/display/sh1106.py
@@ -3,13 +3,13 @@ import busio
 import adafruit_displayio_sh1106  # Display-specific library
 import displayio
 
-from kmk.extensions.display import DisplayBackend
+from kmk.extensions.display import DisplayBase
 
 # Required to initialize this display
 displayio.release_displays()
 
 
-class SH1106(DisplayBackend):
+class SH1106(DisplayBase):
     def __init__(
         self,
         spi=None,

--- a/kmk/extensions/display/sh1106.py
+++ b/kmk/extensions/display/sh1106.py
@@ -20,7 +20,6 @@ class SH1106(DisplayBackend):
         reset=None,
         baudrate=1000000,
     ):
-        displayio.release_displays()
         self.command = command
         self.chip_select = chip_select
         self.reset = reset

--- a/kmk/extensions/display/sh1106.py
+++ b/kmk/extensions/display/sh1106.py
@@ -3,7 +3,7 @@ import busio
 import adafruit_displayio_sh1106  # Display-specific library
 import displayio
 
-from kmk.extensions.display import DisplayBase
+from . import DisplayBase
 
 # Required to initialize this display
 displayio.release_displays()

--- a/kmk/extensions/display/sh1106.py
+++ b/kmk/extensions/display/sh1106.py
@@ -1,0 +1,50 @@
+import busio
+
+import adafruit_displayio_sh1106  # Display-specific library
+import displayio
+
+from kmk.extensions.display import DisplayBackend
+
+# Required to initialize this display
+displayio.release_displays()
+
+
+class SH1106(DisplayBackend):
+    def __init__(
+        self,
+        spi=None,
+        sck=None,
+        mosi=None,
+        command=None,
+        chip_select=None,
+        reset=None,
+        baudrate=1000000,
+    ):
+        displayio.release_displays()
+        self.command = command
+        self.chip_select = chip_select
+        self.reset = reset
+        self.baudrate = baudrate
+        # spi initialization
+        self.spi = spi
+        if self.spi is None:
+            self.spi = busio.SPI(sck, mosi)
+
+    def during_bootup(self, width, height, rotation):
+        self.display = adafruit_displayio_sh1106.SH1106(
+            displayio.FourWire(
+                self.spi,
+                command=self.command,
+                chip_select=self.chip_select,
+                reset=self.reset,
+                baudrate=self.baudrate,
+            ),
+            width=width,
+            height=height,
+            rotation=rotation,
+        )
+
+        return self.display
+
+    def deinit(self):
+        self.spi.deinit()

--- a/kmk/extensions/display/ssd1306.py
+++ b/kmk/extensions/display/ssd1306.py
@@ -1,0 +1,31 @@
+import busio
+
+import adafruit_displayio_ssd1306  # Display-specific library
+import displayio
+
+from kmk.extensions.display import DisplayBackend
+
+# Required to initialize this display
+displayio.release_displays()
+
+
+class SSD1306(DisplayBackend):
+    def __init__(self, i2c=None, sda=None, scl=None, device_address=0x3C):
+        self.device_address = device_address
+        # i2c initialization
+        self.i2c = i2c
+        if self.i2c is None:
+            self.i2c = busio.I2C(scl, sda)
+
+    def during_bootup(self, width, height, rotation):
+        self.display = adafruit_displayio_ssd1306.SSD1306(
+            displayio.I2CDisplay(self.i2c, device_address=self.device_address),
+            width=width,
+            height=height,
+            rotation=rotation,
+        )
+
+        return self.display
+
+    def deinit(self):
+        self.i2c.deinit()

--- a/kmk/extensions/display/ssd1306.py
+++ b/kmk/extensions/display/ssd1306.py
@@ -3,7 +3,7 @@ import busio
 import adafruit_displayio_ssd1306  # Display-specific library
 import displayio
 
-from kmk.extensions.display import DisplayBase
+from . import DisplayBase
 
 # Required to initialize this display
 displayio.release_displays()

--- a/kmk/extensions/display/ssd1306.py
+++ b/kmk/extensions/display/ssd1306.py
@@ -3,13 +3,13 @@ import busio
 import adafruit_displayio_ssd1306  # Display-specific library
 import displayio
 
-from kmk.extensions.display import DisplayBackend
+from kmk.extensions.display import DisplayBase
 
 # Required to initialize this display
 displayio.release_displays()
 
 
-class SSD1306(DisplayBackend):
+class SSD1306(DisplayBase):
     def __init__(self, i2c=None, sda=None, scl=None, device_address=0x3C):
         self.device_address = device_address
         # i2c initialization


### PR DESCRIPTION
A while ago, when I added the `BuiltInDisplay` backend in #846, I made an erroneous assumption about how the displays worked. I moved `displayio.release_displays()` to the `__init__()` methods of the displays that needed it, which inadvertently broke them. (Which I sincerely apologize for.)

This was later fixed in #871, at the cost of breaking `BuiltInDisplay`.

I have since come up with a compromise that should ensure all currently supported displays are functional: Break `display.py` into multiple files:
- `display.py`, which contains the classes for the displays that require `displayio.release_displays()`
- `display_builtin.py`, which contains `BuiltInDisplay`
- `display_common.py`, which contains the code shared by both, which is also re-exported by both of the other files for compatibility.

I tried to make all displays work while minimizing breaking changes. As far as I am aware, the only breaking change is that users of `BuildInDisplay` will need to import from `display_builtin` instead of `display`. I have updated `Display.md` accordingly.

Also, I do not own a keyboard with a `SSD1306` display, so I would need someone else who has one to check that I did not break anything again.