### PR TITLE
Document deprecation of OneShot keys

### DIFF
--- a/docs/en/oneshot.md
+++ b/docs/en/oneshot.md
@@ -1,8 +1,12 @@
 # OneShot Keycodes
 
-OneShot keys or sticky keys enable you to have keys that keep staying pressed
+> [!WARNING]
+> OneShot Keys have been depricated in favor of [StickyKeys](sticky_keys.md)
+> and will be removed at a future date.
+
+OneShot keys enable you to have keys that keep staying pressed
 for a certain time or until another key is pressed and released.
-If the timeout expires or other keys are pressed, and the sticky key wasn't
+If the timeout expires or other keys are pressed, and the OneShot key wasn't
 released, it is handled as a regular key hold.
 
 ## Enable OneShot Keys
@@ -17,9 +21,9 @@ keyboard.modules.append(oneshot)
 
 ## Keycodes
 
-|Keycode          | Aliases      |Description                       |
-|-----------------|--------------|----------------------------------|
-|`KC.OS(KC.ANY)`  | `KC.ONESHOT` |make a sticky version of `KC.ANY` |
+|Keycode          | Aliases      |Description                        |
+|-----------------|--------------|-----------------------------------|
+|`KC.OS(KC.ANY)`  | `KC.ONESHOT` |make a oneshot version of `KC.ANY` |
 
 `KC.ONESHOT` accepts any valid key code as argument, including modifiers and KMK
 internal keys like momentary layer shifts.
@@ -30,7 +34,7 @@ The full OneShot signature is as follows:
 
 ```python
 KC.OS(
-    KC.TAP, # the sticky keycode
+    KC.TAP, # the oneshot keycode
     tap_time=None # length of the tap timeout in milliseconds
     )
 ```

--- a/kmk/modules/oneshot.py
+++ b/kmk/modules/oneshot.py
@@ -20,10 +20,12 @@ class OneShotKey(HoldTapKey):
 
 
 class OneShot(HoldTap):
+    ''' This module is deprecated; use sticky_keys instead.'''
     tap_time = 1000
 
     def __init__(self):
         super().__init__()
+        debug("Warning: OneShot module is deprecated and will be removed; use sticky_keys instead.")
         make_argumented_key(
             names=('OS', 'ONESHOT'),
             constructor=OneShotKey,

--- a/kmk/modules/oneshot.py
+++ b/kmk/modules/oneshot.py
@@ -20,12 +20,15 @@ class OneShotKey(HoldTapKey):
 
 
 class OneShot(HoldTap):
-    ''' This module is deprecated; use sticky_keys instead.'''
+    '''This module is deprecated; use sticky_keys instead.'''
+
     tap_time = 1000
 
     def __init__(self):
         super().__init__()
-        debug("Warning: OneShot module is deprecated and will be removed; use sticky_keys instead.")
+        debug(
+            'Warning: OneShot module is deprecated and will be removed; use sticky_keys instead.'
+        )
         make_argumented_key(
             names=('OS', 'ONESHOT'),
             constructor=OneShotKey,


### PR DESCRIPTION
added docstring to oneshot.py
added deubug message in module's __init__
changed docs to made deprecation of oneshot keys clear and to remove ambiguity with sticky keys.

made changes based on comments found 
here  #978 
and [on Zulip](https://kmkfw.zulipchat.com/#narrow/stream/358347-general/topic/Extensions.20not.20working.20for.20mini.20keyboard/near/447140514)