### PR TITLE
CI: Bump workflow action versions.

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
       - run: echo "A ${{ github.event_name }} event trigged build of branch ${{ github.ref }}, repository ${{ github.repository }}"
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache mpy-cross
         id: cache-mpy-cross
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-mpy-cross-8
         with:
@@ -41,7 +41,7 @@ jobs:
         run: |
           ls -la .compiled/kmk/
       - name: upload zip
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kmk-${{ steps.sha.outputs.SHA }}+mpy-cross-${{ matrix.mpy-cross-release }}
           path: .compiled/kmk/

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -8,6 +8,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: sudo apt-get install aspell
       - run: make spellcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
             python-version: '3.11' # Version range or exact version of a Python version to use, using SemVer's version range syntax
       - run: python -m pip install --upgrade pipenv wheel


### PR DESCRIPTION
Bump the versions of various actions to fix deprecation warnings, which appear in the Annotations section of workflow runs.

eg:

<img width="695" alt="image" src="https://github.com/KMKfw/kmk_firmware/assets/1746967/478576b1-c024-4b1b-b611-d74888965d6b">

from: https://github.com/actions/upload-artifact/actions/runs/9477575562