### PR TITLE
log error when the coordmapping is not guessable

### DIFF
--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -159,7 +159,7 @@ class Split(Module):
 
             keyboard.coord_mapping = tuple(cm)
         else:
-            print("not using the default matrix as keyscanner, please provide coord_mapping")
+            print('Error: please provide coord_mapping for custom scanner')
 
         if self.split_side == SplitSide.RIGHT:
             offset = self.split_offset

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -160,7 +160,6 @@ class Split(Module):
             keyboard.coord_mapping = tuple(cm)
         else:
             print('not using the default matrix as keyscanner, please provide coord_mapping')
-            
 
         if self.split_side == SplitSide.RIGHT:
             offset = self.split_offset

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -140,7 +140,7 @@ class Split(Module):
                     )
 
         # Attempt to sanely guess a coord_mapping if one is not provided.
-        if not keyboard.coord_mapping:
+        if not keyboard.coord_mapping and keyboard.row_pins and keyboard.col_pins:
             cm = []
 
             rows_to_calc = len(keyboard.row_pins)
@@ -158,6 +158,9 @@ class Split(Module):
                     cm.append(cols_to_calc * (rows_to_calc + ridx) + cidx)
 
             keyboard.coord_mapping = tuple(cm)
+        else:
+            print('not using the default matrix as keyscanner, please provide coord_mapping')
+            
 
         if self.split_side == SplitSide.RIGHT:
             offset = self.split_offset

--- a/kmk/modules/split.py
+++ b/kmk/modules/split.py
@@ -159,7 +159,7 @@ class Split(Module):
 
             keyboard.coord_mapping = tuple(cm)
         else:
-            print('not using the default matrix as keyscanner, please provide coord_mapping')
+            print("not using the default matrix as keyscanner, please provide coord_mapping")
 
         if self.split_side == SplitSide.RIGHT:
             offset = self.split_offset


### PR DESCRIPTION
I just ran into an error on a split keyboard with direct pin wiring. when not having a coordmap yet (still testing the keys with the helper to log the keys coordmapping index) KMK would just error with "NoneType has no len()" this did not help me much in debugging this issue.

the cause was that with a custom scanner the keyboard.row_pins and keyboard.col_pins are not set and then the split during_bootup cannot guess a coordmap. I added a print statement that tells the user the coordmapping is missing when both of these are not defined on the keyboard as either the pins are required or the coordmap.