### PR TITLE
feat(bootcfg): set usb identification with a kwargs-dict

### DIFF
--- a/docs/en/boot.md
+++ b/docs/en/boot.md
@@ -33,7 +33,7 @@ bootcfg(
     nkro: bool = False,
     pan: bool = False,
     storage: bool = True,
-    usb_id: Optional[tuple[str, str]] = None,
+    usb_id: Optional[dict] = {},
     **kwargs,
 ) -> bool
 ```
@@ -128,6 +128,9 @@ I have to mount!" every time you plug in your keyboard.
 #### `usb_id`
 A recent addition to CircuitPython 8 is the ability to give your keyboard an
 identity other than "MCU board manufacturer" - "CircuitPython device".
+The argument is expected to be a kwargs-dictionary that is passed to
+`supervisor.set_usb_identification`.
+See the example 1 and the [CircuitPython documentation](https://docs.circuitpython.org/en/latest/shared-bindings/supervisor/index.html#supervisor.set_usb_identification) for reference.
 
 
 #### return value
@@ -156,7 +159,7 @@ bootcfg(
     midi=False,
     mouse=False,
     storage=False,
-    usb_id=('KMK Keyboards', 'Custom 60% Ergo'),
+    usb_id={'manufacturer': 'KMK Keyboards', 'product': 'Custom 60% Ergo'},
 )
 
 ```

--- a/kmk/bootcfg.py
+++ b/kmk/bootcfg.py
@@ -22,7 +22,7 @@ def bootcfg(
     nkro: bool = False,
     pan: bool = False,
     storage: bool = True,
-    usb_id: Optional[tuple[str, str]] = None,
+    usb_id: Optional[dict, tuple[str, str]] = {},
     **kwargs,
 ) -> bool:
 
@@ -43,6 +43,11 @@ def bootcfg(
         import supervisor
 
         supervisor.runtime.autoreload = False
+
+    # Parse `usb_id` tuple for backwards compatibility. This can be removed at
+    # some point in the future(TM).
+    if type(usb_id) is tuple:
+        usb_id = {'manufacturer': usb_id[0], 'product': usb_id[1]}
 
     # configure HID devices
     devices = []
@@ -74,11 +79,13 @@ def bootcfg(
         usb_midi.disable()
 
     # configure usb vendor and product id
-    if usb_id is not None:
+    if usb_id:
         import supervisor
 
-        if hasattr(supervisor, 'set_usb_identification'):
-            supervisor.set_usb_identification(*usb_id)
+        try:
+            supervisor.set_usb_identification(**usb_id)
+        except Exception as e:
+            print('supervisor.set_usb_identification: ', e, type(e))
 
     # configure data serial
     if cdc_data:

--- a/util/aspell.en.pws
+++ b/util/aspell.en.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 376 
+personal_ws-1.1 en 377 
 ADNS
 AMS
 ANAVI
@@ -312,6 +312,7 @@ klar
 klardotsh
 kmk
 kmkfw
+kwargs
 kyria
 leds
 licensor


### PR DESCRIPTION
This will make overriding vid/pid in #1092 a lot simpler and nicer.