### PR TITLE
fix(KMKKeyboard)!: use __init__ to initialize the keyboard class

### DIFF
--- a/boards/a_dux/kb.py
+++ b/boards/a_dux/kb.py
@@ -14,17 +14,19 @@ _KEY_CFG_LEFT = [
 
 
 class KMKKeyboard(_KMKKeyboard):
-    data_pin = pins[4]
-
-    # fmt: off
-    coord_mapping = [
-         0,  1,  2,  3,  4,   21, 20, 19, 18, 17,
-         5,  6,  7,  8,  9,   26, 25, 24, 23, 22,
-        10, 11, 12, 13, 14,   31, 30, 29, 28, 27,
-                    15, 16,   33, 32
-    ]
-    # fmt: on
-
     def __init__(self):
+        super().__init__()
+
+        self.data_pin = pins[4]
+
+        # fmt: off
+        self.coord_mapping = [
+             0,  1,  2,  3,  4,   21, 20, 19, 18, 17,
+             5,  6,  7,  8,  9,   26, 25, 24, 23, 22,
+            10, 11, 12, 13, 14,   31, 30, 29, 28, 27,
+                        15, 16,   33, 32
+        ]
+        # fmt: on
+
         # create and register the scanner
         self.matrix = KeysScanner(_KEY_CFG_LEFT, value_when_pressed=False)

--- a/boards/anavi/anavi-arrows/arrows.py
+++ b/boards/anavi/anavi-arrows/arrows.py
@@ -17,6 +17,7 @@ class AnaviArrows(KMKKeyboard):
     '''
 
     def __init__(self):
+        super().__init__()
         self.matrix = KeysScanner(
             [board.D1, board.D2, board.D3, board.D6],
             value_when_pressed=False,

--- a/boards/boardsource/Lulu/kb.py
+++ b/boards/boardsource/Lulu/kb.py
@@ -8,6 +8,54 @@ from kmk.scanners.keypad import MatrixScanner
 
 class KMKKeyboard(_KMKKeyboard):
     def __init__(self):
+        super().__init__()
+
+        self.col_pins = (
+            board.GP02,
+            board.GP03,
+            board.GP04,
+            board.GP05,
+            board.GP06,
+            board.GP07,
+        )
+        self.row_pins = (board.GP14, board.GP15, board.GP16, board.GP17, board.GP18)
+        self.diode_orientation = DiodeOrientation.COLUMNS
+        self.rx = board.RX
+        self.tx = board.TX
+        self.rgb_pixel_pin = board.GP29
+        self.i2c = board.I2C
+        self.data_pin = board.RX
+        self.rgb_pixel_pin = board.GP29
+        self.i2c = board.I2C
+        self.SCL = board.SCL
+        self.SDA = board.SDA
+        self.encoder_a = board.GP08
+        self.encoder_b = board.GP09
+        # fmt:off
+        self.led_key_pos = [
+            11, 10,  9,  8,  7,  6,         41, 42, 43, 44, 45, 46,
+            12, 13, 14, 15, 16, 17,         52, 51, 50, 49, 48, 47,
+            23, 22, 21, 20, 19, 18,         53, 54, 55, 56, 57, 58,
+            24, 25, 26, 27, 28, 29, 30, 65, 64, 63, 62, 61, 60, 59,
+                        34, 33, 32, 31, 66, 67, 68, 69,
+                         3,  4,  5,         40, 39, 38,
+                         2,  1,  0,         35, 36, 37,
+        ]
+        # fmt:on
+        self.brightness_limit = 0.5
+        self.num_pixels = 70
+
+        # fmt:off
+        self.coord_mapping = [
+             0,  1,  2,  3,  4,  5,         37, 36, 35, 34, 33, 32,
+             6,  7,  8,  9, 10, 11,         43, 42, 41, 40, 39, 38,
+            12, 13, 14, 15, 16, 17,         49, 48, 47, 46, 45, 44,
+            18, 19, 20, 21, 22, 23, 29, 61, 55, 54, 53, 52, 51, 50,
+                    25, 26, 27, 28,         60, 59, 58, 57,
+                            30, 31,         62, 63,
+        ]
+        # fmt:on
+
         # create and register the scanner
         self.matrix = [
             MatrixScanner(
@@ -26,49 +74,3 @@ class KMKKeyboard(_KMKKeyboard):
                 divisor=4,
             ),
         ]
-
-    col_pins = (
-        board.GP02,
-        board.GP03,
-        board.GP04,
-        board.GP05,
-        board.GP06,
-        board.GP07,
-    )
-    row_pins = (board.GP14, board.GP15, board.GP16, board.GP17, board.GP18)
-    diode_orientation = DiodeOrientation.COLUMNS
-    rx = board.RX
-    tx = board.TX
-    rgb_pixel_pin = board.GP29
-    i2c = board.I2C
-    data_pin = board.RX
-    rgb_pixel_pin = board.GP29
-    i2c = board.I2C
-    SCL = board.SCL
-    SDA = board.SDA
-    encoder_a = board.GP08
-    encoder_b = board.GP09
-    # fmt:off
-    led_key_pos = [
-        11, 10,  9,  8,  7,  6,         41, 42, 43, 44, 45, 46,
-        12, 13, 14, 15, 16, 17,         52, 51, 50, 49, 48, 47,
-        23, 22, 21, 20, 19, 18,         53, 54, 55, 56, 57, 58,
-        24, 25, 26, 27, 28, 29, 30, 65, 64, 63, 62, 61, 60, 59,
-                    34, 33, 32, 31, 66, 67, 68, 69,
-                     3,  4,  5,         40, 39, 38,
-                     2,  1,  0,         35, 36, 37,
-    ]
-    # fmt:on
-    brightness_limit = 0.5
-    num_pixels = 70
-
-    # fmt:off
-    coord_mapping = [
-         0,  1,  2,  3,  4,  5,         37, 36, 35, 34, 33, 32,
-         6,  7,  8,  9, 10, 11,         43, 42, 41, 40, 39, 38,
-        12, 13, 14, 15, 16, 17,         49, 48, 47, 46, 45, 44,
-        18, 19, 20, 21, 22, 23, 29, 61, 55, 54, 53, 52, 51, 50,
-                25, 26, 27, 28,         60, 59, 58, 57,
-                        30, 31,         62, 63,
-    ]
-    # fmt:on

--- a/boards/budgy/kb.py
+++ b/boards/budgy/kb.py
@@ -40,17 +40,19 @@ _KEY_CFG_RIGHT = [
 
 class KMKKeyboard(_KMKKeyboard):
     def __init__(self):
+        super().__init__()
+
         # create and register the scanner
         self.matrix = KeysScanner(
             pins=_KEY_CFG_RIGHT if isRight else _KEY_CFG_LEFT,
             value_when_pressed=False,
         )
 
-    # fmt: off
-    coord_mapping = [
-         0,  1,  2,  3,  4,   17, 18, 19, 20, 21,
-         5,  6,  7,  8,  9,   22, 23, 24, 25, 26,
-        10, 11, 12, 13, 14,   27, 28, 29, 30, 31,
-                    15, 16,   32, 33
-    ]
-    # fmt: on
+        # fmt: off
+        self.coord_mapping = [
+             0,  1,  2,  3,  4,   17, 18, 19, 20, 21,
+             5,  6,  7,  8,  9,   22, 23, 24, 25, 26,
+            10, 11, 12, 13, 14,   27, 28, 29, 30, 31,
+                        15, 16,   32, 33
+        ]
+        # fmt: on

--- a/boards/draculad/kb.py
+++ b/boards/draculad/kb.py
@@ -11,6 +11,49 @@ from kmk.scanners.keypad import MatrixScanner
 
 class KMKKeyboard(_KMKKeyboard):
     def __init__(self):
+        super().__init__()
+
+        self.col_pins = (
+            pins[avr['F4']],
+            pins[avr['F5']],
+            pins[avr['F6']],
+            pins[avr['F7']],
+            pins[avr['B1']],
+        )
+        self.row_pins = (
+            pins[avr['D4']],
+            pins[avr['C6']],
+            pins[avr['D7']],
+            pins[avr['E6']],
+        )
+        self.data_pin = pins[avr['D2']]
+        self.rgb_pixel_pin = pins[avr['D3']]
+        self.rgb_num_pixels = 20
+        self.i2c = board.I2C
+        self.SCL = pins[5]
+        self.SDA = pins[4]
+        self.pin_a1 = pins[avr['B2']]
+        self.pin_a2 = pins[avr['B4']]
+        self.pin_b1 = pins[avr['B6']]
+        self.pin_b2 = pins[avr['B5']]
+        # fmt: off
+        self.led_key_pos = [
+             5,  6,  7,  8,  9, 19, 18, 17, 16, 15,
+            14, 13, 12, 11, 10,  0,  1,  2,  3,  4
+        ]
+        # fmt: on
+        self.brightness_limit = 1.0
+        self.num_pixels = 20
+
+        # fmt: off
+        self.coord_mapping = [
+            0,  1,  2,  3,  4,  24, 23, 22, 21, 20,
+            5,  6,  7,  8,  9,  29, 28, 27, 26, 25,
+            10, 11, 12, 13, 14,  34, 33, 32, 31, 30,
+                    17, 18, 19,  39, 38, 37
+        ]
+        # fmt: on
+
         # create and register the scanner
         self.matrix = [
             MatrixScanner(
@@ -35,39 +78,3 @@ class KMKKeyboard(_KMKKeyboard):
             #     divisor=4,
             # )
         ]
-
-    col_pins = (
-        pins[avr['F4']],
-        pins[avr['F5']],
-        pins[avr['F6']],
-        pins[avr['F7']],
-        pins[avr['B1']],
-    )
-    row_pins = (
-        pins[avr['D4']],
-        pins[avr['C6']],
-        pins[avr['D7']],
-        pins[avr['E6']],
-    )
-    data_pin = pins[avr['D2']]
-    rgb_pixel_pin = pins[avr['D3']]
-    rgb_num_pixels = 20
-    i2c = board.I2C
-    SCL = pins[5]
-    SDA = pins[4]
-    pin_a1 = pins[avr['B2']]
-    pin_a2 = pins[avr['B4']]
-    pin_b1 = pins[avr['B6']]
-    pin_b2 = pins[avr['B5']]
-    led_key_pos = [5, 6, 7, 8, 9, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 0, 1, 2, 3, 4]
-    brightness_limit = 1.0
-    num_pixels = 20
-
-    # fmt: off
-    coord_mapping = [
-        0,  1,  2,  3,  4,  24, 23, 22, 21, 20,
-        5,  6,  7,  8,  9,  29, 28, 27, 26, 25,
-        10, 11, 12, 13, 14,  34, 33, 32, 31, 30,
-                17, 18, 19,  39, 38, 37
-    ]
-    # fmt: on

--- a/boards/ferris_sweep/kb.py
+++ b/boards/ferris_sweep/kb.py
@@ -18,14 +18,16 @@ _KEY_CFG_LEFT = [
 
 class KMKKeyboard(_KMKKeyboard):
     def __init__(self):
+        super().__init__()
+
         # create and register the scanner
         self.matrix = KeysScanner(_KEY_CFG_LEFT, value_when_pressed=False)
 
-    # fmt: off
-    coord_mapping = [
-         0,  1,  2,  3,  4,   21, 20, 19, 18, 17,
-         5,  6,  7,  8,  9,   26, 25, 24, 23, 22,
-        10, 11, 12, 13, 14,   31, 30, 29, 28, 27,
-                    15, 16,   33, 32
-    ]
-    # fmt: on
+        # fmt: off
+        self.coord_mapping = [
+             0,  1,  2,  3,  4,   21, 20, 19, 18, 17,
+             5,  6,  7,  8,  9,   26, 25, 24, 23, 22,
+            10, 11, 12, 13, 14,   31, 30, 29, 28, 27,
+                        15, 16,   33, 32
+        ]
+        # fmt: on

--- a/boards/isopad/kb.py
+++ b/boards/isopad/kb.py
@@ -14,5 +14,7 @@ _KEY_CFG = [
 # fmt: on
 class KMKKeyboard(_KMKeyboard):
     def __init__(self):
+        super().__init__()
+
         # create and register the scanner
         self.matrix = KeysScanner(_KEY_CFG, value_when_pressed=False)

--- a/boards/nullbitsco/tidbit/kb.py
+++ b/boards/nullbitsco/tidbit/kb.py
@@ -25,28 +25,28 @@ class KMKKeyboard(_KMKKeyboard):
     landscape_layout=True to orient USB port top right rather than left (default)
     '''
 
-    # led = digitalio.DigitalInOut(board.D21)
-    # led.direction = digitalio.Direction.OUTPUT
-    # led.value = False
-    row_pins = (
-        pins[15],
-        pins[9],
-        pins[8],
-        pins[7],
-        pins[6],
-    )
-    col_pins = (
-        pins[19],
-        pins[18],
-        pins[17],
-        pins[16],
-    )
-    pixel_pin = pins[12]
-    diode_orientation = DiodeOrientation.ROW2COL
-    i2c = board.I2C  # TODO ??
-
     def __init__(self, active_encoders=[0], landscape_layout=False):
         super().__init__()
+
+        # led = digitalio.DigitalInOut(board.D21)
+        # led.direction = digitalio.Direction.OUTPUT
+        # led.value = False
+        self.row_pins = (
+            pins[15],
+            pins[9],
+            pins[8],
+            pins[7],
+            pins[6],
+        )
+        self.col_pins = (
+            pins[19],
+            pins[18],
+            pins[17],
+            pins[16],
+        )
+        self.pixel_pin = pins[12]
+        self.diode_orientation = DiodeOrientation.ROW2COL
+        self.i2c = board.I2C  # TODO ??
 
         if landscape_layout:
             self.coord_mapping = [

--- a/boards/pimoroni/keybow/keybow.py
+++ b/boards/pimoroni/keybow/keybow.py
@@ -107,7 +107,8 @@ class Keybow(KMKKeyboard):
     Default keyboard config for the Keybow.
     '''
 
-    extensions = [rgb]
-
     def __init__(self):
+        super().__init__()
+
+        self.extensions = [rgb]
         self.matrix = KeysScanner(_KEY_CFG, value_when_pressed=False)

--- a/boards/pimoroni/keybow_2040/keybow_2040.py
+++ b/boards/pimoroni/keybow_2040/keybow_2040.py
@@ -43,4 +43,6 @@ class Keybow2040(KMKKeyboard):
     '''
 
     def __init__(self):
+        super().__init__()
+
         self.matrix = KeysScanner(_KEY_CFG, value_when_pressed=False)

--- a/boards/zodiark/kb.py
+++ b/boards/zodiark/kb.py
@@ -9,6 +9,53 @@ from kmk.scanners.keypad import MatrixScanner
 
 class KMKKeyboard(_KMKKeyboard):
     def __init__(self):
+        super().__init__()
+
+        self.col_pins = (
+            pins[avr['F5']],
+            pins[avr['F6']],
+            pins[avr['F7']],
+            pins[avr['B1']],
+            pins[avr['B3']],
+            pins[avr['B2']],
+            pins[avr['B6']],
+        )
+        self.row_pins = (
+            pins[avr['C6']],
+            pins[avr['D7']],
+            pins[avr['E6']],
+            pins[avr['B4']],
+            pins[avr['F4']],
+        )
+        self.diode_orientation = DiodeOrientation.COLUMNS
+        self.rgb_pixel_pin = pins[avr['B5']]
+        self.data_pin = pins[avr['D3']]
+        self.i2c = board.I2C
+        self.SCL = board.SCL
+        self.SDA = board.SDA
+
+        # fmt: off
+        self.led_key_pos = [
+             5,  4,  3,  2,  1, 00,                 34, 35, 36, 37, 38, 39,
+             6,  7,  8,  9, 10, 11, 12,         46, 45, 44, 43, 42, 41, 40,
+            19, 18, 17, 16, 15, 14, 13,         47, 48, 49, 50, 51, 52, 53,
+            20, 21, 22, 23, 24, 25, 26,         60, 59, 58, 57, 56, 55, 54,
+            33, 32, 31, 30, 29,     28, 27, 61, 62,     63, 64, 65, 66, 67
+        ]
+        # fmt:on
+        self.brightness_limit = 0.5
+        self.num_pixels = 62
+
+        # fmt:off
+        self.coord_mapping = [
+             0,  1,  2,  3,  4,  5,                 40, 39, 38, 37, 36, 35,
+             7,  8,  9, 10, 11, 12,  6,         41, 47, 46, 45, 44, 43, 42,
+            14, 15, 16, 17, 18, 19, 13,         48, 54, 53, 52, 51, 50, 49,
+            21, 22, 23, 24, 25, 26, 20, 27, 62, 55, 61, 60, 59, 58, 57, 56,
+            28, 29, 30, 31, 32,     33, 34, 69, 68,     67, 66, 65, 64, 63
+        ]
+        # fmt:on
+
         # create and register the scanner
         self.matrix = [
             MatrixScanner(
@@ -21,47 +68,3 @@ class KMKKeyboard(_KMKKeyboard):
                 max_events=64,
             ),
         ]
-
-    col_pins = (
-        pins[avr['F5']],
-        pins[avr['F6']],
-        pins[avr['F7']],
-        pins[avr['B1']],
-        pins[avr['B3']],
-        pins[avr['B2']],
-        pins[avr['B6']],
-    )
-    row_pins = (
-        pins[avr['C6']],
-        pins[avr['D7']],
-        pins[avr['E6']],
-        pins[avr['B4']],
-        pins[avr['F4']],
-    )
-    diode_orientation = DiodeOrientation.COLUMNS
-    rgb_pixel_pin = pins[avr['B5']]
-    data_pin = pins[avr['D3']]
-    i2c = board.I2C
-    SCL = board.SCL
-    SDA = board.SDA
-    # fmt: off
-    led_key_pos = [
-         5,  4,  3,  2,  1, 00,                 34, 35, 36, 37, 38, 39,
-         6,  7,  8,  9, 10, 11, 12,         46, 45, 44, 43, 42, 41, 40,
-        19, 18, 17, 16, 15, 14, 13,         47, 48, 49, 50, 51, 52, 53,
-        20, 21, 22, 23, 24, 25, 26,         60, 59, 58, 57, 56, 55, 54,
-        33, 32, 31, 30, 29,     28, 27, 61, 62,     63, 64, 65, 66, 67
-    ]
-    # fmt:on
-    brightness_limit = 0.5
-    num_pixels = 62
-
-    # fmt:off
-    coord_mapping = [
-         0,  1,  2,  3,  4,  5,                 40, 39, 38, 37, 36, 35,
-         7,  8,  9, 10, 11, 12,  6,         41, 47, 46, 45, 44, 43, 42,
-        14, 15, 16, 17, 18, 19, 13,         48, 54, 53, 52, 51, 50, 49,
-        21, 22, 23, 24, 25, 26, 20, 27, 62, 55, 61, 60, 59, 58, 57, 56,
-        28, 29, 30, 31, 32,     33, 34, 69, 68,     67, 66, 65, 64, 63
-    ]
-    # fmt:on

--- a/docs/en/scanners.md
+++ b/docs/en/scanners.md
@@ -27,6 +27,8 @@ from kmk.scanners.keypad import MatrixScanner
 
 class MyKeyboard(KMKKeyboard):
     def __init__(self):
+        super().__init__()
+
         # create and register the scanner
         self.matrix = MatrixScanner(
             # required arguments:
@@ -66,6 +68,8 @@ _KEY_CFG = [
 # Keyboard implementation class
 class MyKeyboard(KMKKeyboard):
     def __init__(self):
+        super().__init__()
+
         # create and register the scanner
         self.matrix = KeysScanner(
             # require argument:
@@ -90,6 +94,8 @@ from kmk.scanners.keypad import ShiftRegisterKeys
 
 class MyKeyboard(KMKKeyboard):
     def __init__(self):
+        super().__init__()
+
         # create and register the scanner
         self.matrix = ShiftRegisterKeys(
             # require arguments:
@@ -119,6 +125,8 @@ from kmk.scanners.digitalio import MatrixScanner
 
 class MyKeyboard(KMKKeyboard):
     def __init__(self):
+        super().__init__()
+
         # create and register the scanner
         self.matrix = MatrixScanner(
             cols=self.col_pins,
@@ -141,6 +149,8 @@ from kmk.scanners.encoder import RotaryioEncoder
 
 class MyKeyboard(KMKKeyboard):
     def __init__(self):
+        super().__init__()
+
         # create and register the scanner
         self.matrix = RotaryioEncoder(
             pin_a=board.GP0,
@@ -173,11 +183,15 @@ KMK assumes that successive scanner keys are consecutive, and populates
 Example:
 ```python
 class MyKeyboard(KMKKeyboard):
-    self.matrix = [
-        MatrixScanner(...),
-        KeysScanner(...),
-        # etc...
-    ]
+    def __init__(self):
+        super().__init__()
+
+        # create and register the scanner
+        self.matrix = [
+            MatrixScanner(...),
+            KeysScanner(...),
+            # etc...
+        ]
 ```
 #### Multiple Scanners `coord_mapping` and keymap changes
 To add more scanners you need to add onto your `coord_mapping`.

--- a/kmk/kmk_keyboard.py
+++ b/kmk/kmk_keyboard.py
@@ -34,43 +34,44 @@ class Sandbox:
 
 
 class KMKKeyboard:
-    #####
-    # User-configurable
-    keymap = []
-    coord_mapping = None
+    def __init__(self) -> None:
+        #####
+        # User-configurable
+        self.keymap = []
+        self.coord_mapping = None
 
-    row_pins = None
-    col_pins = None
-    diode_orientation = None
-    matrix = None
+        self.row_pins = None
+        self.col_pins = None
+        self.diode_orientation = None
+        self.matrix = None
 
-    modules = []
-    extensions = []
-    sandbox = Sandbox()
+        self.modules = []
+        self.extensions = []
+        self.sandbox = Sandbox()
 
-    #####
-    # Internal State
-    keys_pressed = set()
-    _coordkeys_pressed = {}
-    implicit_modifier = None
-    hid_type = HIDModes.USB
-    secondary_hid_type = None
-    _hid_helper = None
-    _hid_send_enabled = False
-    hid_pending = False
-    matrix_update = None
-    secondary_matrix_update = None
-    matrix_update_queue = []
-    _trigger_powersave_enable = False
-    _trigger_powersave_disable = False
-    _go_args = None
-    _resume_buffer = []
-    _resume_buffer_x = []
+        #####
+        # Internal State
+        self.keys_pressed = set()
+        self._coordkeys_pressed = {}
+        self.implicit_modifier = None
+        self.hid_type = HIDModes.USB
+        self.secondary_hid_type = None
+        self._hid_helper = None
+        self._hid_send_enabled = False
+        self.hid_pending = False
+        self.matrix_update = None
+        self.secondary_matrix_update = None
+        self.matrix_update_queue = []
+        self._trigger_powersave_enable = False
+        self._trigger_powersave_disable = False
+        self._go_args = None
+        self._resume_buffer = []
+        self._resume_buffer_x = []
 
-    # this should almost always be PREpended to, replaces
-    # former use of reversed_active_layers which had pointless
-    # overhead (the underlying list was never used anyway)
-    active_layers = [0]
+        # this should almost always be PREpended to, replaces
+        # former use of reversed_active_layers which had pointless
+        # overhead (the underlying list was never used anyway)
+        self.active_layers = [0]
 
     def __repr__(self) -> str:
         return self.__class__.__name__


### PR DESCRIPTION
KMKKeyboard has used class attributes instead of instance attributes. That is fundamentally incorrect, but hasn't caused issues in situ, where there's only ever one keyboard instance and the VM is reset with each restart.
It does however cause issues in unit tests, where erroneous internal states can bleed over from failed tests to normally passing tests.