### PR TITLE
Fix ModifiedKey roll-interaction with non-modified keys

### DIFF
--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -53,6 +53,7 @@ class KMKKeyboard:
     keys_pressed = set()
     axes = set()
     _coordkeys_pressed = {}
+    implicit_modifier = None
     hid_type = HIDModes.USB
     secondary_hid_type = None
     _hid_helper = None

--- a/kmk/modules/string_substitution.py
+++ b/kmk/modules/string_substitution.py
@@ -51,7 +51,7 @@ class Phrase:
             if key_code == KC.NO:
                 raise ValueError(f'Invalid character in dictionary: {char}')
             shifted = char.isupper() or (
-                isinstance(key_code, ModifiedKey) and key_code.modifier == KC.LSHIFT
+                isinstance(key_code, ModifiedKey) and key_code.modifier.code == 0x02
             )
             self._characters.append(Character(key_code, shifted))
 

--- a/tests/test_autoshift.py
+++ b/tests/test_autoshift.py
@@ -76,7 +76,7 @@ class TestAutoshift(unittest.TestCase):
         self.kb.test(
             '',
             [(2, True), (0, True), t_after, (2, False), (0, False)],
-            [{KC.LSHIFT, KC.N3}, {KC.LSHIFT, KC.N3, KC.A}, {KC.A}, {}],
+            [{KC.LSHIFT, KC.N3}, {KC.N3, KC.A}, {KC.A}, {}],
         )
 
     def test_hold_internal(self):

--- a/tests/test_kmk_keys.py
+++ b/tests/test_kmk_keys.py
@@ -10,11 +10,7 @@ class TestKmkKeys(unittest.TestCase):
             [],
             [
                 [
-                    KC.HASH,
-                    KC.RALT(KC.HASH),
-                    KC.RALT(KC.LSFT(KC.N3)),
-                    KC.RALT(KC.LSFT),
-                    KC.RALT,
+                    KC.NO,
                     KC.TRNS,
                 ]
             ],
@@ -22,79 +18,111 @@ class TestKmkKeys(unittest.TestCase):
         )
 
         keyboard.test(
-            'Shifted key',
-            [(0, True), (0, False)],
-            [
-                {
-                    KC.N3,
-                    KC.LSFT,
-                },
-                {},
-            ],
+            'No',
+            [(0, True)],
+            [{}],
         )
-
+        self.assertEqual(keyboard.keyboard._coordkeys_pressed, {0: KC.NO})
         keyboard.test(
-            'AltGr+Shifted key',
-            [(1, True), (1, False)],
-            [
-                {
-                    KC.N3,
-                    KC.LSFT,
-                    KC.RALT,
-                },
-                {},
-            ],
-        )
-
-        keyboard.test(
-            'AltGr+Shift+key',
-            [(2, True), (2, False)],
-            [
-                {
-                    KC.N3,
-                    KC.LSFT,
-                    KC.RALT,
-                },
-                {},
-            ],
-        )
-
-        keyboard.test(
-            'Shift+AltGr',
-            [(3, True), (3, False)],
-            [
-                {
-                    KC.LSFT,
-                    KC.RALT,
-                },
-                {},
-            ],
-        )
-
-        keyboard.test(
-            'AltGr',
-            [(4, True), (4, False)],
-            [
-                {
-                    KC.RALT,
-                },
-                {},
-            ],
+            'No',
+            [(0, False)],
+            [{}],
         )
 
         keyboard.test(
             'Transparent',
-            [(5, True)],
+            [(1, True)],
             [{}],
         )
-        self.assertEqual(keyboard.keyboard._coordkeys_pressed, {5: KC.TRNS})
+        self.assertEqual(keyboard.keyboard._coordkeys_pressed, {1: KC.TRNS})
 
         assert isinstance(KC.RGUI, ModifierKey)
-        assert isinstance(KC.RALT(KC.RGUI), ModifiedKey)
         assert isinstance(KC.Q, Key)
         assert not isinstance(KC.Q, ModifierKey)
+
+    def test_modified_keys(self):
+        keyboard = KeyboardTest(
+            [],
+            [
+                [
+                    KC.N0,
+                    KC.EXLM,
+                    KC.RALT(KC.AT),
+                    KC.RALT(KC.LSFT),
+                    KC.RALT(KC.LSFT(KC.N4)),
+                    KC.LSFT,
+                ]
+            ],
+            debug_enabled=False,
+        )
+
+        keyboard.test(
+            'Shifted key',
+            [(1, True), (1, False)],
+            [{KC.LSFT, KC.N1}, {}],
+        )
+
+        keyboard.test(
+            'Shifted key + key',
+            [(1, True), (0, True), (0, False), (1, False)],
+            [{KC.LSFT, KC.N1}, {KC.N0, KC.N1}, {KC.N1}, {}],
+        )
+
+        keyboard.test(
+            'Shifted key + key rolled',
+            [(1, True), (0, True), (1, False), (0, False)],
+            [{KC.LSFT, KC.N1}, {KC.N0, KC.N1}, {KC.N0}, {}],
+        )
+
+        keyboard.test(
+            'Shifted key + shift',
+            [(1, True), (5, True), (5, False), (1, False)],
+            [{KC.LSFT, KC.N1}, {KC.N1}, {}],
+        )
+
+        keyboard.test(
+            'Shifted key + shift rolled',
+            [(1, True), (5, True), (1, False), (5, False)],
+            [{KC.LSFT, KC.N1}, {KC.LSFT}, {}],
+        )
+
+        keyboard.test(
+            'Shift + shifted key',
+            [(5, True), (1, True), (5, False), (1, False)],
+            [{KC.LSFT}, {KC.LSFT, KC.N1}, {}],
+        )
+
+        keyboard.test(
+            'Modified shifted key',
+            [(2, True), (2, False)],
+            [{KC.RALT, KC.LSFT, KC.N2}, {}],
+        )
+
+        keyboard.test(
+            'Modified modifier',
+            [(3, True), (3, False)],
+            [{KC.RALT, KC.LSFT}, {}],
+        )
+
+        keyboard.test(
+            'Modified modifier + shifted key',
+            [(3, True), (1, True), (1, False), (3, False)],
+            [{KC.RALT, KC.LSFT}, {KC.RALT, KC.LSFT, KC.N1}, {KC.RALT, KC.LSFT}, {}],
+        )
+
+        keyboard.test(
+            'Modified modified key',
+            [(4, True), (4, False)],
+            [{KC.RALT, KC.LSFT, KC.N4}, {}],
+        )
+
+        assert isinstance(KC.RALT(KC.RGUI), ModifiedKey)
         assert isinstance(KC.RALT(KC.Q), Key)
         assert not isinstance(KC.RALT(KC.Q), ModifierKey)
+        self.assertEqual(KC.LSFT, KC.LSFT(KC.LSFT))
+        self.assertEqual(
+            KC.RALT(KC.LSFT).modifier.code, KC.RALT(KC.LSFT(KC.RALT)).modifier.code
+        )
 
 
 class TestKeys_dot(unittest.TestCase):
@@ -133,7 +161,7 @@ class TestKeys_dot(unittest.TestCase):
             names=('EURO', '€'),
             constructor=ModifiedKey,
             code=KC.N2.code,
-            modifier=KC.LSFT(KC.ROPT),
+            modifier=KC.LSFT(KC.ROPT).modifier,
         )
         assert created is KC.get('EURO')
         assert created is KC.get('€')
@@ -174,7 +202,7 @@ class TestKeys_index(unittest.TestCase):
             names=('EURO', '€'),
             constructor=ModifiedKey,
             code=KC['N2'].code,
-            modifier=KC.LSFT(KC.ROPT),
+            modifier=KC.LSFT(KC.ROPT).modifier,
         )
         assert created is KC['EURO']
         assert created is KC['€']
@@ -220,7 +248,7 @@ class TestKeys_get(unittest.TestCase):
             names=('EURO', '€'),
             constructor=ModifiedKey,
             code=KC.get('N2').code,
-            modifier=KC.LSFT(KC.ROPT),
+            modifier=KC.LSFT(KC.ROPT).modifier,
         )
         assert created is KC.get('EURO')
         assert created is KC.get('€')

--- a/tests/test_string_substitution.py
+++ b/tests/test_string_substitution.py
@@ -1,8 +1,15 @@
 import unittest
 
-from kmk.keys import ALL_ALPHAS, ALL_NUMBERS, KC
+from kmk.keys import ALL_ALPHAS, ALL_NUMBERS, KC, ModifiedKey
 from kmk.modules.string_substitution import Character, Phrase, Rule, StringSubstitution
 from tests.keyboard_test import KeyboardTest
+
+
+def extract_code(key):
+    if isinstance(key, ModifiedKey):
+        return key.key.code, key.modifier.code
+    else:
+        return key.code
 
 
 class TestStringSubstitution(unittest.TestCase):
@@ -370,13 +377,13 @@ class TestStringSubstitution(unittest.TestCase):
             'unshifted character key code is correct',
         )
         self.assertEqual(
-            shifted_letter.key_code.__dict__,
-            KC.LSHIFT(KC.A).__dict__,
+            extract_code(shifted_letter.key_code),
+            extract_code(KC.LSHIFT(KC.A)),
             'shifted letter key code is correct',
         )
         self.assertEqual(
-            shifted_symbol.key_code.__dict__,
-            KC.LSHIFT(KC.N1).__dict__,
+            extract_code(shifted_symbol.key_code),
+            extract_code(KC.LSHIFT(KC.N1)),
             'shifted symbol key code is correct',
         )
 
@@ -397,8 +404,8 @@ class TestStringSubstitution(unittest.TestCase):
         for letter in ALL_ALPHAS:
             phrase = Phrase(letter)
             self.assertEqual(
-                phrase.get_character_at_index(0).key_code.__dict__,
-                KC.LSHIFT(KC[letter]).__dict__,
+                extract_code(phrase.get_character_at_index(0).key_code),
+                extract_code(KC.LSHIFT(KC[letter])),
                 f'Test failed when constructing phrase with upper-case letter {letter}',
             )
         # numbers
@@ -415,8 +422,8 @@ class TestStringSubstitution(unittest.TestCase):
             if character.isupper():
                 key = KC.LSHIFT(KC[character])
             self.assertEqual(
-                multi_character_phrase.get_character_at_index(i).key_code.__dict__,
-                key.__dict__,
+                extract_code(multi_character_phrase.get_character_at_index(i).key_code),
+                extract_code(key),
                 f'Test failed when constructing phrase with character {character}',
             )
 
@@ -462,8 +469,8 @@ class TestStringSubstitution(unittest.TestCase):
             if character.isupper():
                 key = KC.LSHIFT(KC[character])
             self.assertEqual(
-                phrase.get_character_at_index(i).key_code.__dict__,
-                key.__dict__,
+                extract_code(phrase.get_character_at_index(i).key_code),
+                extract_code(key),
                 f'Test failed when constructing phrase with character {character}',
             )
 


### PR DESCRIPTION
fixes #642
This introduces a mechanism that distinguishes between explicit (`KC.LSFT`) and implicit (`KC.LSFT(KC.EQL)` == `KC.PLUS`) modifiers.