### PR TITLE
Make bootcfg sense optional

### DIFF
--- a/docs/en/boot.md
+++ b/docs/en/boot.md
@@ -19,9 +19,8 @@ configuration.
 from kmk.bootcfg import bootcfg
 
 bootcfg(
-    # required:
-    sense: [microcontroller.Pin, digitalio.DigitalInOut],
     # optional:
+    sense: Optional[microcontroller.Pin, digitalio.DigitalInOut] = None,
     source: Optional[microcontroller.Pin, digitalio.DigitalInOut] = None,
     autoreload: bool = True,
     boot_device: int = 0,
@@ -45,8 +44,8 @@ they may differ from board specific defaults.
 #### `sense`
 `sense` accepts either uninitialized `Pin`s or `DigitalInOut` instances for
 maximum flexibility.
-The boot configuration is only applied if `sense` reads `True` or "high", and
-skipped if it reads `False` or "low".
+The lockout-prone subset of boot configuration is only applied if `sense` reads `True` or "high", and
+skipped if it reads `False` or "low". The latter is also true if `sense` is not provided.
 If `sense` is an uninitialized `Pin`, it'll be configured as pulled-up input; it
 wont be further configured if it is a `DigitalInOut`.
 
@@ -81,6 +80,7 @@ for details.
 
 #### `cdc_console`
 This will enable or disable the USB endpoint for the serial console with REPL.
+**Caution**: If erroneous `sense` parameter is provided, changing this might make recovery problematic.
 
 
 #### `cdc_data`
@@ -122,6 +122,7 @@ hid endpoint.
 #### `storage`
 Disable storage if you don't want your computer to go "there's a new thumb drive
 I have to mount!" every time you plug in your keyboard.
+**Caution**: If erroneous `sense` parameter is provided, changing this might make recovery problematic.
 
 
 #### `usb_id`

--- a/kmk/bootcfg.py
+++ b/kmk/bootcfg.py
@@ -9,7 +9,7 @@ import usb_hid
 
 
 def bootcfg(
-    sense: [microcontroller.Pin, digitalio.DigitalInOut],
+    sense: Optional[microcontroller.Pin, digitalio.DigitalInOut] = None,
     source: Optional[microcontroller.Pin, digitalio.DigitalInOut] = None,
     autoreload: bool = True,
     boot_device: int = 0,
@@ -85,7 +85,12 @@ def bootcfg(
         import usb_cdc
 
         usb_cdc.enable(data=True)
-
+        
+    # sense not provided -> Skip boot configuration that may disable debug or
+    # rescue facilities.
+    if sense is None:
+        return False
+        
     # sense pulled low -> Skip boot configuration that may disable debug or
     # rescue facilities.
     if not sense.value:

--- a/kmk/bootcfg.py
+++ b/kmk/bootcfg.py
@@ -85,12 +85,12 @@ def bootcfg(
         import usb_cdc
 
         usb_cdc.enable(data=True)
-        
+
     # sense not provided -> Skip boot configuration that may disable debug or
     # rescue facilities.
     if sense is None:
         return False
-        
+
     # sense pulled low -> Skip boot configuration that may disable debug or
     # rescue facilities.
     if not sense.value:

--- a/kmk/bootcfg.py
+++ b/kmk/bootcfg.py
@@ -86,14 +86,9 @@ def bootcfg(
 
         usb_cdc.enable(data=True)
 
-    # sense not provided -> Skip boot configuration that may disable debug or
-    # rescue facilities.
-    if sense is None:
-        return False
-
-    # sense pulled low -> Skip boot configuration that may disable debug or
-    # rescue facilities.
-    if not sense.value:
+    # sense not provided or pulled low -> Skip boot configuration that may
+    # disable debug or rescue facilities.
+    if sense is None or not sense.value:
         return False
 
     # Entries for serial console (REPL) and storage are intentionally evaluated


### PR DESCRIPTION
Initially bootcfg was all or nothing, this is no longer the case. Value of the sense pin currently only affects serial console and storage, but user might not even be interested in disabling those. No reason to lock stuff like NKRO behind this piece of configuration.