### PR TITLE
[peg_oled_display] Update outdated `show()` calls

### DIFF
--- a/kmk/extensions/peg_oled_display.py
+++ b/kmk/extensions/peg_oled_display.py
@@ -97,7 +97,7 @@ class Oled(Extension):
                 y=25,
             )
         )
-        self._display.show(splash)
+        self._display.root_group = splash
         gc.collect()
 
     def renderOledImgLayer(self, layer):
@@ -107,7 +107,7 @@ class Oled(Extension):
         )
         image = displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
         splash.append(image)
-        self._display.show(splash)
+        self._display.root_group = splash
         gc.collect()
 
     def updateOLED(self, sandbox):


### PR DESCRIPTION
These were [deprecated in circuitpython 9](https://github.com/adafruit/circuitpython/pull/8456) and need to be updated to use the `root_group` API to support latest versions.

`root_group` has been around for some time so although this is a breaking change for almost anyone using Peg + Blok. 

Anecdotally, my Lily58 was an early Blok build and the microcontroller I got from BoardSource had circuitpython 8.x.