### PR TITLE
Fix typo in combo_layers.md

### DIFF
--- a/docs/en/combo_layers.md
+++ b/docs/en/combo_layers.md
@@ -75,7 +75,7 @@ keyboard.keymap = [
     ],
     [ #Layer 1
     KC.N1,    KC.N2, KC.N3, KC.N4,
-    KC.N5,    KC.N6, KC.N7, KC.8,
+    KC.N5,    KC.N6, KC.N7, KC.N8,
     KC.MO(1), KC.N9, KC.N0, KC.MO(2),
     ],
         [ #Layer 2


### PR DESCRIPTION
changes fixes a minor typo in the example by changing KC.8 to KC.N8 