### PR TITLE
Keybow 2040: Speed up RGB.

### DIFF
--- a/boards/pimoroni/keybow_2040/code.py
+++ b/boards/pimoroni/keybow_2040/code.py
@@ -1,5 +1,5 @@
-from is31fl3731_pixelbuf import Keybow2040Leds
 from keybow_2040 import Keybow2040
+from keybow_2040_rgb import Keybow2040Leds
 
 from kmk.extensions.rgb import RGB, AnimationModes
 from kmk.keys import KC

--- a/boards/pimoroni/keybow_2040/keybow_2040_rgb.py
+++ b/boards/pimoroni/keybow_2040/keybow_2040_rgb.py
@@ -19,6 +19,24 @@ class Keybow2040Leds(PixelBuf):
 
     width = 16
     height = 3
+    _pixel_addr = [
+        (120, 88, 104),  # 0, 0
+        (136, 40, 72),  # 1, 0
+        (112, 80, 96),  # 2, 0
+        (128, 32, 64),  # 3, 0
+        (121, 89, 105),  # 0, 1
+        (137, 41, 73),  # 1, 1
+        (113, 81, 97),  # 2, 1
+        (129, 33, 65),  # 3, 1
+        (122, 90, 106),  # 0, 2
+        (138, 25, 74),  # 1, 2
+        (114, 82, 98),  # 2, 2
+        (130, 17, 66),  # 3, 2
+        (123, 91, 107),  # 0, 3
+        (139, 26, 75),  # 1, 3
+        (115, 83, 99),  # 2, 3
+        (131, 18, 67),  # 3, 3
+    ]
 
     def __init__(self, size: int = 16):  # Kept for backward compatibility
         self.i2c = busio.I2C(board.SCL, board.SDA, frequency=400_000)
@@ -42,7 +60,7 @@ class Keybow2040Leds(PixelBuf):
         # Shuffle the 16 pixel PixelBuf buffer into our 144 LED
         # display native format.
         for x in range(self._pixels):
-            r, g, b = Keybow2040Leds.pixel_addr(x)
+            r, g, b = self._pixel_addr[x]
             self.out_buffer[r] = buffer[x * 3 + 0]
             self.out_buffer[g] = buffer[x * 3 + 1]
             self.out_buffer[b] = buffer[x * 3 + 2]
@@ -61,24 +79,3 @@ class Keybow2040Leds(PixelBuf):
 
         # Switch to our other buffer
         self._frame = not self._frame
-
-    @staticmethod
-    def pixel_addr(x):
-        return [
-            (120, 88, 104),  # 0, 0
-            (136, 40, 72),  # 1, 0
-            (112, 80, 96),  # 2, 0
-            (128, 32, 64),  # 3, 0
-            (121, 89, 105),  # 0, 1
-            (137, 41, 73),  # 1, 1
-            (113, 81, 97),  # 2, 1
-            (129, 33, 65),  # 3, 1
-            (122, 90, 106),  # 0, 2
-            (138, 25, 74),  # 1, 2
-            (114, 82, 98),  # 2, 2
-            (130, 17, 66),  # 3, 2
-            (123, 91, 107),  # 0, 3
-            (139, 26, 75),  # 1, 3
-            (115, 83, 99),  # 2, 3
-            (131, 18, 67),  # 3, 3
-        ][x]

--- a/boards/pimoroni/keybow_2040/keybow_2040_rgb.py
+++ b/boards/pimoroni/keybow_2040/keybow_2040_rgb.py
@@ -57,13 +57,16 @@ class Keybow2040Leds(PixelBuf):
             i2c.write(bytes([_SHUTDOWN_REGISTER, 0x01]))  # 0 == shutdown, 1 == normal
 
     def _transmit(self, buffer):
+        # Bring these into local scope for a tiny perf improvement ~.7ms
+        pixel_addr = self._pixel_addr
+        out = self.out_buffer
         # Shuffle the 16 pixel PixelBuf buffer into our 144 LED
         # display native format.
         for x in range(self._pixels):
-            r, g, b = self._pixel_addr[x]
-            self.out_buffer[r] = buffer[x * 3 + 0]
-            self.out_buffer[g] = buffer[x * 3 + 1]
-            self.out_buffer[b] = buffer[x * 3 + 2]
+            r, g, b = pixel_addr[x]
+            out[r] = buffer[x * 3 + 0]
+            out[g] = buffer[x * 3 + 1]
+            out[b] = buffer[x * 3 + 2]
 
         with self.i2c_device as i2c:
             # Switch to our new (not currently visible) frame

--- a/boards/pimoroni/keybow_2040/keybow_2040_rgb.py
+++ b/boards/pimoroni/keybow_2040/keybow_2040_rgb.py
@@ -1,0 +1,112 @@
+import board
+from micropython import const
+
+from adafruit_bus_device.i2c_device import I2CDevice
+from adafruit_pixelbuf import PixelBuf
+
+_FRAME_REGISTER = const(0x01)
+_SHUTDOWN_REGISTER = const(0x0A)
+_CONFIG_BANK = const(0x0B)
+_BANK_ADDRESS = const(0xFD)
+
+_ENABLE_OFFSET = const(0x00)
+_COLOR_OFFSET = const(0x24)
+
+
+class Keybow2040Leds(PixelBuf):
+    '''Supports the Pimoroni Keybow 2040 with 4x4 matrix of RGB LEDs'''
+
+    width = 16
+    height = 3
+
+    def __init__(self, size: int = 16):  # Kept for backward compatibility
+        self.i2c_device = I2CDevice(board.I2C(), 0x74)
+        self.out_buffer = bytearray(144)
+        self._pixels = 16
+        self._frame = 0
+        super().__init__(self._pixels, byteorder='RGB')
+
+        with self.i2c_device as i2c:
+            for frame in range(2):
+                i2c.write(bytes([_BANK_ADDRESS, frame]))
+                i2c.write(bytes([_ENABLE_OFFSET] + [0xFF] * 18))  # Enable all LEDs
+                i2c.write(bytes([_COLOR_OFFSET] + [0x00] * 144))  # Init all to 0
+
+            i2c.write(bytes([_BANK_ADDRESS, _CONFIG_BANK]))
+            i2c.write(bytes([0x00] * 14))  # Clear Mode, Frame, ... etc
+            i2c.write(bytes([_SHUTDOWN_REGISTER, 0x01]))  # 0 == shutdown, 1 == normal
+
+        # Keep track of the LEDs we actually use (48 out of 144)
+        # so we can batch up individual i2c transactions and avoid
+        # copying unused data.
+        self.used_leds = [
+            [17, 18],
+            [25, 26],
+            [32, 33],
+            [40, 41],
+            [64, 65, 66, 67],
+            [72, 73, 74, 75],
+            [80, 81, 82, 83],
+            [88, 89, 90, 91],
+            [96, 97, 98, 99],
+            [104, 105, 106, 107],
+            [112, 113, 114, 115],
+            [120, 121, 122, 123],
+            [128, 129, 130, 131],
+            [136, 137, 138, 139],
+        ]
+
+    def _transmit(self, buffer):
+        # Shuffle the 16 pixel PixelBuf buffer into our 144 LED
+        # display native format.
+        for x in range(self._pixels):
+            r, g, b = Keybow2040Leds.pixel_addr(x)
+            self.out_buffer[r] = buffer[x * 3 + 0]
+            self.out_buffer[g] = buffer[x * 3 + 1]
+            self.out_buffer[b] = buffer[x * 3 + 2]
+
+        with self.i2c_device as i2c:
+            # Switch to our new (not currently visible) frame
+            i2c.write(bytes([_BANK_ADDRESS, self._frame]))
+
+            # Lazy non-batched write, probably fast enough?
+            # i2c.write(bytes([_COLOR_OFFSET]) + self.out_buffer)
+
+            # We only actually use 16 * 3 = 48 LEDs out of the 144 total
+            # They're kind of awkwardly spread around, but if we batch up
+            # the writes it gets the update time from ~0.016ms to ~0.012ms
+            for group in self.used_leds:
+                offset = group[0]
+                count = len(group)
+                i2c.write(
+                    bytes([_COLOR_OFFSET + offset])
+                    + self.out_buffer[offset : offset + count]
+                )
+
+            # Set the newly written frame as the visible one
+            i2c.write(bytes([_BANK_ADDRESS, _CONFIG_BANK]))
+            i2c.write(bytes([_FRAME_REGISTER, self._frame]))
+
+        # Switch to our other buffer
+        self._frame = not self._frame
+
+    @staticmethod
+    def pixel_addr(x):
+        return [
+            (120, 88, 104),  # 0, 0
+            (136, 40, 72),  # 1, 0
+            (112, 80, 96),  # 2, 0
+            (128, 32, 64),  # 3, 0
+            (121, 89, 105),  # 0, 1
+            (137, 41, 73),  # 1, 1
+            (113, 81, 97),  # 2, 1
+            (129, 33, 65),  # 3, 1
+            (122, 90, 106),  # 0, 2
+            (138, 25, 74),  # 1, 2
+            (114, 82, 98),  # 2, 2
+            (130, 17, 66),  # 3, 2
+            (123, 91, 107),  # 0, 3
+            (139, 26, 75),  # 1, 3
+            (115, 83, 99),  # 2, 3
+            (131, 18, 67),  # 3, 3
+        ][x]

--- a/boards/pimoroni/keybow_2040/keybow_2040_rgb.py
+++ b/boards/pimoroni/keybow_2040/keybow_2040_rgb.py
@@ -5,7 +5,6 @@ from micropython import const
 from adafruit_bus_device.i2c_device import I2CDevice
 from adafruit_pixelbuf import PixelBuf
 
-_FRAME_REGISTER = const(0x01)
 _SHUTDOWN_REGISTER = const(0x0A)
 _CONFIG_BANK = const(0x0B)
 _BANK_ADDRESS = const(0xFD)
@@ -19,66 +18,60 @@ class Keybow2040Leds(PixelBuf):
 
     width = 16
     height = 3
+
+    # Pixel addresses starting from LED 17,
+    # then offset by 1 to fit register addr
     _pixel_addr = [
-        (120, 88, 104),  # 0, 0
-        (136, 40, 72),  # 1, 0
-        (112, 80, 96),  # 2, 0
-        (128, 32, 64),  # 3, 0
-        (121, 89, 105),  # 0, 1
-        (137, 41, 73),  # 1, 1
-        (113, 81, 97),  # 2, 1
-        (129, 33, 65),  # 3, 1
-        (122, 90, 106),  # 0, 2
-        (138, 25, 74),  # 1, 2
-        (114, 82, 98),  # 2, 2
-        (130, 17, 66),  # 3, 2
-        (123, 91, 107),  # 0, 3
-        (139, 26, 75),  # 1, 3
-        (115, 83, 99),  # 2, 3
-        (131, 18, 67),  # 3, 3
+        (0, 104, 72, 88),  # 0, 0
+        (3, 120, 24, 56),  # 1, 0
+        (6, 96, 64, 80),  # 2, 0
+        (9, 112, 16, 48),  # 3, 0
+        (12, 105, 73, 89),  # 0, 1
+        (15, 121, 25, 57),  # 1, 1
+        (18, 97, 65, 81),  # 2, 1
+        (21, 113, 17, 49),  # 3, 1
+        (24, 106, 74, 90),  # 0, 2
+        (27, 122, 9, 58),  # 1, 2
+        (30, 98, 66, 82),  # 2, 2
+        (33, 114, 1, 50),  # 3, 2
+        (36, 107, 75, 91),  # 0, 3
+        (39, 123, 10, 59),  # 1, 3
+        (42, 99, 67, 83),  # 2, 3
+        (45, 115, 2, 51),  # 3, 3
     ]
 
-    def __init__(self, size: int = 16):  # Kept for backward compatibility
+    def __init__(self, size: int = 16):  # size kept for backward compatibility
         self.i2c = busio.I2C(board.SCL, board.SDA, frequency=400_000)
         self.i2c_device = I2CDevice(self.i2c, 0x74)
-        self.out_buffer = bytearray(144)
+        self.out_buffer = bytearray(124)
         self._pixels = 16
-        self._frame = 0
         super().__init__(self._pixels, byteorder='RGB')
 
+        # First byte of buffer is our first LED address
+        self.out_buffer[0] = _COLOR_OFFSET + 17
+
         with self.i2c_device as i2c:
-            for frame in range(2):
-                i2c.write(bytes([_BANK_ADDRESS, frame]))
-                i2c.write(bytes([_ENABLE_OFFSET] + [0xFF] * 18))  # Enable all LEDs
-                i2c.write(bytes([_COLOR_OFFSET] + [0x00] * 144))  # Init all to 0
+            i2c.write(bytes([_BANK_ADDRESS, 0]))
+            i2c.write(bytes([_ENABLE_OFFSET] + [0xFF] * 18))  # Enable all LEDs
+            i2c.write(bytes([_COLOR_OFFSET] + [0x00] * 144))  # Init all to 0
 
             i2c.write(bytes([_BANK_ADDRESS, _CONFIG_BANK]))
             i2c.write(bytes([0x00] * 14))  # Clear Mode, Frame, ... etc
             i2c.write(bytes([_SHUTDOWN_REGISTER, 0x01]))  # 0 == shutdown, 1 == normal
 
+            i2c.write(bytes([_BANK_ADDRESS, 0]))
+
     def _transmit(self, buffer):
-        # Bring these into local scope for a tiny perf improvement ~.7ms
-        pixel_addr = self._pixel_addr
+        # Bring buffer into local scope for a tiny perf improvement
         out = self.out_buffer
         # Shuffle the 16 pixel PixelBuf buffer into our 144 LED
         # display native format.
-        for x in range(self._pixels):
-            r, g, b = pixel_addr[x]
-            out[r] = buffer[x * 3 + 0]
-            out[g] = buffer[x * 3 + 1]
-            out[b] = buffer[x * 3 + 2]
+        for o, r, g, b in self._pixel_addr:
+            out[r] = buffer[o + 0]
+            out[g] = buffer[o + 1]
+            out[b] = buffer[o + 2]
 
         with self.i2c_device as i2c:
-            # Switch to our new (not currently visible) frame
-            i2c.write(bytes([_BANK_ADDRESS, self._frame]))
-
-            # We only actually use 16 * 3 = 48 LEDs out of the 144 total
-            # but at 400KHz I2C it's cheaper just to write the whole lot
-            i2c.write(bytes([_COLOR_OFFSET + 17]) + self.out_buffer[17:140])
-
-            # Set the newly written frame as the visible one
-            i2c.write(bytes([_BANK_ADDRESS, _CONFIG_BANK]))
-            i2c.write(bytes([_FRAME_REGISTER, self._frame]))
-
-        # Switch to our other buffer
-        self._frame = not self._frame
+            # Write our 124 byte buffer
+            # byte 0 is prefilled with the register address
+            i2c.write(out)

--- a/boards/pimoroni/keybow_2040/keybow_2040_rgb.py
+++ b/boards/pimoroni/keybow_2040/keybow_2040_rgb.py
@@ -20,11 +20,8 @@ class Keybow2040Leds(PixelBuf):
     width = 16
     height = 3
 
-    def __init__(
-            self,
-            size: int = 16  # Kept for backward compatibility
-    ):
-        self.i2c = busio.I2C( board.SCL, board.SDA, frequency=400_000)
+    def __init__(self, size: int = 16):  # Kept for backward compatibility
+        self.i2c = busio.I2C(board.SCL, board.SDA, frequency=400_000)
         self.i2c_device = I2CDevice(self.i2c, 0x74)
         self.out_buffer = bytearray(144)
         self._pixels = 16
@@ -56,7 +53,7 @@ class Keybow2040Leds(PixelBuf):
 
             # We only actually use 16 * 3 = 48 LEDs out of the 144 total
             # but at 400KHz I2C it's cheaper just to write the whole lot
-            i2c.write(bytes([_COLOR_OFFSET]) + self.out_buffer)
+            i2c.write(bytes([_COLOR_OFFSET + 17]) + self.out_buffer[17:140])
 
             # Set the newly written frame as the visible one
             i2c.write(bytes([_BANK_ADDRESS, _CONFIG_BANK]))

--- a/boards/pimoroni/keybow_2040/keybow_2040_rgb.py
+++ b/boards/pimoroni/keybow_2040/keybow_2040_rgb.py
@@ -1,4 +1,5 @@
 import board
+import busio
 from micropython import const
 
 from adafruit_bus_device.i2c_device import I2CDevice
@@ -19,8 +20,12 @@ class Keybow2040Leds(PixelBuf):
     width = 16
     height = 3
 
-    def __init__(self, size: int = 16):  # Kept for backward compatibility
-        self.i2c_device = I2CDevice(board.I2C(), 0x74)
+    def __init__(
+            self,
+            size: int = 16  # Kept for backward compatibility
+    ):
+        self.i2c = busio.I2C( board.SCL, board.SDA, frequency=400_000)
+        self.i2c_device = I2CDevice(self.i2c, 0x74)
         self.out_buffer = bytearray(144)
         self._pixels = 16
         self._frame = 0


### PR DESCRIPTION
Replace slow RGB wrapper for is31fl3731 driver with a custom implementation which double-buffers with two frames and writes pixels in batches (or all 144 in bulk).

Speeds up default RGB breath effect from ~12FPS to ~60FPS.

Fixes #859.