### PR TITLE
Fix retap_cancel after interrupting key press

### DIFF
--- a/kmk/modules/sticky_keys.py
+++ b/kmk/modules/sticky_keys.py
@@ -107,7 +107,9 @@ class StickyKeys(Module):
             keyboard.cancel_timeout(sk.meta.timeout)
 
         # If active sticky key is tapped again, cancel.
-        if key.meta.retap_cancel and key.meta.state == _SK_RELEASED:
+        if key.meta.retap_cancel and (
+            key.meta.state == _SK_RELEASED or key.meta.state == _SK_STICKY
+        ):
             self.deactivate(keyboard, key)
         # Reset on repeated taps.
         elif key.meta.state != _SK_IDLE:

--- a/tests/test_sticky_keys.py
+++ b/tests/test_sticky_keys.py
@@ -429,6 +429,32 @@ class TestStickyKey(unittest.TestCase):
             ],
         )
 
+        keyboard.test(
+            'stick stack, retap_cancel, multiple interleaved other',
+            [
+                (0, True),
+                (0, False),
+                (1, True),
+                (1, False),
+                (2, True),
+                (3, True),
+                (0, True),
+                (0, False),
+                (2, False),
+                (3, False),
+            ],
+            [
+                {KC.N0},
+                {KC.N0, KC.N1},
+                {KC.N0, KC.N1, KC.N2},
+                {KC.N0, KC.N1, KC.N2, KC.N3},
+                {KC.N1, KC.N2, KC.N3},
+                {KC.N1, KC.N3},
+                {KC.N1},
+                {},
+            ],
+        )
+
     def test_sticky_key_in_tapdance(self):
         self.keyboard.keyboard.active_layers = [3]
         keyboard = self.keyboard
@@ -516,6 +542,12 @@ class TestStickyKey(unittest.TestCase):
                 (2, False),
             ],
             [{KC.N0}, {KC.N0, KC.N1}, {KC.N1}, {KC.N1, KC.N2}, {KC.N1}, {}],
+        )
+
+        keyboard.test(
+            'stick, interleaved retap_cancel',
+            [(0, True), (0, False), (2, True), (0, True), (0, False), (2, False)],
+            [{KC.N0}, {KC.N0, KC.N2}, {KC.N2}, {}],
         )
 
     def test_sticky_key_w_holdtap(self):


### PR DESCRIPTION
We actually missed a scenario: canceling a sticky key while one or more interrupting keys have already been pressed.