### PR TITLE
Make unittest only scan the `tests/` directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ powerwash: clean
 
 test: lint unit-tests
 
+TESTS ?= tests
 .PHONY: unit-tests
 unit-tests: devdeps
 ifdef TESTS

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,13 @@
+import os
+
 from tests.mocks import init_circuit_python_modules_mocks
 
 init_circuit_python_modules_mocks()
+
+
+def load_tests(loader, standard_tests, pattern):
+    # top level directory cached on loader instance
+    this_dir = os.path.dirname(__file__)
+    package_tests = loader.discover(start_dir=this_dir, pattern='test*.py')
+    standard_tests.addTests(package_tests)
+    return standard_tests


### PR DESCRIPTION
I had this issue a while back, where scanning the entire project for `test*.py` files caused problems in combination with the `TESTS` variable. To be honest, the details elude mit at this point in time -- but it probably doesn't hurt to restrict the test discovery? At least for me it worked well enough that I forgot to PR it.