### PR TITLE
Sticky keys: retap_cancel

### DIFF
--- a/docs/en/sticky_keys.md
+++ b/docs/en/sticky_keys.md
@@ -31,9 +31,9 @@ The full sticky key signature is as follows:
 
 ```python
 KC.SK(
-    KC.ANY,                     # the key to made sticky
-    defer_release=False         # when to release the key
-    retap_cancel=True   # repeated tap releases the key
+    KC.ANY,              # the key to made sticky
+    defer_release=False  # when to release the key
+    retap_cancel=True    # repeated tap releases the key
 )
 ```
 
@@ -44,9 +44,9 @@ releases.
 If `True`: stay sticky until all keys are released. Useful when combined with
 non-sticky modifiers, layer keys, etc...
 
-### `repat_cancel`
+### `repeat_cancel`
 
-If `True` (default): Repeated tap releases the key.
+If `True` (default): Repeated tap releases the key and refreshes timeout.
 If `False`: Repeated tap refreshes the timeout.
 
 ## Sticky Stacks

--- a/docs/en/sticky_keys.md
+++ b/docs/en/sticky_keys.md
@@ -33,7 +33,7 @@ The full sticky key signature is as follows:
 KC.SK(
     KC.ANY,                     # the key to made sticky
     defer_release=False         # when to release the key
-    tap_again_to_release=True   # repeated tap releases the key
+    retap_cancel=True   # repeated tap releases the key
 )
 ```
 
@@ -44,7 +44,7 @@ releases.
 If `True`: stay sticky until all keys are released. Useful when combined with
 non-sticky modifiers, layer keys, etc...
 
-### `tap_again_to_release`
+### `repat_cancel`
 
 If `True` (default): Repeated tap releases the key.
 If `False`: Repeated tap refreshes the timeout.

--- a/docs/en/sticky_keys.md
+++ b/docs/en/sticky_keys.md
@@ -31,8 +31,9 @@ The full sticky key signature is as follows:
 
 ```python
 KC.SK(
-    KC.ANY,              # the key to made sticky
-    defer_release=False  # when to release the key
+    KC.ANY,                     # the key to made sticky
+    defer_release=False         # when to release the key
+    tap_again_to_release=True   # repeated tap releases the key
 )
 ```
 
@@ -42,6 +43,11 @@ If `False` (default): release sticky key after the first interrupting key
 releases.
 If `True`: stay sticky until all keys are released. Useful when combined with
 non-sticky modifiers, layer keys, etc...
+
+### `tap_again_to_release`
+
+If `True` (default): Repeated tap releases the key.
+If `False`: Repeated tap refreshes the timeout.
 
 ## Sticky Stacks
 

--- a/kmk/modules/sticky_keys.py
+++ b/kmk/modules/sticky_keys.py
@@ -102,7 +102,7 @@ class StickyKeys(Module):
 
     def on_press(self, key, keyboard, *args, **kwargs):
         # If active sticky key is tapped again, cancel.
-        if  key.meta.tap_again_to_release and key.meta.state == _SK_RELEASED:
+        if key.meta.tap_again_to_release and key.meta.state == _SK_RELEASED:
             self.deactivate(keyboard, key)
             return
         # Let sticky keys stack while renewing timeouts.

--- a/kmk/modules/sticky_keys.py
+++ b/kmk/modules/sticky_keys.py
@@ -15,12 +15,12 @@ _SK_STICKY = const(4)
 
 
 class StickyKeyMeta:
-    def __init__(self, key, defer_release=False, tap_again_to_release=True):
+    def __init__(self, key, defer_release=False, retap_cancel=True):
         self.key = key
         self.defer_release = defer_release
         self.timeout = None
         self.state = _SK_IDLE
-        self.tap_again_to_release = tap_again_to_release
+        self.retap_cancel = retap_cancel
 
 
 class StickyKeys(Module):
@@ -101,16 +101,15 @@ class StickyKeys(Module):
         )
 
     def on_press(self, key, keyboard, *args, **kwargs):
-        # If active sticky key is tapped again, cancel.
-        if key.meta.tap_again_to_release and key.meta.state == _SK_RELEASED:
-            self.deactivate(keyboard, key)
-            return
         # Let sticky keys stack while renewing timeouts.
         for sk in self.active_keys:
             keyboard.cancel_timeout(sk.meta.timeout)
 
+        # If active sticky key is tapped again, cancel.
+        if key.meta.retap_cancel and key.meta.state == _SK_RELEASED:
+            self.deactivate(keyboard, key)
         # Reset on repeated taps.
-        if key.meta.state != _SK_IDLE:
+        elif key.meta.state != _SK_IDLE:
             key.meta.state = _SK_PRESSED
         else:
             self.activate(keyboard, key)

--- a/kmk/modules/sticky_keys.py
+++ b/kmk/modules/sticky_keys.py
@@ -15,11 +15,12 @@ _SK_STICKY = const(4)
 
 
 class StickyKeyMeta:
-    def __init__(self, key, defer_release=False):
+    def __init__(self, key, defer_release=False, tap_again_to_release=True):
         self.key = key
         self.defer_release = defer_release
         self.timeout = None
         self.state = _SK_IDLE
+        self.tap_again_to_release = tap_again_to_release
 
 
 class StickyKeys(Module):
@@ -100,7 +101,11 @@ class StickyKeys(Module):
         )
 
     def on_press(self, key, keyboard, *args, **kwargs):
-        # Let sticky keys stack by renewing timeouts.
+        # If active sticky key is tapped again, cancel.
+        if  key.meta.tap_again_to_release and key.meta.state == _SK_RELEASED:
+            self.deactivate(keyboard, key)
+            return
+        # Let sticky keys stack while renewing timeouts.
         for sk in self.active_keys:
             keyboard.cancel_timeout(sk.meta.timeout)
 

--- a/kmk/modules/sticky_keys.py
+++ b/kmk/modules/sticky_keys.py
@@ -69,6 +69,7 @@ class StickyKeys(Module):
                 isinstance(current_key.meta, StickyKeyMeta)
                 or current_key.meta.__class__.__name__ == 'TapDanceKeyMeta'
                 or current_key.meta.__class__.__name__ == 'HoldTapKeyMeta'
+                or current_key.meta.__class__.__name__ == 'LayerTapKeyMeta'
             ):
                 continue
 

--- a/tests/test_sticky_keys.py
+++ b/tests/test_sticky_keys.py
@@ -61,6 +61,12 @@ class TestStickyKey(unittest.TestCase):
                     KC.C,
                     KC.D,
                 ],
+                [
+                    KC.SK(KC.N0, retap_cancel=True),
+                    KC.SK(KC.N1, retap_cancel=False),
+                    KC.N2,
+                    KC.N3,
+                ],
             ],
             debug_enabled=False,
         )
@@ -78,12 +84,6 @@ class TestStickyKey(unittest.TestCase):
         keyboard.test(
             'hold',
             [(0, True), t_after, (0, False)],
-            [{KC.N0}, {}],
-        )
-
-        keyboard.test(
-            'double tap',
-            [(0, True), (0, False), (0, True), (0, False)],
             [{KC.N0}, {}],
         )
 
@@ -457,6 +457,39 @@ class TestStickyKey(unittest.TestCase):
                 (2, False),
             ],
             [{KC.N0}, {KC.N0, KC.A}, {KC.N0, KC.A, KC.N2}, {KC.N0, KC.A}, {KC.N0}, {}],
+        )
+
+    def test_sticky_key_retap_cancel(self):
+        self.keyboard.keyboard.active_layers = [5]
+        keyboard = self.keyboard
+
+        keyboard.test(
+            'retap_cancel',
+            [(0, True), (0, False), (0, True), (0, False), (2, True), (2, False)],
+            [{KC.N0}, {}, {KC.N2}, {}],
+        )
+
+        keyboard.test(
+            'no retap_cancel',
+            [(1, True), (1, False), (1, True), (1, False), (2, True), (2, False)],
+            [{KC.N1}, {KC.N1, KC.N2}, {KC.N1}, {}],
+        )
+
+        keyboard.test(
+            'stack, retap_cancel renew timeout',
+            [
+                (0, True),
+                (0, False),
+                (1, True),
+                (1, False),
+                t_holdtap,
+                (0, True),
+                (0, False),
+                t_holdtap,
+                (2, True),
+                (2, False),
+            ],
+            [{KC.N0}, {KC.N0, KC.N1}, {KC.N1}, {KC.N1, KC.N2}, {KC.N1}, {}],
         )
 
     def test_sticky_key_w_holdtap(self):

--- a/tests/test_sticky_keys.py
+++ b/tests/test_sticky_keys.py
@@ -42,7 +42,7 @@ class TestStickyKey(unittest.TestCase):
                 ],
                 [
                     KC.SK(KC.N0, defer_release=True),
-                    KC.SK(KC.N1, defer_release=True),
+                    KC.SK(KC.N1, defer_release=True, retap_cancel=False),
                     KC.N2,
                     KC.N3,
                 ],
@@ -399,6 +399,32 @@ class TestStickyKey(unittest.TestCase):
                 {KC.N0, KC.N2, KC.N3},
                 {KC.N2, KC.N3},
                 {KC.N3},
+                {},
+            ],
+        )
+
+        keyboard.test(
+            'stick stack, retap_cancel, multiple interleaved other',
+            [
+                (0, True),
+                (0, False),
+                (1, True),
+                (1, False),
+                (0, True),
+                (0, False),
+                (2, True),
+                (3, True),
+                (2, False),
+                (3, False),
+            ],
+            [
+                {KC.N0},
+                {KC.N0, KC.N1},
+                {KC.N1},
+                {KC.N1, KC.N2},
+                {KC.N1, KC.N2, KC.N3},
+                {KC.N1, KC.N3},
+                {KC.N1},
                 {},
             ],
         )


### PR DESCRIPTION
An enhancement that makes it possible to release a sticky key by tapping it again -- useful when user only wants to tap a key(`KC.LGUI`) or simply changes their mind.
This behavior is enabled by default.