### PR TITLE
Add boot configuration for autoreload when writing to the CP drive

### DIFF
--- a/docs/en/boot.md
+++ b/docs/en/boot.md
@@ -23,6 +23,7 @@ bootcfg(
     sense: [microcontroller.Pin, digitalio.DigitalInOut],
     # optional:
     source: Optional[microcontroller.Pin, digitalio.DigitalInOut] = None,
+    autoreload: bool = True,
     boot_device: int = 0,
     cdc_console: bool = True,
     cdc_data: bool = False,
@@ -64,6 +65,13 @@ Common matrix and direct pin configurations (see also the examples below):
 |`COL2ROW`         |column     |row        |
 |`ROW2COL`         |row        |column     |
 |direct pin        |direct pin |`None`     |
+
+
+#### `autoreload`
+CircuitPython will automatically reload when any data or meta data is written to
+the CircuitPython drive.
+Certain operating systems tend to do that without asking; in that case
+`autoreload` can be disabled as a workaround.
 
 
 #### `boot_device`

--- a/kmk/bootcfg.py
+++ b/kmk/bootcfg.py
@@ -11,6 +11,7 @@ import usb_hid
 def bootcfg(
     sense: [microcontroller.Pin, digitalio.DigitalInOut],
     source: Optional[microcontroller.Pin, digitalio.DigitalInOut] = None,
+    autoreload: bool = True,
     boot_device: int = 0,
     cdc_console: bool = True,
     cdc_data: bool = False,
@@ -38,9 +39,10 @@ def bootcfg(
         source.direction = digitalio.Direction.OUTPUT
         source.value = False
 
-    # sense pulled low -> skip boot configuration
-    if not sense.value:
-        return False
+    if not autoreload:
+        import supervisor
+
+        supervisor.runtime.autoreload = False
 
     # configure HID devices
     devices = []
@@ -83,6 +85,11 @@ def bootcfg(
         import usb_cdc
 
         usb_cdc.enable(data=True)
+
+    # sense pulled low -> Skip boot configuration that may disable debug or
+    # rescue facilities.
+    if not sense.value:
+        return False
 
     # Entries for serial console (REPL) and storage are intentionally evaluated
     # last to ensure the board is debuggable, mountable and rescueable, in case


### PR DESCRIPTION
There have been people complaining about windows occasionally "rebooting" their keyboard.