### PR TITLE
added the media_keys extension import in encoder.md example

### DIFF
--- a/docs/en/encoder.md
+++ b/docs/en/encoder.md
@@ -121,12 +121,14 @@ from kmk.keys import KC
 from kmk.scanners import DiodeOrientation
 from kmk.modules.layers import Layers
 from kmk.modules.encoder import EncoderHandler
+from kmk.extensions.media_keys import MediaKeys
 
 
 keyboard = KMKKeyboard()
 layers = Layers()
 encoder_handler = EncoderHandler()
 keyboard.modules = [layers, encoder_handler]
+keyboard.extensions.append(MediaKeys())
 
 
 keyboard.col_pins = (


### PR DESCRIPTION
the example provided in the encoder.md uses media_keys extension but the extension is not imported or appended