### PR TITLE
doc: change dead links from kmkfw.io to repo docs

### DIFF
--- a/boards/helix/README.md
+++ b/boards/helix/README.md
@@ -7,7 +7,7 @@ A compact split ortholinear keyboard.
 * Keyboard Maintainer: [yushakobo](https://github.com/yushakobo)
 * Hardware Supported: Helix PCBs (probably rev2 only), Pro Micro RP2040 boards
 
-Copy the `kb.py` and `main.py` files from your preferred keymap folder into your root directory of your keyboard as detailed in the [KMK instructions](http://kmkfw.io/docs/Getting_Started/).
+Copy the `kb.py` and `main.py` files from your preferred keymap folder into your root directory of your keyboard as detailed in the [KMK instructions](Getting_Started.md).
 
 ## Microcontroller support
 

--- a/boards/nullbitsco/tidbit/README.md
+++ b/boards/nullbitsco/tidbit/README.md
@@ -17,7 +17,7 @@ The default is for a single encoder in either of the top two locations labeled 1
 in the build diagram, i.e. `active_encoders=[0]`.  Pass an empty list if you skipped
 adding any encoders.
 
-You can control the RGB backlights with the [RGB extension](http://kmkfw.io/docs/rgb).
+You can control the RGB backlights with the [RGB extension](rgb.md).
 Here's an example:
 
 ```python

--- a/docs/en/pimoroni_trackball.md
+++ b/docs/en/pimoroni_trackball.md
@@ -138,7 +138,7 @@ To choose the default mode, pass it in `Trackball` constructor.
 
 ### Light animation
 
-The trackball has a RGB LED which can be controlled with the [RGB extension](http://kmkfw.io/docs/rgb).
+The trackball has a RGB LED which can be controlled with the [RGB extension](rgb.md).
 Example of very slowly glowing led, almost seamlessly changing colors:
 
 ```python


### PR DESCRIPTION
Regardless of wether kmkfw.io is coming back (unlikely), these links should have been pointing to relative *.md anyway.