### PR TITLE
fixes #1005: Missing attribute `code` results in AttributeError

### DIFF
--- a/kmk/modules/combos.py
+++ b/kmk/modules/combos.py
@@ -56,7 +56,7 @@ class Combo:
         if self._match_coord:
             return f'{self.__class__.__name__}({list(self.match)})'
         else:
-            return f'{self.__class__.__name__}({[k.code for k in self.match]})'
+            return f'{self.__class__.__name__}({[k.code if hasattr(k, 'code') else k for k in self.match]})'
 
     def matches(self, key: Key, int_coord: int):
         raise NotImplementedError

--- a/kmk/modules/combos.py
+++ b/kmk/modules/combos.py
@@ -53,10 +53,7 @@ class Combo:
             self._match_coord = match_coord
 
     def __repr__(self):
-        if self._match_coord:
-            return f'{self.__class__.__name__}({list(self.match)})'
-        else:
-            return f'{self.__class__.__name__}({[k.code if hasattr(k, 'code') else k for k in self.match]})'
+        return f'{self.__class__.__name__}({list(self.match)})'
 
     def matches(self, key: Key, int_coord: int):
         raise NotImplementedError


### PR DESCRIPTION
To prevent unconditional acess, this change checks if the `code` attribute actually exists and falls back to the key description.