### PR TITLE
Fix _rgb_tog

### DIFF
--- a/kmk/extensions/rgb.py
+++ b/kmk/extensions/rgb.py
@@ -134,7 +134,7 @@ class RGB(Extension):
 
         self._substep = 0
 
-        make_key(names=('RGB_TOG',), on_press=self._rgb_to)
+        make_key(names=('RGB_TOG',), on_press=self._rgb_tog)
         make_key(names=('RGB_HUI',), on_press=self._rgb_hui)
         make_key(names=('RGB_HUD',), on_press=self._rgb_hud)
         make_key(names=('RGB_SAI',), on_press=self._rgb_sai)


### PR DESCRIPTION
After upgrading to the latest version of KMK, I encountered this error: 
```
AttributeError: 'RGB' object has no attribute '_rgb_to'
```
It looks like `self._rgb_tog` was misspelled as `self._rgb_to`.