### PR TITLE
Improve key generation debug

### DIFF
--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -434,11 +434,8 @@ class KeyAttrDict:
 
         if not maybe_key:
             if debug.enabled:
-                debug(f'Invalid key: {name}')
+                debug('Invalid key: ', name)
             return KC.NO
-
-        if debug.enabled:
-            debug(f'{name}: {maybe_key}')
 
         return maybe_key
 

--- a/kmk/modules/holdtap.py
+++ b/kmk/modules/holdtap.py
@@ -1,6 +1,6 @@
 from micropython import const
 
-from kmk.keys import KC, make_argumented_key
+from kmk.keys import make_argumented_key
 from kmk.modules import Module
 from kmk.utils import Debug
 
@@ -51,10 +51,11 @@ class HoldTapKeyMeta:
 class HoldTap(Module):
     tap_time = 300
 
-    def __init__(self):
+    def __init__(self, _make_key=True):
         self.key_buffer = []
         self.key_states = {}
-        if KC.get('HT') == KC.NO:
+
+        if _make_key:
             make_argumented_key(
                 validator=HoldTapKeyMeta,
                 names=('HT',),

--- a/kmk/modules/layers.py
+++ b/kmk/modules/layers.py
@@ -47,7 +47,7 @@ class Layers(HoldTap):
         combo_layers=None,
     ):
         # Layers
-        super().__init__()
+        super().__init__(_make_key=False)
         self.combo_layers = combo_layers
         make_argumented_key(
             validator=layer_key_validator,

--- a/kmk/modules/tapdance.py
+++ b/kmk/modules/tapdance.py
@@ -29,7 +29,7 @@ class TapDanceKeyMeta:
 
 class TapDance(HoldTap):
     def __init__(self):
-        super().__init__()
+        super().__init__(_make_key=False)
         make_argumented_key(
             validator=TapDanceKeyMeta,
             names=('TD',),


### PR DESCRIPTION
Generating a debug message for every successfully instantiated key is excessively noisy and generally not helpfull. Similarly, indicating a failure to look up the hold-tap key when failure is the expected outcome, is not usefull information and has confused users in the past. (The HT check is not pretty, but necessary in order to bind `KC.HT` to `HoldTap` instead of modules inheriting the constructor, fyi)
This PR addresses both of those inconveniences.
