### PR TITLE
small BLE fix on hid.py

### DIFF
--- a/kmk/hid.py
+++ b/kmk/hid.py
@@ -282,7 +282,7 @@ class BLEHID(AbstractHID):
     def ble_monitor(self):
         if self.ble_connected != self.connected:
             self.ble_connected = self.connected
-            if self._connected:
+            if self.connected:
                 if debug.enabled:
                     debug('BLE connected')
             else:


### PR DESCRIPTION
`_connected` was recently refactored out in hid.py however there was one that remained. This caused a crash on my board. After checking out the code and making the included change, changing this line to refer to `connected` works.