### PR TITLE
Add 'unhold' keycode to HoldTap key config (fire keycode when uninterrupted 'hold' is released), so one can combine homerow mods and autoshift

### DIFF
--- a/kmk/modules/holdtap.py
+++ b/kmk/modules/holdtap.py
@@ -20,9 +20,10 @@ class HoldTapKeyState:
     RELEASED = const(0)
     PRESSED = const(1)
     HOLD_TIMEOUT = const(2)
-    INTERRUPTED = const(3)
-    HOLD_INTERRUPTED = const(4)
-    REPEAT = const(5)
+    HOLD_TIMEOUT_INACTIVE = const(3)
+    INTERRUPTED = const(4)
+    HOLD_INTERRUPTED = const(5)
+    REPEAT = const(6)
 
     def __init__(self, timeout_key, *args, **kwargs):
         self.timeout_key = timeout_key
@@ -40,6 +41,7 @@ class HoldTapKeyMeta:
         hold,
         unhold=None,
         prefer_hold=True,
+        dont_hold_until_interrupted=False,
         tap_interrupted=False,
         tap_time=None,
         repeat=HoldTapRepeat.NONE,
@@ -48,6 +50,7 @@ class HoldTapKeyMeta:
         self.hold = hold
         self.unhold = unhold
         self.prefer_hold = prefer_hold
+        self.dont_hold_until_interrupted = dont_hold_until_interrupted
         self.tap_interrupted = tap_interrupted
         self.tap_time = tap_time
         self.repeat = repeat
@@ -89,6 +92,13 @@ class HoldTap(Module):
             if state.key_state == HoldTapKeyState.HOLD_TIMEOUT and is_pressed:
                 # some key was pressed while holding holdtap key
                 state.key_state = HoldTapKeyState.HOLD_INTERRUPTED
+                continue
+
+            if state.key_state == HoldTapKeyState.HOLD_TIMEOUT_INACTIVE and is_pressed:
+                state.key_state = HoldTapKeyState.HOLD_INTERRUPTED
+                self.ht_activate_hold(state, key, keyboard, *state.args, **state.kwargs)
+                append_buffer = True
+                send_buffer = True
                 continue
 
             if state.key_state != HoldTapKeyState.PRESSED:
@@ -170,7 +180,7 @@ class HoldTap(Module):
         state = self.key_states[key]
         keyboard.cancel_timeout(state.timeout_key)
 
-        if state.key_state == HoldTapKeyState.HOLD_TIMEOUT:
+        if state.key_state == HoldTapKeyState.HOLD_TIMEOUT or state.key_state == HoldTapKeyState.HOLD_TIMEOUT_INACTIVE:
             # release hold
             self.ht_deactivate(state, key, keyboard, *args, **kwargs)
             # send unhold if any
@@ -223,9 +233,12 @@ class HoldTap(Module):
 
         if self.key_states[key].key_state == HoldTapKeyState.PRESSED:
             # press hold because timer expired after tap time
-            self.key_states[key].key_state = HoldTapKeyState.HOLD_TIMEOUT
-            self.ht_activate_hold(state, key, keyboard, *args, **kwargs)
-            self.send_key_buffer(keyboard)
+            if key.meta.dont_hold_until_interrupted:
+                self.key_states[key].key_state = HoldTapKeyState.HOLD_TIMEOUT_INACTIVE
+            else:
+                self.key_states[key].key_state = HoldTapKeyState.HOLD_TIMEOUT
+                self.ht_activate_hold(state, key, keyboard, *args, **kwargs)
+                self.send_key_buffer(keyboard)
         elif state.key_state == HoldTapKeyState.RELEASED:
             del self.key_states[key]
 


### PR DESCRIPTION
When reviewing, please view commits one-by-one for better understandig.

Backward compatibility is preserved: old code using holdtap module will continue working without changes.

1. First two commits are just refactoring for future convinience. Reasons for refactoring are:
a) 'activated' field values are inconsistent: serving repeat function it can contain 'HOLD_TIMEOUT' and 'INTERRUPTED' values while actual key state is 'released', and for 'tap' action in similar case it separates released state with 'RELEASED' value;
b) keycode to be inactivated and its repeatetivenes are calculated at the ht_released although these values were already calculated earlier (when correspondig keycode was activated), so there is some logic duplication

This complicates the module to the extent where adding new functionality is quite difficult and error prone. My idea was to store active keycode and repeatetivenes inside the state object and make the 'activated' field more consistent (after refactoring it just reflects key state as it is)

2. Third commit is adding 'unhold' behaviour itself. The most obvious application of this functionality is to implement combination of autoshift and homerow mods. For example, let's combine letter 'a' and LCTL:

```
A_CTL = KC.HT(KC.A, KC.LCTL, unhold = KC.LSFT(KC.A), repeat = HoldTapRepeat.TAP | HoldTapRepeat.UNHOLD, tap_interrupted=True, prefer_hold=True)
```

So, short press produces 'a' letter, long press produces 'A' letter, and a+s produces ctrl+s hotkey.

3. Though there is one caveat addressed in the fourth commit. Consider assigning 'g' with autoshift to homerow LGUI mod:
```
G_GUI = KC.HT(KC.G, KC.LGUI, unhold = KC.LSFT(KC.G), repeat = HoldTapRepeat.TAP | HoldTapRepeat.UNHOLD, tap_interrupted=True, prefer_hold=True)
```
In such a case, long-pressing it produces the following event sequence: lgui press/release, than shift+g press/release. But Windows and Gnome (at least) have special meaning for LGUI tap so our key will behave quite naughty.

Good solution to this problem is to hold down activating the actual 'hold' keycode until some other key is pressed (i.e. 'hold' is 'interrupted'). But this breaks current holdtap usecases like, for example, sharing q+esc on a single button.

In order to preserve backward compatibility, this behaviour is made customizable via additional 'dont_hold_until_interrupted' flag. So both the following keys will work as expected:
```
G_GUI = KC.HT(KC.G, KC.LGUI, unhold = KC.LSFT(KC.G), repeat = HoldTapRepeat.TAP | HoldTapRepeat.UNHOLD, tap_interrupted=True, prefer_hold=True, dont_hold_until_interrupted=True)
Q_ESC = KC.HT(KC.Q, KC.ESC, repeat = HoldTapRepeat.ALL, tap_interrupted=True, prefer_hold=False)
```