### PR TITLE
ANAVI Knobs 3: Support SSD1306 I2C OLED Display

### DIFF
--- a/boards/anavi/knobs3/README.md
+++ b/boards/anavi/knobs3/README.md
@@ -8,3 +8,4 @@ Extensions enabled by default:
 - [Encoder](/docs/en/encoder.md) Twist control for all the things
 - [RGB](/docs/en/rgb.md) Light it up (for underlighting)
 - [MediaKeys](/docs/en/media_keys.md) Control volume and other media functions
+- [Display](/docs/en/Display.md) Show information on the mini OLED display

--- a/boards/anavi/knobs3/code.py
+++ b/boards/anavi/knobs3/code.py
@@ -1,5 +1,7 @@
 import board
 
+from kmk.extensions.display import Display, TextEntry
+from kmk.extensions.display.ssd1306 import SSD1306
 from kmk.extensions.media_keys import MediaKeys
 from kmk.extensions.RGB import RGB, AnimationModes
 from kmk.keys import KC
@@ -8,6 +10,20 @@ from kmk.modules.encoder import EncoderHandler
 from kmk.scanners.keypad import KeysScanner
 
 knob = KMKKeyboard()
+
+# I2C pins for the mini OLED display
+knob.SCL = board.D5
+knob.SDA = board.D4
+
+display = Display(
+    display=SSD1306(sda=board.D4, scl=board.D5),
+    entries=[
+        TextEntry(text='ANAVI Knobs 3\n\nKMK Firmware'),
+    ],
+    height=64,
+)
+knob.extensions.append(display)
+
 knob.matrix = KeysScanner([], value_when_pressed=False)
 
 media_keys = MediaKeys()
@@ -25,8 +41,6 @@ encoder_handler.map = (
     ((KC.VOLD, KC.VOLU, KC.MUTE), (KC.UP, KC.DOWN, KC.A), (KC.RIGHT, KC.LEFT, KC.B)),
 )
 knob.modules.append(encoder_handler)
-
-print('ANAVI Knobs 3')
 
 rgb = RGB(
     pixel_pin=board.NEOPIXEL,


### PR DESCRIPTION
Hi,

This GitHub pull request adds SSD1306 I2C display support for ANAVI Knobs 3 with the following commits:

* boards/anavi/knobs3/code.py: Add a new feature to support a mini OLED I2C SSD1306 display.
* boards/anavi/knobs3/README.md: Add information about the Display extension for ANAVI Knobs 3.

Best regards, Leon
