### PR TITLE
Add data serial to `bootcfg` and rename console serial

### DIFF
--- a/docs/en/boot.md
+++ b/docs/en/boot.md
@@ -24,7 +24,8 @@ bootcfg(
     # optional:
     source: Optional[microcontroller.Pin, digitalio.DigitalInOut] = None,
     boot_device: int = 0,
-    cdc: bool = True,
+    cdc_console: bool = True,
+    cdc_data: bool = False,
     consumer_control: bool = True,
     keyboard: bool = True,
     midi: bool = True,
@@ -70,8 +71,12 @@ Boot HID device configuration for `usb_hid`, see the [`usb_hid` documentation](h
 for details.
 
 
-#### `cdc`
+#### `cdc_console`
 This will enable or disable the USB endpoint for the serial console with REPL.
+
+
+#### `cdc_data`
+This will enable or disable the USB endpoint for the data serial.
 
 
 #### `consumer_control`
@@ -180,7 +185,7 @@ sense = True
 
 bootcfg(
     sense=sense,
-    cdc=False,
+    cdc_console=False,
     consumer_control=False,
     keyboard=False,
     midi=False,

--- a/docs/en/serialace.md
+++ b/docs/en/serialace.md
@@ -15,11 +15,19 @@ use for the CircuitPython debugger).
 
 ## Prerequisite
 
-Enable the data serial in `boot.py`:
+Enable the data serial in `boot.py`, for example by using KMK's builtin boot
+configurator:
 ```python
-import usb_cdc
-usb_cdc.enable(data=True)
+from kmk.bootcfg import bootcfg
+
+bootcfg(
+    # ...excerpt
+    cdc_data=True,
+    # ...
+)
+
 ```
+Consult the [bootcfg documentation](boot.md) for more details.
 
 
 ## Example

--- a/kmk/bootcfg.py
+++ b/kmk/bootcfg.py
@@ -12,7 +12,8 @@ def bootcfg(
     sense: [microcontroller.Pin, digitalio.DigitalInOut],
     source: Optional[microcontroller.Pin, digitalio.DigitalInOut] = None,
     boot_device: int = 0,
-    cdc: bool = True,
+    cdc_console: bool = True,
+    cdc_data: bool = False,
     consumer_control: bool = True,
     keyboard: bool = True,
     midi: bool = True,
@@ -77,13 +78,19 @@ def bootcfg(
         if hasattr(supervisor, 'set_usb_identification'):
             supervisor.set_usb_identification(*usb_id)
 
-    # Entries for cdc (REPL) and storage are intentionally evaluated last to
-    # ensure the board is debuggable, mountable and rescueable, in case any of
-    # the previous code throws an exception.
-    if not cdc:
+    # configure data serial
+    if cdc_data:
         import usb_cdc
 
-        usb_cdc.disable()
+        usb_cdc.enable(data=True)
+
+    # Entries for serial console (REPL) and storage are intentionally evaluated
+    # last to ensure the board is debuggable, mountable and rescueable, in case
+    # any of the previous code throws an exception.
+    if not cdc_console:
+        import usb_cdc
+
+        usb_cdc.enable(console=False)
 
     if not storage:
         import storage

--- a/util/aspell.en.pws
+++ b/util/aspell.en.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 348 
+personal_ws-1.1 en 349
 ADNS
 AMS
 ANAVI
@@ -217,6 +217,7 @@ ble
 bmp
 bondings
 boolean
+bootcfg
 bootloader
 bootup
 bytecode


### PR DESCRIPTION
Add data serial to bootcfg, rename console serial to distinguish between them.

Draft, because I have currently no clue why the spellchecker started complaining about a single code segment...