### PR TITLE
Implement automatic firmware reload and show error stacktrace

### DIFF
--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -461,17 +461,28 @@ class KMKKeyboard:
                 debug_error(ext, 'deinit', err)
 
     def go(self, hid_type=HIDModes.USB, secondary_hid_type=None, **kwargs) -> None:
-        self._init(hid_type=hid_type, secondary_hid_type=secondary_hid_type, **kwargs)
         try:
+            self._init(
+                hid_type=hid_type,
+                secondary_hid_type=secondary_hid_type,
+                **kwargs,
+            )
             while True:
                 self._main_loop()
         except Exception as err:
-            debug_error(self, 'Unexpected error', err)
+            import traceback
+
+            traceback.print_exception(err)
         finally:
             debug('cleaning up...')
             self._deinit_hid()
             self.deinit()
             debug('...done')
+
+            if not debug.enabled:
+                import supervisor
+
+                supervisor.reload()
 
     def _init(
         self,


### PR DESCRIPTION
Trigger a supervisor reload on any exception, restarting the firmware; unless it's a keyboard interrupt in which case we explicitly want to drop into the REPL.
Replace the sparse debug error message with a stacktrace.