### PR TITLE
Documentation update - activ layer rgb indication

### DIFF
--- a/docs/en/layers.md
+++ b/docs/en/layers.md
@@ -75,26 +75,47 @@ keyboard.keymap = [
 ]
 ```
 
-## Advanced Example
+## Active Layer indication with RGB
 A common question is: "How do I change RGB background based on my active layer?"
 Here is _one_ (simple) way of many to go about it.
 
+To indicate active layer you can use RGB background, or in many cases board's status LED, then no additional hardware is needed. Information about the LED type and to which GPIO pin it is connected is often available on the pinout of the board and in the documentation.
+
+In this example on board RGB status LED is used. Number of layers is unlimited and only chosen layers can be used. Note, that LED's basic colors can have different order for different hardware.
+
 ```python
+import board
+
 from kmk.modules.layers import Layers as _Layers
 from kmk.extensions.rgb import RGB
 
-rgb = RGB(...) # your RGB configuration goes here
+sat = 255
+val = 5; # brightness in range 0-255
+
+rgb = RGB(pixel_pin=board.GP16,     # GPIO pin of the status LED, or background RGB light
+        num_pixels=1,               # one if status LED, more if background RGB light
+        rgb_order=(0, 1, 2),        # RGB order may differ depending on the hardware
+        hue_default=0,              # in range 0-255: 0/255-red, 85-green, 170-blue
+        sat_default=sat,
+        val_default=val,
+        )
+
 keyboard.extensions.append(rgb)
 
 class Layers(_Layers):
-	last_top_layer = 0
-	hues = (4, 20, 69)
-	
-	def after_hid_send(self, keyboard):
-		if keyboard.active_layers[0] != self.last_top_layer:
-			self.last_top_layer = keyboard.active_layers[0]
-			rgb.set_hsv_fill(self.hues[self.last_top_layer], 255, 255)
-			rgb.hue = self.hues[self.last_top_layer]
+    last_top_layer = 0
+    
+    def after_hid_send(self, keyboard):
+        if keyboard.active_layers[0] != self.last_top_layer:
+            self.last_top_layer = keyboard.active_layers[0]
+            if self.last_top_layer == 0:  # default
+                rgb.set_hsv_fill(0, sat, val)   # red
+            elif self.last_top_layer == 1:
+                rgb.set_hsv_fill(170, sat, val) # blue
+            elif self.last_top_layer == 2:
+                rgb.set_hsv_fill(43, sat, val)  # yellow
+            elif self.last_top_layer == 4:
+                rgb.set_hsv_fill(0, 0, val)     # white
 
 keyboard.modules.append(Layers())
 ```

--- a/docs/en/pimoroni_trackball.md
+++ b/docs/en/pimoroni_trackball.md
@@ -63,3 +63,37 @@ trackball.set_white(brightness)
 
 This module exposes one keycode `TB_MODE`, which on hold switches between `MOUSE_MODE` and `SCROLL_MODE`.
 To choose the default mode, pass it in `Trackball` constructor.
+
+
+#### Light animation
+
+The trackball has smart LED which can be controlled with [NeoPixel library from Adafruit](https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel/blob/main/neopixel.py) and the [RGB extension](http://kmkfw.io/docs/rgb).
+Example of very slowly glowing led, almost seamlessly changing colors:
+
+```python
+# initiate the trackball and add the library for the trackball pixel buffer
+from kmk.modules.pimoroni_trackball import TrackballPixel
+
+# add rgb extension with animations
+from kmk.extensions.rgb import RGB, AnimationModes
+
+# pass the pixel buffer to the rgb extension and declare pixel pin None
+pixels = ( TrackballPixel(trackball) )
+
+# set the rgb animation configuration to your taste
+rgb = RGB(pixel_pin=None,
+        num_pixels=1,
+        pixels=pixels,
+        hue_default=0,
+        sat_default=255,
+        val_default=255,
+        hue_step=1,
+        sat_step=0,
+        val_step=0,
+        animation_speed=0.5,
+        animation_mode=AnimationModes.SWIRL,
+        )
+
+keyboard.extensions.append(rgb)
+```
+


### PR DESCRIPTION
- change for more descriptive paragraph subtitle
- introducing idea that also board's RGB status LED can be used for that purpose
- slightly expanded code snippet to make it copy-paste usable
- more comments in the code snippet about values range and their specifics
- slightly refactored code to add possibility to indicate only chosen layers