### PR TITLE
Fix syntax error with mpy-cross-8.x

### DIFF
--- a/kmk/keys.py
+++ b/kmk/keys.py
@@ -568,7 +568,7 @@ def make_argumented_key(
 ) -> Key:
 
     def argumented_key(*args, **kwargs) -> Key:
-        return constructor(*args, **kwargs, **_kwargs)
+        return constructor(*args, **(_kwargs | kwargs))
 
     for name in names:
         KC[name] = argumented_key


### PR DESCRIPTION
Apparently this syntax is fine with CP 9.x's mpy-cross, but not CP 8.x's.