### PR TITLE
Update keycodes.md

### DIFF
--- a/docs/en/keycodes.md
+++ b/docs/en/keycodes.md
@@ -183,14 +183,6 @@
 |`KC.RGUI(kc)`|Hold Right GUI and press `kc`         |
 
 
-## [Bluetooth Keys]
-
-|Key                          |Aliases            |Description                       |
-|-----------------------------|-------------------|----------------------------------|
-|`KC.BT_CLEAR_BONDS`          |`KC.BT_CLR`        |Clears all stored bondings        |
-|`KC.BT_NEXT_CONN`            |`KC.BT_NXT`        |Selects the next BT connection    |
-|`KC.BT_PREV_CONN`            |`KC.BT_PRV`        |Selects the previous BT connection|
-
 ## [International Keys]
 See [International extension](international.md).
 


### PR DESCRIPTION
removed references to bluetooth key codes that don't actually exist in the codebase (and if they did, it would probably make more sense for them to be included on the BLE HID doc as is the case with other key codes that are specific to extensions etc).