### PR TITLE
fix(combo): emit result to processing pipeline

### DIFF
--- a/kmk/modules/combos.py
+++ b/kmk/modules/combos.py
@@ -301,13 +301,13 @@ class Combos(Module):
     def activate(self, keyboard, combo):
         if debug.enabled:
             debug('activate', combo)
-        combo.result.on_press(keyboard)
+        keyboard.resume_process_key(self, combo.result, True)
         combo._state = _ComboState.ACTIVE
 
     def deactivate(self, keyboard, combo):
         if debug.enabled:
             debug('deactivate', combo)
-        combo.result.on_release(keyboard)
+        keyboard.resume_process_key(self, combo.result, False)
         combo._state = _ComboState.IDLE
 
     def reset_combo(self, keyboard, combo):

--- a/tests/test_combos_sticky_keys.py
+++ b/tests/test_combos_sticky_keys.py
@@ -1,0 +1,58 @@
+import unittest
+
+from kmk.keys import KC
+from kmk.modules.combos import Chord, Combo, Combos
+from kmk.modules.sticky_keys import StickyKeys
+from tests.keyboard_test import KeyboardTest
+
+t_within = 2 * KeyboardTest.loop_delay_ms
+t_combo = 6 * KeyboardTest.loop_delay_ms
+t_sticky = 8 * KeyboardTest.loop_delay_ms
+t_after = 11 * KeyboardTest.loop_delay_ms
+
+# overide default timeouts
+Combo.timeout = t_combo
+
+combos = Combos()
+combos.combos = [
+    Chord((KC.N0, KC.N1), KC.A),
+]
+
+sticky_keys = StickyKeys(release_after=t_sticky)
+
+kb = KeyboardTest(
+    [combos, sticky_keys],
+    [[KC.N0, KC.N1, KC.SK(KC.LSFT)]],
+    debug_enabled=True,
+)
+
+
+class TestCombo(unittest.TestCase):
+    def test_0(self):
+        kb.test(
+            '',
+            [(2, True), (2, False), (0, True), (1, True), (0, False), (1, False)],
+            [{KC.LSFT}, {KC.LSFT, KC.A}, {KC.LSFT}, {}],
+        )
+
+    def test_1(self):
+        kb.test(
+            '',
+            [(2, True), (0, True), (2, False), (1, True), (0, False), (1, False)],
+            [{KC.LSFT}, {KC.LSFT, KC.N0}, {KC.N0}, {KC.N0, KC.N1}, {KC.N1}, {}],
+        )
+
+    def test_2(self):
+        kb.test(
+            '',
+            [
+                (2, True),
+                t_after,
+                (0, True),
+                (1, True),
+                (2, False),
+                (0, False),
+                (1, False),
+            ],
+            [{KC.LSFT}, {KC.LSFT, KC.A}, {KC.A}, {}],
+        )


### PR DESCRIPTION
This is necessary in order for other processing modules (sticky keys, holdtap, etc.) to see the combo result as a "regular" key event.