### PR TITLE
Cleanup legacy `keyboard.tap_time`

### DIFF
--- a/boards/atreus62/main.py
+++ b/boards/atreus62/main.py
@@ -31,8 +31,6 @@ encoder = EncoderHandler(
 macros = Macros()
 keyboard.modules = [layers, encoder, macros]
 
-keyboard.tap_time = 250
-
 
 # custom keys
 NEW = KC.LCTL(KC.N)

--- a/boards/fingerpunch/ffkb/other_pro_micro/main.py
+++ b/boards/fingerpunch/ffkb/other_pro_micro/main.py
@@ -11,7 +11,6 @@ from kmk.modules.layers import Layers
 from kmk.modules.mouse_keys import MouseKeys
 
 keyboard = KMKKeyboard()
-keyboard.tap_time = 150
 
 # Cleaner key names
 _______ = KC.TRNS

--- a/boards/keebio/iris/main.py
+++ b/boards/keebio/iris/main.py
@@ -7,8 +7,6 @@ from kmk.modules.split import Split, SplitSide, SplitType
 
 keyboard = KMKKeyboard()
 
-keyboard.tap_time = 750
-
 _______ = KC.TRNS
 xxxxxxx = KC.NO
 

--- a/boards/lunakey_pico/main.py
+++ b/boards/lunakey_pico/main.py
@@ -17,7 +17,6 @@ led.direction = digitalio.Direction.OUTPUT
 led.value = True
 
 keyboard = KMKKeyboard()
-keyboard.tap_time = 100
 
 layers = Layers()
 holdtap = HoldTap()

--- a/docs/en/config_and_keymap.md
+++ b/docs/en/config_and_keymap.md
@@ -79,9 +79,3 @@ keyboard.keymap = [[KC.A, KC.B]]
   The row x column matrix structure doesn't appear explicitly
   in the keymap.  Use `KC.NO` to mark grid positions without a physical key.
   For very sparse grids `keyboard.coord_mapping` can be useful to avoid `KC.NO`. 
-
-You can further define a bunch of other stuff:
-
-- `keyboard.tap_time` which defines how long `KC.TT` and `KC.LT` will wait before
-  considering a key "held" (see `layers.md`).
-

--- a/docs/en/encoder.md
+++ b/docs/en/encoder.md
@@ -147,8 +147,6 @@ keyboard.diode_orientation = DiodeOrientation.COLUMNS
 # encoder_handler.divisor = 2 # for encoders with more precision
 encoder_handler.pins = ((board.GP17, board.GP15, board.GP14, False),)
 
-keyboard.tap_time = 250
-
 
 # Filler keys
 _______ = KC.TRNS


### PR DESCRIPTION
Out of use for literal years.