### PR TITLE
Fix unittest auto-discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,11 @@ test: lint unit-tests
 
 .PHONY: unit-tests
 unit-tests: devdeps
+ifdef TESTS
 	@$(PIPENV) run python3 -m unittest $(TESTS)
+else
+	@$(PIPENV) run python3 -m unittest discover -t . -s tests
+endif # TESTS
 
 reset-bootloader:
 	@echo "===> Rebooting your board to bootloader (safe to ignore file not found errors)"


### PR DESCRIPTION
Fixes issues with auto-discovery / order of mock imports (specifically #930).
As a side effect: speeds up unittesting.