### PR TITLE
Do not delete the keys pressed in a sequence

### DIFF
--- a/kmk/handlers/sequences.py
+++ b/kmk/handlers/sequences.py
@@ -14,9 +14,6 @@ def get_wide_ordinal(char):
 
 
 def sequence_press_handler(key, keyboard, KC, *args, **kwargs):
-    oldkeys_pressed = keyboard.keys_pressed
-    keyboard.keys_pressed = set()
-
     for ikey in key.meta.seq:
         if not getattr(ikey, 'no_press', None):
             keyboard.add_key(ikey)
@@ -27,8 +24,6 @@ def sequence_press_handler(key, keyboard, KC, *args, **kwargs):
         else:
             keyboard.tap_key(ikey)
             keyboard._send_hid()
-
-    keyboard.keys_pressed = oldkeys_pressed
 
     return keyboard
 


### PR DESCRIPTION
Remember the keys that were pressed before entering the sequence. E.g. when a sequence creates the German Umlaut "ä", holding shift should lead to "Ä". This is also the behavior in QMK.