### PR TITLE
bugfix: `KMKKeyboard.during_bootup` method

### DIFF
--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -347,7 +347,7 @@ class KMKKeyboard:
                 debug_error(ext, 'during_bootup', err)
                 self.extensions[idx] = None
 
-        self.modules[:] = [_ for _ in self.modules if _]
+        self.extensions[:] = [_ for _ in self.extensions if _]
 
         if debug.enabled:
             debug('extensions=', [_.__class__.__name__ for _ in self.extensions])


### PR DESCRIPTION
Fix #1011