### PR TITLE
Fix: hid.py BLEHID

### DIFF
--- a/kmk/hid.py
+++ b/kmk/hid.py
@@ -347,20 +347,20 @@ class BLEHID(AbstractHID):
         return self.hid.devices
 
     def ble_monitor(self):
-        if self.ble_connected != self.connected:
+        if debug.enabled and self.ble_connected != self.connected:
             self.ble_connected = self.connected
             if self.connected:
-                if debug.enabled:
-                    debug('BLE connected')
+                debug('BLE connected')
             else:
-                # Security-wise this is not right. While you're away someone turns
-                # on your keyboard and they can pair with it nice and clean and then
-                # listen to keystrokes.
-                # On the other hand we don't have LESC so it's like shouting your
-                # keystrokes in the air
-                self.start_advertising()
-                if debug.enabled:
-                    debug('BLE disconnected')
+                debug('BLE disconnected')
+
+        if not self.connected:
+            # Security-wise this is not right. While you're away someone turns
+            # on your keyboard and they can pair with it nice and clean and then
+            # listen to keystrokes.
+            # On the other hand we don't have LESC so it's like shouting your
+            # keystrokes in the air
+            self.start_advertising()
 
     def clear_bonds(self):
         import _bleio


### PR DESCRIPTION
Bug was pointed out [here](https://kmkfw.zulipchat.com/#narrow/channel/358347-general/topic/xiao.20esp32c6.20support.20ble.20sans.20usb/near/514450141), solution proposed [here](https://kmkfw.zulipchat.com/#narrow/channel/358347-general/topic/xiao.20esp32c6.20support.20ble.20sans.20usb/near/514509355).

The difference between proposed solution and this PR is that we make use of the `ble_connected` variable to avoid spamming debug with BLE status every second.